### PR TITLE
Typed dedup keys for type-checker errors (supersedes #115)

### DIFF
--- a/core/type-checker/docs/architecture.md
+++ b/core/type-checker/docs/architecture.md
@@ -723,8 +723,8 @@ The type checker continues after errors to collect multiple issues:
 ```rust
 pub(crate) struct TypeChecker {
     symbol_table: SymbolTable,
-    errors: Vec<TypeCheckError>,           // Accumulate errors
-    reported_error_keys: FxHashSet<String>,  // Deduplicate errors
+    errors: Vec<TypeCheckError>,                     // Accumulate errors
+    reported_errors: FxHashSet<(DedupKind, String)>, // Deduplicate by (kind, name)
     ...
 }
 
@@ -764,16 +764,21 @@ impl TypeChecker {
 Errors are deduplicated using a key-based system:
 
 ```rust
-fn report_error(&mut self, error: TypeCheckError) {
-    let key = error.deduplication_key();
-    if !self.reported_error_keys.contains(&key) {
-        self.reported_error_keys.insert(key);
-        self.errors.push(error);
+fn push_error_dedup(&mut self, error: TypeCheckError) {
+    if let Some(key) = error.dedup_key() {
+        if !self.reported_errors.insert(key) {
+            return;
+        }
     }
+    self.errors.push(error);
 }
 ```
 
-This prevents reporting the same error multiple times when an incorrect symbol is used in multiple places.
+The key is a `(DedupKind, String)` tuple where `DedupKind` is a small enum
+listing the variants that participate in deduplication and the `String` is
+the offending symbol's name (or a composite key for variants like
+`SpecFunctionShadowsTopLevel`). This prevents reporting the same error
+multiple times when an incorrect symbol is used in multiple places.
 
 ## Performance Considerations
 

--- a/core/type-checker/docs/errors.md
+++ b/core/type-checker/docs/errors.md
@@ -1088,9 +1088,12 @@ fn test() -> i32 {
 
 ## Error Deduplication
 
-Errors are deduplicated by a key derived from the error kind and location. The same error
-(same variant, same source position) will not be reported more than once even if the checker
-encounters the same expression multiple times during analysis.
+Errors that share both an error kind and an offending symbol name are deduplicated using
+a typed `(DedupKind, String)` key. The set of variants that participate is listed in
+`DedupKind` (`UnknownType`, `UndefinedFunction`, `UnknownIdentifier`, `UndefinedStruct`,
+`UndefinedEnum`, `SpecFunctionShadowsTopLevel`); other variants are always recorded as-is.
+This means the same missing symbol is reported once regardless of how many times it is
+referenced, even when registration and inference both visit it.
 
 ## Location Information
 

--- a/core/type-checker/src/errors.rs
+++ b/core/type-checker/src/errors.rs
@@ -216,7 +216,7 @@ impl Display for VisibilityContext {
 /// the registration and inference passes; other `TypeCheckError` variants
 /// are always recorded as-is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum ErrorKind {
+pub(crate) enum DedupKind {
     UnknownType,
     UndefinedFunction,
     UnknownIdentifier,
@@ -613,19 +613,37 @@ impl TypeCheckError {
         }
     }
 
-    /// Returns the [`ErrorKind`] for variants that participate in
-    /// node-ID-based deduplication, or `None` for variants that are always
-    /// reported as-is.
-    pub(crate) fn kind(&self) -> Option<ErrorKind> {
+    /// Returns the deduplication key for variants that participate in
+    /// name-based deduplication, or `None` for variants that are always
+    /// reported as-is. The returned tuple of `(DedupKind, String)` is used
+    /// as a `FxHashSet` key inside the type checker so the same diagnostic
+    /// for the same symbol is recorded only once even when both registration
+    /// and inference visit it.
+    pub(crate) fn dedup_key(&self) -> Option<(DedupKind, String)> {
         match self {
-            TypeCheckError::UnknownType { .. } => Some(ErrorKind::UnknownType),
-            TypeCheckError::UndefinedFunction { .. } => Some(ErrorKind::UndefinedFunction),
-            TypeCheckError::UnknownIdentifier { .. } => Some(ErrorKind::UnknownIdentifier),
-            TypeCheckError::UndefinedStruct { .. } => Some(ErrorKind::UndefinedStruct),
-            TypeCheckError::UndefinedEnum { .. } => Some(ErrorKind::UndefinedEnum),
-            TypeCheckError::SpecFunctionShadowsTopLevel { .. } => {
-                Some(ErrorKind::SpecFunctionShadowsTopLevel)
+            TypeCheckError::UnknownType { name, .. } => {
+                Some((DedupKind::UnknownType, name.clone()))
             }
+            TypeCheckError::UndefinedFunction { name, .. } => {
+                Some((DedupKind::UndefinedFunction, name.clone()))
+            }
+            TypeCheckError::UnknownIdentifier { name, .. } => {
+                Some((DedupKind::UnknownIdentifier, name.clone()))
+            }
+            TypeCheckError::UndefinedStruct { name, .. } => {
+                Some((DedupKind::UndefinedStruct, name.clone()))
+            }
+            TypeCheckError::UndefinedEnum { name, .. } => {
+                Some((DedupKind::UndefinedEnum, name.clone()))
+            }
+            TypeCheckError::SpecFunctionShadowsTopLevel {
+                spec_name,
+                function_name,
+                ..
+            } => Some((
+                DedupKind::SpecFunctionShadowsTopLevel,
+                format!("{spec_name}:{function_name}"),
+            )),
             _ => None,
         }
     }

--- a/core/type-checker/src/errors.rs
+++ b/core/type-checker/src/errors.rs
@@ -210,6 +210,21 @@ impl Display for VisibilityContext {
     }
 }
 
+/// Categorizes errors that participate in node-ID-based deduplication.
+///
+/// Only the variants listed here can produce duplicate diagnostics across
+/// the registration and inference passes; other `TypeCheckError` variants
+/// are always recorded as-is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ErrorKind {
+    UnknownType,
+    UndefinedFunction,
+    UnknownIdentifier,
+    UndefinedStruct,
+    UndefinedEnum,
+    SpecFunctionShadowsTopLevel,
+}
+
 /// Represents a type checking error with source location.
 /// All type errors are tied to AST nodes and must have a location.
 #[derive(Debug, Clone, Error)]
@@ -595,6 +610,23 @@ impl TypeCheckError {
             | TypeCheckError::DivisionByZero { location, .. }
             | TypeCheckError::DuplicateEnumVariant { location, .. }
             | TypeCheckError::SpecFunctionShadowsTopLevel { location, .. } => location,
+        }
+    }
+
+    /// Returns the [`ErrorKind`] for variants that participate in
+    /// node-ID-based deduplication, or `None` for variants that are always
+    /// reported as-is.
+    pub(crate) fn kind(&self) -> Option<ErrorKind> {
+        match self {
+            TypeCheckError::UnknownType { .. } => Some(ErrorKind::UnknownType),
+            TypeCheckError::UndefinedFunction { .. } => Some(ErrorKind::UndefinedFunction),
+            TypeCheckError::UnknownIdentifier { .. } => Some(ErrorKind::UnknownIdentifier),
+            TypeCheckError::UndefinedStruct { .. } => Some(ErrorKind::UndefinedStruct),
+            TypeCheckError::UndefinedEnum { .. } => Some(ErrorKind::UndefinedEnum),
+            TypeCheckError::SpecFunctionShadowsTopLevel { .. } => {
+                Some(ErrorKind::SpecFunctionShadowsTopLevel)
+            }
+            _ => None,
         }
     }
 }

--- a/core/type-checker/src/errors.rs
+++ b/core/type-checker/src/errors.rs
@@ -210,11 +210,13 @@ impl Display for VisibilityContext {
     }
 }
 
-/// Categorizes errors that participate in node-ID-based deduplication.
+/// Categorizes errors that participate in `(DedupKind, name)` deduplication.
 ///
-/// Only the variants listed here can produce duplicate diagnostics across
-/// the registration and inference passes; other `TypeCheckError` variants
-/// are always recorded as-is.
+/// The set is empirical: only variants that the registration and inference
+/// passes have actually been observed to emit for the same symbol twice are
+/// listed here. Other `TypeCheckError` variants are always recorded as-is.
+/// When adding a new diagnostic that the walker can hit from multiple
+/// passes, extend both this enum and `TypeCheckError::dedup_key`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum DedupKind {
     UnknownType,

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -19,7 +19,7 @@
 //!
 //! Errors are not fatal: the checker collects them in `self.errors` and
 //! keeps walking the AST so a single run reports as many issues as
-//! possible. Duplicate entries are filtered via `reported_error_keys`.
+//! possible. Duplicate entries are filtered via `reported_errors`.
 //!
 //! ## Generics
 //!
@@ -41,7 +41,7 @@ use inference_ast::nodes::{
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    errors::{RegistrationKind, TypeCheckError, TypeMismatchContext, VisibilityContext},
+    errors::{ErrorKind, RegistrationKind, TypeCheckError, TypeMismatchContext, VisibilityContext},
     symbol_table::{FuncInfo, Import, ImportItem, ImportKind, ResolvedImport, SymbolTable},
     type_info::{NumberType, TypeInfo, TypeInfoKind},
     typed_context::TypedContext,
@@ -52,7 +52,7 @@ pub(crate) struct TypeChecker {
     symbol_table: SymbolTable,
     errors: Vec<TypeCheckError>,
     glob_resolution_in_progress: FxHashSet<u32>,
-    reported_error_keys: FxHashSet<String>,
+    reported_errors: FxHashSet<(ErrorKind, u32)>,
     /// Type parameter names for the function/method body currently being inferred.
     /// Set before walking the body, cleared after. Used by `infer_statement` to
     /// pass type param context to `validate_type` and `TypeInfo::from_type_id_with_type_params`.
@@ -483,14 +483,14 @@ impl TypeChecker {
                         .lookup_function_in_root(&fn_name)
                         .is_some()
                     {
-                        let key = format!("SpecFunctionShadowsTopLevel:{spec_name}:{fn_name}");
-                        if self.reported_error_keys.insert(key) {
-                            self.errors.push(TypeCheckError::SpecFunctionShadowsTopLevel {
+                        self.push_error_dedup(
+                            TypeCheckError::SpecFunctionShadowsTopLevel {
                                 spec_name: spec_name.clone(),
                                 function_name: fn_name,
                                 location: arena[inner_id].location,
-                            });
-                        }
+                            },
+                            inner_id.into_raw().into_u32(),
+                        );
                     }
                 }
             }
@@ -839,20 +839,26 @@ impl TypeChecker {
             TypeNode::Generic { base, params } => {
                 let base_name = arena[*base].name.clone();
                 if self.symbol_table.lookup_type(&base_name).is_none() {
-                    self.push_error_dedup(TypeCheckError::UnknownType {
-                        name: base_name,
-                        location: arena[*base].location,
-                    });
+                    self.push_error_dedup(
+                        TypeCheckError::UnknownType {
+                            name: base_name,
+                            location: arena[*base].location,
+                        },
+                        base.into_raw().into_u32(),
+                    );
                 }
                 for param in params {
                     let param_name = arena[*param].name.clone();
                     if !type_param_names.contains(&param_name)
                         && self.symbol_table.lookup_type(&param_name).is_none()
                     {
-                        self.push_error_dedup(TypeCheckError::UnknownType {
-                            name: param_name,
-                            location: arena[*param].location,
-                        });
+                        self.push_error_dedup(
+                            TypeCheckError::UnknownType {
+                                name: param_name,
+                                location: arena[*param].location,
+                            },
+                            param.into_raw().into_u32(),
+                        );
                     }
                 }
             }
@@ -865,10 +871,13 @@ impl TypeChecker {
                     return;
                 }
                 if self.symbol_table.lookup_type(&name).is_none() {
-                    self.push_error_dedup(TypeCheckError::UnknownType {
-                        name,
-                        location: arena[*ident_id].location,
-                    });
+                    self.push_error_dedup(
+                        TypeCheckError::UnknownType {
+                            name,
+                            location: arena[*ident_id].location,
+                        },
+                        ident_id.into_raw().into_u32(),
+                    );
                 }
             }
         }
@@ -889,10 +898,13 @@ impl TypeChecker {
             match value.parse::<u32>() {
                 Ok(1..) => {}
                 Ok(0) | Err(_) => {
-                    self.push_error_dedup(TypeCheckError::InvalidArraySize {
-                        size: value.clone(),
-                        location: type_location,
-                    });
+                    self.push_error_dedup(
+                        TypeCheckError::InvalidArraySize {
+                            size: value.clone(),
+                            location: type_location,
+                        },
+                        size_expr_id.into_raw().into_u32(),
+                    );
                 }
             }
         }
@@ -1528,10 +1540,13 @@ impl TypeChecker {
                         None
                     }
                 } else {
-                    self.push_error_dedup(TypeCheckError::UndefinedEnum {
-                        name: enum_name,
-                        location,
-                    });
+                    self.push_error_dedup(
+                        TypeCheckError::UndefinedEnum {
+                            name: enum_name,
+                            location,
+                        },
+                        expr_id.into_raw().into_u32(),
+                    );
                     None
                 }
             }
@@ -1630,10 +1645,13 @@ impl TypeChecker {
                     ctx.set_node_typeinfo(NodeId::Expr(expr_id), struct_type.clone());
                     return Some(struct_type);
                 }
-                self.push_error_dedup(TypeCheckError::UndefinedStruct {
-                    name: struct_name,
-                    location,
-                });
+                self.push_error_dedup(
+                    TypeCheckError::UndefinedStruct {
+                        name: struct_name,
+                        location,
+                    },
+                    expr_id.into_raw().into_u32(),
+                );
                 None
             }
             Expr::PrefixUnary { expr, op } => match op {
@@ -1850,7 +1868,10 @@ impl TypeChecker {
                     ctx.set_node_typeinfo(NodeId::Expr(expr_id), var_ty.clone());
                     Some(var_ty)
                 } else {
-                    self.push_error_dedup(TypeCheckError::UnknownIdentifier { name, location });
+                    self.push_error_dedup(
+                        TypeCheckError::UnknownIdentifier { name, location },
+                        expr_id.into_raw().into_u32(),
+                    );
                     None
                 }
             }
@@ -2135,10 +2156,13 @@ impl TypeChecker {
             );
             s.clone()
         } else {
-            self.push_error_dedup(TypeCheckError::UndefinedFunction {
-                name: func_name,
-                location,
-            });
+            self.push_error_dedup(
+                TypeCheckError::UndefinedFunction {
+                    name: func_name,
+                    location,
+                },
+                call_expr_id.into_raw().into_u32(),
+            );
             for arg in call_args {
                 self.infer_expression(arg.1, ctx);
             }
@@ -2793,28 +2817,21 @@ impl TypeChecker {
 
     // validate_literal_range moved to analysis rule A022 (LiteralOutOfRange).
 
-    /// Push an error, deduplicating errors for the same unknown type/function/identifier.
-    /// This prevents duplicate errors when registration fails but inference continues.
-    fn push_error_dedup(&mut self, error: TypeCheckError) {
-        let key = match &error {
-            TypeCheckError::UnknownType { name, .. } => Some(format!("UnknownType:{name}")),
-            TypeCheckError::UndefinedFunction { name, .. } => {
-                Some(format!("UndefinedFunction:{name}"))
-            }
-            TypeCheckError::UnknownIdentifier { name, .. } => {
-                Some(format!("UnknownIdentifier:{name}"))
-            }
-            TypeCheckError::UndefinedStruct { name, .. } => Some(format!("UndefinedStruct:{name}")),
-            TypeCheckError::UndefinedEnum { name, .. } => Some(format!("UndefinedEnum:{name}")),
-            _ => None,
-        };
-        if let Some(key) = key {
-            if self.reported_error_keys.contains(&key) {
+    /// Push an error, deduplicating per `(ErrorKind, node_id)` so a single
+    /// AST node never produces the same error twice across passes.
+    ///
+    /// `node_id` is the raw `u32` index of the AST node this error is
+    /// tied to. For errors whose `kind()` is `None`, the error is always
+    /// recorded as-is and `node_id` is ignored.
+    fn push_error_dedup(&mut self, error: TypeCheckError, node_id: u32) {
+        if let Some(kind) = error.kind() {
+            let key = (kind, node_id);
+            if self.reported_errors.contains(&key) {
                 cov_mark::hit!(type_checker_error_dedup_skips_duplicate);
                 return;
             }
             cov_mark::hit!(type_checker_error_dedup_first_occurrence);
-            self.reported_error_keys.insert(key);
+            self.reported_errors.insert(key);
         }
         self.errors.push(error);
     }

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -41,7 +41,7 @@ use inference_ast::nodes::{
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    errors::{ErrorKind, RegistrationKind, TypeCheckError, TypeMismatchContext, VisibilityContext},
+    errors::{DedupKind, RegistrationKind, TypeCheckError, TypeMismatchContext, VisibilityContext},
     symbol_table::{FuncInfo, Import, ImportItem, ImportKind, ResolvedImport, SymbolTable},
     type_info::{NumberType, TypeInfo, TypeInfoKind},
     typed_context::TypedContext,
@@ -52,7 +52,7 @@ pub(crate) struct TypeChecker {
     symbol_table: SymbolTable,
     errors: Vec<TypeCheckError>,
     glob_resolution_in_progress: FxHashSet<u32>,
-    reported_errors: FxHashSet<(ErrorKind, u32)>,
+    reported_errors: FxHashSet<(DedupKind, String)>,
     /// Type parameter names for the function/method body currently being inferred.
     /// Set before walking the body, cleared after. Used by `infer_statement` to
     /// pass type param context to `validate_type` and `TypeInfo::from_type_id_with_type_params`.
@@ -483,14 +483,11 @@ impl TypeChecker {
                         .lookup_function_in_root(&fn_name)
                         .is_some()
                     {
-                        self.push_error_dedup(
-                            TypeCheckError::SpecFunctionShadowsTopLevel {
-                                spec_name: spec_name.clone(),
-                                function_name: fn_name,
-                                location: arena[inner_id].location,
-                            },
-                            inner_id.into_raw().into_u32(),
-                        );
+                        self.push_error_dedup(TypeCheckError::SpecFunctionShadowsTopLevel {
+                            spec_name: spec_name.clone(),
+                            function_name: fn_name,
+                            location: arena[inner_id].location,
+                        });
                     }
                 }
             }
@@ -839,26 +836,20 @@ impl TypeChecker {
             TypeNode::Generic { base, params } => {
                 let base_name = arena[*base].name.clone();
                 if self.symbol_table.lookup_type(&base_name).is_none() {
-                    self.push_error_dedup(
-                        TypeCheckError::UnknownType {
-                            name: base_name,
-                            location: arena[*base].location,
-                        },
-                        base.into_raw().into_u32(),
-                    );
+                    self.push_error_dedup(TypeCheckError::UnknownType {
+                        name: base_name,
+                        location: arena[*base].location,
+                    });
                 }
                 for param in params {
                     let param_name = arena[*param].name.clone();
                     if !type_param_names.contains(&param_name)
                         && self.symbol_table.lookup_type(&param_name).is_none()
                     {
-                        self.push_error_dedup(
-                            TypeCheckError::UnknownType {
-                                name: param_name,
-                                location: arena[*param].location,
-                            },
-                            param.into_raw().into_u32(),
-                        );
+                        self.push_error_dedup(TypeCheckError::UnknownType {
+                            name: param_name,
+                            location: arena[*param].location,
+                        });
                     }
                 }
             }
@@ -871,13 +862,10 @@ impl TypeChecker {
                     return;
                 }
                 if self.symbol_table.lookup_type(&name).is_none() {
-                    self.push_error_dedup(
-                        TypeCheckError::UnknownType {
-                            name,
-                            location: arena[*ident_id].location,
-                        },
-                        ident_id.into_raw().into_u32(),
-                    );
+                    self.push_error_dedup(TypeCheckError::UnknownType {
+                        name,
+                        location: arena[*ident_id].location,
+                    });
                 }
             }
         }
@@ -898,13 +886,10 @@ impl TypeChecker {
             match value.parse::<u32>() {
                 Ok(1..) => {}
                 Ok(0) | Err(_) => {
-                    self.push_error_dedup(
-                        TypeCheckError::InvalidArraySize {
-                            size: value.clone(),
-                            location: type_location,
-                        },
-                        size_expr_id.into_raw().into_u32(),
-                    );
+                    self.push_error_dedup(TypeCheckError::InvalidArraySize {
+                        size: value.clone(),
+                        location: type_location,
+                    });
                 }
             }
         }
@@ -1540,13 +1525,10 @@ impl TypeChecker {
                         None
                     }
                 } else {
-                    self.push_error_dedup(
-                        TypeCheckError::UndefinedEnum {
-                            name: enum_name,
-                            location,
-                        },
-                        expr_id.into_raw().into_u32(),
-                    );
+                    self.push_error_dedup(TypeCheckError::UndefinedEnum {
+                        name: enum_name,
+                        location,
+                    });
                     None
                 }
             }
@@ -1645,13 +1627,10 @@ impl TypeChecker {
                     ctx.set_node_typeinfo(NodeId::Expr(expr_id), struct_type.clone());
                     return Some(struct_type);
                 }
-                self.push_error_dedup(
-                    TypeCheckError::UndefinedStruct {
-                        name: struct_name,
-                        location,
-                    },
-                    expr_id.into_raw().into_u32(),
-                );
+                self.push_error_dedup(TypeCheckError::UndefinedStruct {
+                    name: struct_name,
+                    location,
+                });
                 None
             }
             Expr::PrefixUnary { expr, op } => match op {
@@ -1868,10 +1847,7 @@ impl TypeChecker {
                     ctx.set_node_typeinfo(NodeId::Expr(expr_id), var_ty.clone());
                     Some(var_ty)
                 } else {
-                    self.push_error_dedup(
-                        TypeCheckError::UnknownIdentifier { name, location },
-                        expr_id.into_raw().into_u32(),
-                    );
+                    self.push_error_dedup(TypeCheckError::UnknownIdentifier { name, location });
                     None
                 }
             }
@@ -2156,13 +2132,10 @@ impl TypeChecker {
             );
             s.clone()
         } else {
-            self.push_error_dedup(
-                TypeCheckError::UndefinedFunction {
-                    name: func_name,
-                    location,
-                },
-                call_expr_id.into_raw().into_u32(),
-            );
+            self.push_error_dedup(TypeCheckError::UndefinedFunction {
+                name: func_name,
+                location,
+            });
             for arg in call_args {
                 self.infer_expression(arg.1, ctx);
             }
@@ -2817,21 +2790,19 @@ impl TypeChecker {
 
     // validate_literal_range moved to analysis rule A022 (LiteralOutOfRange).
 
-    /// Push an error, deduplicating per `(ErrorKind, node_id)` so a single
-    /// AST node never produces the same error twice across passes.
+    /// Push an error, deduplicating per `(DedupKind, name)` so the same
+    /// diagnostic for the same symbol is never recorded twice across the
+    /// registration and inference passes.
     ///
-    /// `node_id` is the raw `u32` index of the AST node this error is
-    /// tied to. For errors whose `kind()` is `None`, the error is always
-    /// recorded as-is and `node_id` is ignored.
-    fn push_error_dedup(&mut self, error: TypeCheckError, node_id: u32) {
-        if let Some(kind) = error.kind() {
-            let key = (kind, node_id);
-            if self.reported_errors.contains(&key) {
+    /// Errors whose [`TypeCheckError::dedup_key`] returns `None` are always
+    /// recorded as-is.
+    fn push_error_dedup(&mut self, error: TypeCheckError) {
+        if let Some(key) = error.dedup_key() {
+            if !self.reported_errors.insert(key) {
                 cov_mark::hit!(type_checker_error_dedup_skips_duplicate);
                 return;
             }
             cov_mark::hit!(type_checker_error_dedup_first_occurrence);
-            self.reported_errors.insert(key);
         }
         self.errors.push(error);
     }

--- a/tests/src/type_checker/error_recovery.rs
+++ b/tests/src/type_checker/error_recovery.rs
@@ -139,8 +139,8 @@ mod error_recovery_tests {
             let error_msg = error.to_string();
             let unknown_type_count = error_msg.matches("unknown type `UnknownType`").count();
             assert_eq!(
-                unknown_type_count, 2,
-                "UnknownType error should appear once per AST node (2 uses), got: {}",
+                unknown_type_count, 1,
+                "UnknownType error should appear exactly once due to deduplication, got: {}",
                 error_msg
             );
         }
@@ -161,14 +161,17 @@ mod error_recovery_tests {
         );
     }
 
-    /// Structural coverage: verifies that the dedup `skips_duplicate` branch
-    /// fires when the same AST node is visited twice. Two `UnknownType`
-    /// uses at distinct nodes do NOT trigger the skip path under node-ID
-    /// keys; this asserts zero hits to lock in that behavior.
+    /// Structural coverage: verifies that the second occurrence of the same
+    /// deduplicated error type hits the `type_checker_error_dedup_skips_duplicate`
+    /// branch in `push_error_dedup`. Uses a source where `UnknownType` appears
+    /// exactly twice so that the first occurrence hits
+    /// `type_checker_error_dedup_first_occurrence` and the second occurrence
+    /// hits `type_checker_error_dedup_skips_duplicate`; this test specifically
+    /// asserts only on the skips-duplicate path.
     #[test]
     fn test_error_dedup_skips_duplicate() {
         let source = r#"fn test(a: UnknownType, b: UnknownType) -> i32 { return 0; }"#;
-        cov_mark::check_count!(type_checker_error_dedup_skips_duplicate, 0);
+        cov_mark::check_count!(type_checker_error_dedup_skips_duplicate, 1);
         let result = try_type_check(source);
         assert!(
             result.is_err(),
@@ -465,8 +468,8 @@ mod error_recovery_tests {
             let error_msg = error.to_string();
             let count = error_msg.matches("unknown type `UnknownType`").count();
             assert_eq!(
-                count, 4,
-                "UnknownType error should appear once per AST node (4 uses), but appeared {} times in: {}",
+                count, 1,
+                "UnknownType error should appear exactly once due to deduplication, but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -486,8 +489,8 @@ mod error_recovery_tests {
                 .matches("undefined function `missing_func`")
                 .count();
             assert_eq!(
-                count, 2,
-                "missing_func error should appear once per call site (2 calls), but appeared {} times in: {}",
+                count, 1,
+                "missing_func error should appear exactly once due to deduplication, but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -507,8 +510,8 @@ mod error_recovery_tests {
                 .matches("undeclared variable `unknown_var`")
                 .count();
             assert_eq!(
-                count, 3,
-                "unknown_var error should appear once per use site (3 uses), but appeared {} times in: {}",
+                count, 1,
+                "unknown_var error should appear exactly once due to deduplication, but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -529,8 +532,8 @@ mod error_recovery_tests {
                 .count();
             let type_count = error_msg.matches("unknown type `MissingStruct`").count();
             assert!(
-                struct_count <= 1 && type_count <= 3,
-                "MissingStruct error should appear once per AST node (struct: {}, type: {}, expected type <= 3), error: {}",
+                struct_count <= 1 && type_count <= 1,
+                "MissingStruct error should appear at most once due to deduplication (struct: {}, type: {}), error: {}",
                 struct_count,
                 type_count,
                 error_msg
@@ -551,8 +554,8 @@ mod error_recovery_tests {
                 .count();
             let type_count = error_msg.matches("unknown type `MissingEnum`").count();
             assert!(
-                enum_count <= 1 && type_count <= 2,
-                "MissingEnum error should appear once per AST node (enum: {}, type: {}, expected type <= 2), error: {}",
+                enum_count <= 1 && type_count <= 1,
+                "MissingEnum error should appear at most once due to deduplication (enum: {}, type: {}), error: {}",
                 enum_count,
                 type_count,
                 error_msg

--- a/tests/src/type_checker/error_recovery.rs
+++ b/tests/src/type_checker/error_recovery.rs
@@ -139,8 +139,8 @@ mod error_recovery_tests {
             let error_msg = error.to_string();
             let unknown_type_count = error_msg.matches("unknown type `UnknownType`").count();
             assert_eq!(
-                unknown_type_count, 1,
-                "UnknownType error should appear exactly once due to deduplication, got: {}",
+                unknown_type_count, 2,
+                "UnknownType error should appear once per AST node (2 uses), got: {}",
                 error_msg
             );
         }
@@ -161,17 +161,14 @@ mod error_recovery_tests {
         );
     }
 
-    /// Structural coverage: verifies that the second occurrence of the same
-    /// deduplicated error type hits the `type_checker_error_dedup_skips_duplicate`
-    /// branch in `push_error_dedup`. Uses a source where `UnknownType` appears
-    /// exactly twice so that the first occurrence hits
-    /// `type_checker_error_dedup_first_occurrence` and the second occurrence
-    /// hits `type_checker_error_dedup_skips_duplicate`; this test specifically
-    /// asserts only on the skips-duplicate path.
+    /// Structural coverage: verifies that the dedup `skips_duplicate` branch
+    /// fires when the same AST node is visited twice. Two `UnknownType`
+    /// uses at distinct nodes do NOT trigger the skip path under node-ID
+    /// keys; this asserts zero hits to lock in that behavior.
     #[test]
     fn test_error_dedup_skips_duplicate() {
         let source = r#"fn test(a: UnknownType, b: UnknownType) -> i32 { return 0; }"#;
-        cov_mark::check_count!(type_checker_error_dedup_skips_duplicate, 1);
+        cov_mark::check_count!(type_checker_error_dedup_skips_duplicate, 0);
         let result = try_type_check(source);
         assert!(
             result.is_err(),
@@ -468,8 +465,8 @@ mod error_recovery_tests {
             let error_msg = error.to_string();
             let count = error_msg.matches("unknown type `UnknownType`").count();
             assert_eq!(
-                count, 1,
-                "UnknownType error should appear exactly once due to deduplication, but appeared {} times in: {}",
+                count, 4,
+                "UnknownType error should appear once per AST node (4 uses), but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -489,8 +486,8 @@ mod error_recovery_tests {
                 .matches("undefined function `missing_func`")
                 .count();
             assert_eq!(
-                count, 1,
-                "missing_func error should appear exactly once due to deduplication, but appeared {} times in: {}",
+                count, 2,
+                "missing_func error should appear once per call site (2 calls), but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -510,8 +507,8 @@ mod error_recovery_tests {
                 .matches("undeclared variable `unknown_var`")
                 .count();
             assert_eq!(
-                count, 1,
-                "unknown_var error should appear exactly once due to deduplication, but appeared {} times in: {}",
+                count, 3,
+                "unknown_var error should appear once per use site (3 uses), but appeared {} times in: {}",
                 count, error_msg
             );
         }
@@ -532,8 +529,8 @@ mod error_recovery_tests {
                 .count();
             let type_count = error_msg.matches("unknown type `MissingStruct`").count();
             assert!(
-                struct_count <= 1 && type_count <= 1,
-                "MissingStruct error should appear at most once due to deduplication (struct: {}, type: {}), error: {}",
+                struct_count <= 1 && type_count <= 3,
+                "MissingStruct error should appear once per AST node (struct: {}, type: {}, expected type <= 3), error: {}",
                 struct_count,
                 type_count,
                 error_msg
@@ -554,8 +551,8 @@ mod error_recovery_tests {
                 .count();
             let type_count = error_msg.matches("unknown type `MissingEnum`").count();
             assert!(
-                enum_count <= 1 && type_count <= 1,
-                "MissingEnum error should appear at most once due to deduplication (enum: {}, type: {}), error: {}",
+                enum_count <= 1 && type_count <= 2,
+                "MissingEnum error should appear once per AST node (enum: {}, type: {}, expected type <= 2), error: {}",
                 enum_count,
                 type_count,
                 error_msg

--- a/tests/src/type_checker/error_recovery.rs
+++ b/tests/src/type_checker/error_recovery.rs
@@ -885,4 +885,82 @@ mod error_recovery_tests {
             }
         }
     }
+
+    /// Locks in `(DedupKind, name)` semantics: the same identifier
+    /// `Foo` used as an unknown type and as an undefined struct produces
+    /// *both* errors. Dedup is per kind, not just per name.
+    #[test]
+    fn test_dedup_distinguishes_different_kinds_with_same_name() {
+        let source = r#"fn test() -> i32 { let x: Foo = Foo { }; return 0; }"#;
+        let result = try_type_check(source);
+        assert!(result.is_err(), "Type checker should detect errors");
+        if let Err(error) = result {
+            let error_msg = error.to_string();
+            let type_count = error_msg.matches("unknown type `Foo`").count();
+            let struct_count = error_msg.matches("struct `Foo` is not defined").count();
+            assert_eq!(
+                type_count, 1,
+                "UnknownType:Foo should fire exactly once: {}",
+                error_msg
+            );
+            assert_eq!(
+                struct_count, 1,
+                "UndefinedStruct:Foo should fire exactly once: {}",
+                error_msg
+            );
+        }
+    }
+
+    /// Locks in dedup of `SpecFunctionShadowsTopLevel`: a spec that
+    /// shadows a top-level function emits the error exactly once even
+    /// though the walker could plausibly reach the inner def from
+    /// multiple paths.
+    #[test]
+    fn test_spec_function_shadows_top_level_is_deduplicated() {
+        let source = r#"
+            fn shared() -> i32 { return 0; }
+            spec MySpec {
+                fn shared() -> i32 { return 0; }
+            }
+        "#;
+        let result = try_type_check(source);
+        assert!(
+            result.is_err(),
+            "Type checker should reject spec function shadowing a top-level function"
+        );
+        if let Err(error) = result {
+            let error_msg = error.to_string();
+            let count = error_msg
+                .matches("shadows a top-level function")
+                .count();
+            assert_eq!(
+                count, 1,
+                "SpecFunctionShadowsTopLevel error should be deduplicated once per (spec, fn) pair: {}",
+                error_msg
+            );
+        }
+    }
+
+    /// Sanity check that errors *not* listed in `DedupKind` are recorded
+    /// as-is: a type-mismatch in two different statements must surface
+    /// both messages.
+    #[test]
+    fn test_non_deduplicated_errors_are_recorded_per_site() {
+        let source =
+            r#"fn test() -> i32 { let x: i32 = true; let y: i32 = false; return x + y; }"#;
+        let result = try_type_check(source);
+        assert!(
+            result.is_err(),
+            "Type checker should detect both type mismatches"
+        );
+        if let Err(error) = result {
+            let error_msg = error.to_string();
+            let mismatch_count = error_msg.matches("type mismatch").count();
+            assert_eq!(
+                mismatch_count, 2,
+                "Each TypeMismatch site should be reported (no dedup): {}",
+                error_msg
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Salvaged and rebased version of #115 by @Arowolokehinde (their commit `838f44e` is preserved verbatim with original authorship). #115's branch could not be force-pushed back to the fork from this environment (classic PAT lacks maintainer-edit write capability), so this PR opens against an upstream branch instead.

Two commits:

- **`838f44e` (Arowolo kehinde)** — faithful implementation of #71: introduces `ErrorKind` enum, switches `reported_error_keys: FxHashSet<String>` to `reported_errors: FxHashSet<(ErrorKind, u32)>`, adds `node_id` to `push_error_dedup`, updates all eight call sites, and refits the test counts.
- **`a0b9beb` (review fixup)** — addresses the maintainer review left on #115:
  - Per-node dedup is dead code in practice (every diagnostic site is visited exactly once) and floods user output (errors are joined with `; `). Switch the key back to the symbol name so the prior dedup-by-name behaviour is restored while keeping the contributor's typed-key improvement over `format!()`-built strings.
  - Rename `ErrorKind` → `DedupKind` (only 6 of 30+ `TypeCheckError` variants participate, so the broader name was misleading).
  - Collapse `kind()` + outer name-extraction match into a single `dedup_key(&self) -> Option<(DedupKind, String)>` helper. One source of truth, no `unreachable!` arm.
  - Drop the `node_id: u32` parameter from `push_error_dedup` and every call site; keep `cov_mark::hit!` instrumentation intact for PR #110's coverage tests.
  - Restore the original `error_recovery` assertions (`count == 1` and `<= 1`) now that name-based dedup is back.
  - Route the previously open-coded `SpecFunctionShadowsTopLevel` site at `type_checker.rs:486` through `push_error_dedup` so the dedup mechanism has one source of truth.
  - Refresh `core/type-checker/docs/architecture.md` so the field shape and the dedup snippet match the code.

Fixes #71. Closes #115 (with credit to @Arowolokehinde).

## Testing

- `cargo build` — workspace builds clean
- `cargo test` — full test suite passes; the `error_recovery` dedup tests and the `cov_mark::check_count!` assertions from #110 all pass

## Files modified

- `core/type-checker/src/errors.rs` — `DedupKind` enum + `TypeCheckError::dedup_key()`
- `core/type-checker/src/type_checker.rs` — field/import rename, `push_error_dedup` rewrite, 9 call sites
- `core/type-checker/docs/architecture.md` — field shape + dedup snippet
- `tests/src/type_checker/error_recovery.rs` — count assertions stay at 1 (no behavioural regression)