### PR TITLE
feat: Implement TypeInfoKind::Error for type poisoning

### DIFF
--- a/core/type-checker/src/type_info.rs
+++ b/core/type-checker/src/type_info.rs
@@ -111,6 +111,7 @@ pub enum TypeInfoKind {
     Struct(String),
     Enum(String),
     Spec(String),
+    Error,
 }
 
 impl Display for TypeInfoKind {
@@ -129,6 +130,7 @@ impl Display for TypeInfoKind {
             | TypeInfoKind::Qualified(ty)
             | TypeInfoKind::Function(ty) => write!(f, "{ty}"),
             TypeInfoKind::Generic(ty) => write!(f, "{ty}'"),
+            TypeInfoKind::Error => write!(f, "{{unknown}}"),
         }
     }
 }
@@ -343,6 +345,11 @@ impl TypeInfo {
         matches!(self.kind, TypeInfoKind::Generic(_))
     }
 
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self.kind, TypeInfoKind::Error)
+    }
+
     /// Returns true if this is a signed integer type (i8, i16, i32, i64).
     #[must_use = "this is a pure check with no side effects"]
     pub fn is_signed_integer(&self) -> bool {
@@ -386,7 +393,8 @@ impl TypeInfo {
             | TypeInfoKind::Function(_)
             | TypeInfoKind::Struct(_)
             | TypeInfoKind::Enum(_)
-            | TypeInfoKind::Spec(_) => self.clone(),
+            | TypeInfoKind::Spec(_)
+            | TypeInfoKind::Error => self.clone(),
         }
     }
 
@@ -407,7 +415,8 @@ impl TypeInfo {
             | TypeInfoKind::Function(_)
             | TypeInfoKind::Struct(_)
             | TypeInfoKind::Enum(_)
-            | TypeInfoKind::Spec(_) => false,
+            | TypeInfoKind::Spec(_)
+            | TypeInfoKind::Error => false,
         }
     }
 


### PR DESCRIPTION
# Description

Closes #72

# Changes proposed

## What were you told to do?

I was tasked with implementing Error Type Poisoning to prevent cascading errors in the type checker. This involved adding a `TypeInfoKind::Error` variant similar to `rustc`'s `TyKind::Error` and updating the type checker to gracefully handle these error types.

## What did I do?

### Implemented `TypeInfoKind::Error`

- Added `Error` variant to the `TypeInfoKind` enum in `core/type-checker/src/type_info.rs`.
- Updated `Display` implementation to show `{unknown}` for error types.
- Added `is_error()` helper method to `TypeInfo`.
- Updated `substitute` and `has_unresolved_params` to handle `Error` variants neutrally.

### Updated Type Checker Logic

- Modified `core/type-checker/src/type_checker.rs` to use `TypeInfoKind::Error` for type poisoning.
- Updated `infer_expression` for `Identifier`, `Struct` initialization, `MemberAccess`, `TypeMemberAccess`, and `FunctionCall` to return `TypeInfoKind::Error` upon lookup failure instead of `None` or continuing with invalid types.
- Updated type mismatch checks in `Statement::Assign`, `Statement::Return`, `Statement::If`, `Statement::Loop`, and others to suppress errors if either the expected or found type is `Error`.
- Updated `Expression::ArrayIndexAccess`, `Expression::PrefixUnary`, and `Expression::Binary` to propagate `Error` types and suppress secondary errors (e.g., "expected array type" when the array expression itself failed).

### Benefits

- Prevents cascading errors when a type lookup fails.
- Allows type checking to continue more gracefully.
- Aligns with `rustc`'s error handling model.

# Check List (Check all the applicable boxes)

🚨Please review the contribution guideline for this repository.

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos
<img width="753" height="765" alt="Screenshot 2026-01-22 at 13 49 02" src="https://github.com/user-attachments/assets/8a90c567-ee86-4427-a7e6-c118f948635a" />

