### PR TITLE
Fix ref cycle in `SymbolTable`

### DIFF
--- a/core/type-checker/src/symbol_table.rs
+++ b/core/type-checker/src/symbol_table.rs
@@ -20,7 +20,7 @@
 //! lightweight value-based representation without heap allocation.
 
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use anyhow::bail;
 
@@ -32,6 +32,7 @@ use inference_ast::nodes::{
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(crate) type ScopeRef = Rc<RefCell<Scope>>;
+pub(crate) type WeakScopeRef = Weak<RefCell<Scope>>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct FuncInfo {
@@ -254,7 +255,7 @@ pub(crate) struct Scope {
     pub(crate) full_path: String,
     #[allow(dead_code)]
     pub(crate) visibility: Visibility,
-    pub(crate) parent: Option<ScopeRef>,
+    pub(crate) parent: Option<WeakScopeRef>,
     pub(crate) children: Vec<ScopeRef>,
     pub(crate) symbols: FxHashMap<String, Symbol>,
     pub(crate) variables: FxHashMap<String, (u32, TypeInfo)>,
@@ -272,7 +273,7 @@ impl Scope {
         name: &str,
         full_path: String,
         visibility: Visibility,
-        parent: Option<ScopeRef>,
+        parent: Option<WeakScopeRef>,
     ) -> ScopeRef {
         Rc::new(RefCell::new(Self {
             id,
@@ -311,7 +312,7 @@ impl Scope {
         if let Some(symbol) = self.lookup_symbol_local(name) {
             return Some(symbol.clone());
         }
-        if let Some(parent) = &self.parent {
+        if let Some(parent) = self.parent.as_ref().and_then(|p| p.upgrade()) {
             return parent.borrow().lookup_symbol(name);
         }
         None
@@ -340,7 +341,7 @@ impl Scope {
         if let Some((_, ty)) = self.lookup_variable_local(name) {
             return Some(ty);
         }
-        if let Some(parent) = &self.parent {
+        if let Some(parent) = self.parent.as_ref().and_then(|p| p.upgrade()) {
             return parent.borrow().lookup_variable(name);
         }
         None
@@ -362,7 +363,7 @@ impl Scope {
         {
             return Some(method_info.clone());
         }
-        if let Some(parent) = &self.parent {
+        if let Some(parent) = self.parent.as_ref().and_then(|p| p.upgrade()) {
             return parent.borrow().lookup_method(type_name, method_name);
         }
         None
@@ -472,7 +473,7 @@ impl SymbolTable {
             None => name.to_string(),
         };
 
-        let new_scope = Scope::new(scope_id, name, full_path, visibility, parent.clone());
+        let new_scope = Scope::new(scope_id, name, full_path, visibility, parent.as_ref().map(Rc::downgrade));
 
         if let Some(current) = &parent {
             current.borrow_mut().add_child(Rc::clone(&new_scope));
@@ -485,7 +486,7 @@ impl SymbolTable {
 
     pub(crate) fn pop_scope(&mut self) {
         if let Some(current) = &self.current_scope {
-            let parent = current.borrow().parent.clone();
+            let parent = current.borrow().parent.as_ref().and_then(|p| p.upgrade());
             self.current_scope = parent;
         }
     }
@@ -1200,7 +1201,7 @@ mod tests {
             let child_id = table.push_scope();
             let child_scope = table.get_scope(child_id).unwrap();
             let parent_scope = table.get_scope(parent_id).unwrap();
-            let child_parent = child_scope.borrow().parent.clone();
+            let child_parent = child_scope.borrow().parent.as_ref().and_then(|p| p.upgrade());
             assert!(
                 child_parent.is_some(),
                 "Anonymous child scope should have parent"

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -2000,7 +2000,7 @@ impl TypeChecker {
                 return true;
             }
             if let Some(scope) = self.symbol_table.get_scope(current) {
-                if let Some(parent) = &scope.borrow().parent {
+                if let Some(parent) = scope.borrow().parent.as_ref().and_then(|p| p.upgrade()) {
                     current = parent.borrow().id;
                 } else {
                     return false;

--- a/core/wasm-to-v/src/lib.rs
+++ b/core/wasm-to-v/src/lib.rs
@@ -171,6 +171,7 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_parse_test_data() {
         let test_data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data");
 


### PR DESCRIPTION
# The Problem: Reference Counting Cycle

Rust's `Rc<T>` keeps a count of how many owners point to the data. When the count drops to `0`, the data is freed.

In the symbol table, parent and child scopes point at each other:

```
Parent scope (Rc count = 2: SymbolTable + Child's parent field)
├── children: [Rc → Child]
│
Child scope  (Rc count = 2: SymbolTable + Parent's children vec)
└── parent:  Rc → Parent
```

When SymbolTable is dropped, it releases its Rc references. But:
- Parent's count goes from 2 → 1 (child still holds it)
- Child's count goes from 2 → 1 (parent still holds it)

Neither ever reaches 0. Memory is leaked. This is what Miri flagged (409 times).

## The Fix: Weak<T>

`Weak<T>` is a non-owning reference — it does not increment the reference count. It's designed exactly for "child points back to parent" patterns.

```
Parent scope (Rc count = 1: only SymbolTable)
  ├── children: [Rc → Child]        ← strong, parent owns children
  │
Child scope  (Rc count = 2: SymbolTable + Parent's children vec)
  └── parent:  Weak → Parent        ← weak, doesn't keep parent alive
```

Now when SymbolTable drops:
- Parent's count goes from `1 → 0 → freed`
- Child's count goes from `2 → 0 → freed`

### Using Weak in practice

`Weak` can't be used directly — the data might already be freed. You must call `.upgrade()` which returns `Option<Rc<T>>`:

```rust
// Before (Rc):
if let Some(parent) = &self.parent {
    return parent.borrow().lookup_symbol(name);
}

// After (Weak):
if let Some(parent) = self.parent.as_ref().and_then(|p| p.upgrade()) {
    return parent.borrow().lookup_symbol(name);
}
```

In our case `.upgrade()` will never return `None` because `SymbolTable.scopes` `HashMap` holds strong `Rc` refs to all scopes, keeping them alive for as long as the table exists. The `Weak` is purely to break the cycle.