### PR TITLE
feat(analysis): A036 stack overflow guard via static call-graph analysis (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Builds a whole-program call graph keyed by the canonical function name (matching the codegen `FnKey` scheme); call resolution is conservative, so edges are created only to existing nodes and the rule never produces a false positive
   - Reports each call cycle once via a white/gray/black DFS, naming the full cycle (e.g. `a -> b -> a`) and pointing the diagnostic at the call site that closes it
   - Migrated the recursive codegen fixtures to iterative form to comply with the new rule: rewrote `algo_bitwise` (`popcount`, `count_leading_zeros`), `algo_converge` (`slow_div`, `slow_mod`, `peasant_mul`, `is_prime`, `collatz_steps`, `collatz_max`), and `algo_i64_mixed` (`factorial_i64`, `fibonacci_i64`, `gcd_i64`) into conditional loops with `mut` accumulators and a single trailing return; removed the wholly recursive `algo_recursive_math` fixture (its functions already have iterative equivalents in `algo_iter`)
+- A036 `StackDepthExceeded`: reject programs whose cumulative shadow-stack usage along a call chain exceeds the 64 KB stack budget, turning the previously opaque runtime `memory.fill` out-of-bounds trap into a precise compile-time error ([#166])
+  - Reuses A035's whole-program call graph (now a DAG, since recursion is forbidden) and computes the maximum-weight root-to-leaf path, where each node's weight is a conservative upper bound on that function's compound (array/struct) frame size; scalar locals live in WASM locals and contribute nothing
+  - The frame-size estimator computes each compound type's **exact** codegen size (mirroring `compute_struct_field_layout` field-by-field, including array-of-structs) and adds only a flat worst-case leading-padding margin once per frame slot, then rounds to the 16-byte boundary — so it remains a sound upper bound on codegen's `FrameLayout.total_size` (never accepts a program codegen would overflow) without falsely rejecting valid array-of-structs frames; `if`/`else` branches take the per-branch maximum, mirroring codegen's offset reuse
+  - The longest-path DFS is cycle-safe (white/gray/black coloring); a recursive program is reported by A035 while A036 does not hang
+  - Factored the shared call-graph construction into `core/analysis/src/call_graph.rs`, consumed by both A035 and A036
+  - Diagnostic names the offending chain (e.g. `a -> b -> c`) and reports the computed byte total against the budget
+  - The estimator's soundness (estimate ≥ codegen's real frame) is enforced cross-crate: `inference_analysis::estimate_frame_sizes()` and `CodegenOutput::frame_sizes()` expose per-function sizes (keyed by canonical name), and a parity test asserts estimate ≥ real over a corpus of struct, mixed-alignment, nested, array-of-struct, mutable-self, and if/else cases. A codegen test guards the ≤8-byte max-alignment invariant that `MAX_SLOT_PADDING` relies on
 
 ### AST
 
@@ -697,3 +704,4 @@ Initial tagged release.
 [#111]: https://github.com/Inferara/inference/pull/111
 [#117]: https://github.com/Inferara/inference/pull/117
 [#205]: https://github.com/Inferara/inference/issues/205
+[#166]: https://github.com/Inferara/inference/issues/166

--- a/core/analysis/Cargo.toml
+++ b/core/analysis/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["compilers"]
 inference-ast.workspace = true
 inference-type-checker.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+inference-type-checker = { workspace = true, features = ["test-utils"] }

--- a/core/analysis/README.md
+++ b/core/analysis/README.md
@@ -105,6 +105,14 @@ These rules cover constructs that are valid in the type system but cannot yet be
 
 A035 builds a whole-program call graph keyed by the canonical function name (matching the codegen `FnKey` scheme) and reports each call cycle once, pointing at the call site that closes the cycle.
 
+### Stack Depth (errors)
+
+| ID | Struct | Severity | What it checks |
+|----|--------|----------|----------------|
+| A036 | `StackDepthExceeded` | error | cumulative shadow-stack usage along a call chain must not exceed the 64 KB stack budget |
+
+A036 reuses A035's whole-program call graph (a DAG, since recursion is forbidden) and computes the maximum-weight root-to-leaf path, where each node's weight is a conservative upper bound on that function's compound (array/struct) frame size. Scalar locals live in WASM locals and contribute nothing. The estimate over-approximates codegen's real frame layout by construction, so the rule never accepts a program codegen would overflow. The shared graph construction lives in `src/call_graph.rs`.
+
 ## Diagnostic Output Format
 
 ```
@@ -200,6 +208,7 @@ Test files are organized by rule group:
 | `rules_a029_a030.rs` | A029 (compound literal in compound assign), A030 removal acceptance tests |
 | `rules_a031.rs` | A031 (unsupported compound return expression) |
 | `rules_a035.rs` | A035 (direct and mutual/indirect recursion) |
+| `rules_a036.rs` | A036 (cumulative stack depth exceeded) |
 | `walker_tests.rs` | `walk_function_bodies`, `WalkContext` depth tracking |
 
 ## Dependencies

--- a/core/analysis/src/call_graph.rs
+++ b/core/analysis/src/call_graph.rs
@@ -1,0 +1,348 @@
+//! Whole-program call graph shared by the recursion (A035) and stack-depth
+//! (A036) analyses.
+//!
+//! Both rules need the same directed graph of function definitions keyed by the
+//! canonical name codegen lowers to (the [`FnKey`] Display scheme: free `f`,
+//! spec-free `S.f`, method `T.m`, spec-method `S.T.m`). This module builds that
+//! graph once and exposes the spec-first edge resolution that turns raw callee
+//! keys into node indices.
+//!
+//! # Call resolution
+//!
+//! A call site carries only the callee *expression*, never the resolved callee
+//! `DefId`. Rather than re-running full name resolution, the graph keys mirror
+//! the strings codegen lowers to, which guarantees the same call targets the
+//! compiler would actually emit. Resolution is deliberately conservative: an
+//! edge is created only when it can be resolved to an existing graph node, so
+//! callers never produce a false positive.
+//!
+//! Resolved forms (see [`resolve_callee_raw`]):
+//! - `Expr::Identifier(name)` — a free or spec-inner free function.
+//! - `Expr::TypeMemberAccess { Type::assoc }` — an associated function `T.assoc`.
+//! - `Expr::MemberAccess { recv.m }` — a method, when the receiver's type is a
+//!   known struct; otherwise the edge is dropped.
+//! - any other callee form (e.g. a function-valued expression) is dropped.
+//!
+//! [`FnKey`]: (codegen-internal; mirrored here, not imported)
+
+use std::collections::{HashMap, HashSet};
+
+use inference_ast::arena::AstArena;
+use inference_ast::ids::{BlockId, DefId, ExprId, NodeId, StmtId};
+use inference_ast::nodes::{Def, Expr, Location, Stmt, TypeNode};
+#[cfg(test)]
+use inference_ast::ids::idx_from_u32;
+use inference_type_checker::type_info::TypeInfoKind;
+
+use crate::rule::TypedContext;
+use crate::walker::{for_each_stmt_expr, walk_expr};
+
+/// One outgoing call edge: the resolved *raw* (un-spec-prefixed) callee key, the
+/// enclosing spec of the caller (for spec-first resolution), and the call-site
+/// location used for the diagnostic.
+pub(crate) struct CallEdge {
+    pub(crate) callee_raw: String,
+    pub(crate) spec: Option<String>,
+    pub(crate) location: Location,
+}
+
+/// A function node in the call graph.
+///
+/// `key` is the canonical name matching the codegen `FnKey` Display scheme
+/// (free `f`, spec-free `S.f`, method `T.m`, spec-method `S.T.m`). `display` is
+/// the human-facing label used to render a chain; today it equals `key`.
+///
+/// The remaining fields carry just enough of the definition for downstream
+/// rules that weight or inspect each node (A036's frame-size estimator): the
+/// `DefId` of the function, the body block, and the enclosing struct name (so a
+/// mutable-`self` frame slot can be sized). A035 ignores them.
+pub(crate) struct FnNode {
+    pub(crate) key: String,
+    pub(crate) display: String,
+    pub(crate) edges: Vec<CallEdge>,
+    pub(crate) def_id: DefId,
+    pub(crate) body: BlockId,
+    pub(crate) location: Location,
+    /// Name of the struct that owns this function when it is a method, used to
+    /// size a mutable-`self` frame slot. `None` for free and associated
+    /// functions.
+    pub(crate) struct_name: Option<String>,
+}
+
+/// Builds the whole-program call graph across every source file.
+pub(crate) fn build_call_graph(ctx: &TypedContext) -> Vec<FnNode> {
+    let arena = ctx.arena();
+    let mut nodes: Vec<FnNode> = Vec::new();
+    for source_file in ctx.source_files() {
+        collect_defs(ctx, arena, &source_file.defs, None, None, &mut nodes);
+    }
+    nodes
+}
+
+/// Recurses through definitions, tracking the enclosing spec name and
+/// struct/type name so the graph keys match the codegen `FnKey` Display scheme.
+/// `ExternFunction` has no body and is never a node.
+fn collect_defs(
+    ctx: &TypedContext,
+    arena: &AstArena,
+    def_ids: &[DefId],
+    spec: Option<&str>,
+    type_name: Option<&str>,
+    nodes: &mut Vec<FnNode>,
+) {
+    for &def_id in def_ids {
+        match &arena[def_id].kind {
+            Def::Function { name, body, .. } => {
+                let fname = arena[*name].name.clone();
+                let key = fn_key(spec, type_name, &fname);
+                let mut edges = Vec::new();
+                collect_calls_in_block(ctx, arena, *body, spec, &mut edges);
+                nodes.push(FnNode {
+                    display: key.clone(),
+                    key,
+                    edges,
+                    def_id,
+                    body: *body,
+                    location: arena[def_id].location,
+                    struct_name: type_name.map(str::to_string),
+                });
+            }
+            Def::Struct { name, methods, .. } => {
+                let tn = arena[*name].name.clone();
+                collect_defs(ctx, arena, methods, spec, Some(&tn), nodes);
+            }
+            Def::Spec { name, defs, .. } => {
+                let sn = arena[*name].name.clone();
+                collect_defs(ctx, arena, defs, Some(&sn), type_name, nodes);
+            }
+            Def::Module { defs: Some(d), .. } => {
+                collect_defs(ctx, arena, d, spec, type_name, nodes);
+            }
+            Def::Enum { .. }
+            | Def::Constant { .. }
+            | Def::ExternFunction { .. }
+            | Def::TypeAlias { .. }
+            | Def::Module { defs: None, .. } => {}
+        }
+    }
+}
+
+/// Visits every statement of `body` (recursing into nested `If`/`Loop`/`Block`
+/// sub-blocks) and every sub-expression, collecting one edge per
+/// `Expr::FunctionCall` whose callee resolves.
+fn collect_calls_in_block(
+    ctx: &TypedContext,
+    arena: &AstArena,
+    body: BlockId,
+    spec: Option<&str>,
+    edges: &mut Vec<CallEdge>,
+) {
+    for &stmt_id in &arena[body].stmts {
+        collect_calls_in_stmt(ctx, arena, stmt_id, spec, edges);
+    }
+}
+
+fn collect_calls_in_stmt(
+    ctx: &TypedContext,
+    arena: &AstArena,
+    stmt_id: StmtId,
+    spec: Option<&str>,
+    edges: &mut Vec<CallEdge>,
+) {
+    for_each_stmt_expr(&arena[stmt_id].kind, arena, &mut |expr_id| {
+        walk_expr(arena, expr_id, &mut |sub| {
+            if let Expr::FunctionCall { function, .. } = &arena[sub].kind
+                && let Some(raw) = resolve_callee_raw(ctx, *function)
+            {
+                edges.push(CallEdge {
+                    callee_raw: raw,
+                    spec: spec.map(str::to_string),
+                    location: arena[sub].location,
+                });
+            }
+        });
+    });
+    // `for_each_stmt_expr` yields only a statement's own expressions; it does
+    // not descend into nested control-flow blocks, so recurse explicitly.
+    match &arena[stmt_id].kind {
+        Stmt::If {
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_calls_in_block(ctx, arena, *then_block, spec, edges);
+            if let Some(else_id) = else_block {
+                collect_calls_in_block(ctx, arena, *else_id, spec, edges);
+            }
+        }
+        Stmt::Loop { body, .. } => collect_calls_in_block(ctx, arena, *body, spec, edges),
+        Stmt::Block(b) => collect_calls_in_block(ctx, arena, *b, spec, edges),
+        _ => {}
+    }
+}
+
+/// Builds a canonical node key matching the codegen `FnKey` Display scheme.
+pub(crate) fn fn_key(spec: Option<&str>, type_name: Option<&str>, fname: &str) -> String {
+    match (spec, type_name) {
+        (Some(s), Some(t)) => format!("{s}.{t}.{fname}"),
+        (Some(s), None) => format!("{s}.{fname}"),
+        (None, Some(t)) => format!("{t}.{fname}"),
+        (None, None) => fname.to_string(),
+    }
+}
+
+/// Resolves a callee expression to a *raw* (un-spec-prefixed) key, or `None`
+/// when the callee form is unsupported or its receiver type is unknown.
+///
+/// Known limitation: a `recv.method()` whose receiver type only resolves via
+/// [`TypedContext::lookup_struct`] is dropped when that lookup misses. The
+/// symbol table does not recurse into `Def::Module.defs`, so a method of a
+/// module-nested struct is not visible there and its edge would go unrecorded.
+/// This is unreachable today (the grammar has no module-body syntax — see the
+/// `unimplemented!` in `core/ast/src/builder.rs`) but must be revisited when
+/// modules land, alongside the matching `lookup_struct` gap.
+fn resolve_callee_raw(ctx: &TypedContext, function: ExprId) -> Option<String> {
+    let arena = ctx.arena();
+    match &arena[function].kind {
+        Expr::Identifier(id) => Some(arena[*id].name.clone()),
+        Expr::TypeMemberAccess { expr, name } => {
+            let tn = type_name_of(arena, *expr)?;
+            Some(format!("{tn}.{}", arena[*name].name))
+        }
+        Expr::MemberAccess { expr, name } => {
+            let recv = ctx.get_node_typeinfo(NodeId::Expr(*expr))?;
+            let tn = match &recv.kind {
+                TypeInfoKind::Struct(t) => t.clone(),
+                TypeInfoKind::Custom(t) if ctx.lookup_struct(t).is_some() => t.clone(),
+                _ => return None,
+            };
+            Some(format!("{tn}.{}", arena[*name].name))
+        }
+        _ => None,
+    }
+}
+
+/// Extracts a type name from the left-hand side of a `TypeMemberAccess`
+/// (`Type::assoc()`), accepting either a bare identifier or a `Custom` type.
+fn type_name_of(arena: &AstArena, expr: ExprId) -> Option<String> {
+    match &arena[expr].kind {
+        Expr::Identifier(id) => Some(arena[*id].name.clone()),
+        Expr::Type(ty) => match &arena[*ty].kind {
+            TypeNode::Custom(id) => Some(arena[*id].name.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Resolves each node's raw edges into a directed adjacency list of node
+/// indices, paired with the call-site location of the edge.
+///
+/// Each raw edge is resolved with spec-first resolution (matching codegen's
+/// spec-active call probe): a bare name inside spec `S` is first tried as
+/// `S.name`, then as the top-level `name`; if neither names an existing node
+/// the edge is dropped. Because edges only ever target existing nodes, callers
+/// can never manufacture a false edge.
+pub(crate) fn resolve_adjacency(nodes: &[FnNode]) -> Vec<Vec<(usize, Location)>> {
+    let index: HashMap<&str, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.key.as_str(), i))
+        .collect();
+    let known: HashSet<&str> = index.keys().copied().collect();
+
+    nodes
+        .iter()
+        .map(|n| {
+            n.edges
+                .iter()
+                .filter_map(|e| {
+                    let spec_key = e.spec.as_ref().map(|s| format!("{s}.{}", e.callee_raw));
+                    let resolved = spec_key
+                        .as_deref()
+                        .filter(|k| known.contains(k))
+                        .or_else(|| known.get(e.callee_raw.as_str()).copied());
+                    resolved.and_then(|k| index.get(k).map(|&j| (j, e.location)))
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// DFS coloring used by the cycle-aware traversals in both rules.
+pub(crate) const WHITE: u8 = 0;
+pub(crate) const GRAY: u8 = 1;
+pub(crate) const BLACK: u8 = 2;
+
+/// Builds a graph node whose outgoing edges are top-level (spec-free) raw keys,
+/// for the unit tests of the rules that share this module. The body/def
+/// metadata is irrelevant to graph-shape tests, so it is filled with
+/// arena-index placeholders.
+#[cfg(test)]
+pub(crate) fn test_node(key: &str, callees: &[&str]) -> FnNode {
+    FnNode {
+        key: key.to_string(),
+        display: key.to_string(),
+        edges: callees
+            .iter()
+            .map(|c| CallEdge {
+                callee_raw: (*c).to_string(),
+                spec: None,
+                location: Location::default(),
+            })
+            .collect(),
+        def_id: idx_from_u32(0),
+        body: idx_from_u32(0),
+        location: Location::default(),
+        struct_name: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc() -> Location {
+        Location::default()
+    }
+
+    #[test]
+    fn adjacency_resolves_known_edges_and_drops_unknown() {
+        let nodes = vec![test_node("a", &["b", "ext"]), test_node("b", &[])];
+        let adj = resolve_adjacency(&nodes);
+        assert_eq!(adj[0].len(), 1, "edge to unknown `ext` must be dropped");
+        assert_eq!(adj[0][0].0, 1, "edge `a -> b` must resolve to node index 1");
+        assert!(adj[1].is_empty());
+    }
+
+    #[test]
+    fn adjacency_spec_first_prefers_spec_inner_node() {
+        let nodes = vec![
+            FnNode {
+                key: "S.f".to_string(),
+                display: "S.f".to_string(),
+                edges: vec![CallEdge {
+                    callee_raw: "f".to_string(),
+                    spec: Some("S".to_string()),
+                    location: loc(),
+                }],
+                def_id: idx_from_u32(0),
+                body: idx_from_u32(0),
+                location: loc(),
+                struct_name: None,
+            },
+            test_node("f", &[]),
+        ];
+        let adj = resolve_adjacency(&nodes);
+        assert_eq!(adj[0].len(), 1);
+        assert_eq!(adj[0][0].0, 0, "bare `f` inside spec `S` must resolve to `S.f`");
+    }
+
+    #[test]
+    fn fn_key_matches_codegen_display_scheme() {
+        assert_eq!(fn_key(None, None, "f"), "f");
+        assert_eq!(fn_key(Some("S"), None, "f"), "S.f");
+        assert_eq!(fn_key(None, Some("T"), "m"), "T.m");
+        assert_eq!(fn_key(Some("S"), Some("T"), "m"), "S.T.m");
+    }
+}

--- a/core/analysis/src/errors.rs
+++ b/core/analysis/src/errors.rs
@@ -185,6 +185,14 @@ pub enum AnalysisDiagnostic {
 
     #[error("recursive function call is not allowed: {cycle}; Inference forbids direct and indirect recursion (Power of 10, Rule 1) so stack usage stays statically bounded; restructure into an explicit loop")]
     RecursionDetected { cycle: String, location: Location },
+
+    #[error("maximum stack depth {chain} uses {depth_bytes} bytes, exceeding the {budget_bytes}-byte stack; reduce array/struct frame sizes along this call chain")]
+    StackDepthExceeded {
+        chain: String,
+        depth_bytes: u32,
+        budget_bytes: u32,
+        location: Location,
+    },
 }
 
 impl AnalysisDiagnostic {
@@ -223,7 +231,8 @@ impl AnalysisDiagnostic {
             | AnalysisDiagnostic::TopLevelConstNotSupported { location, .. }
             | AnalysisDiagnostic::CombinedUnaryOperators { location, .. }
             | AnalysisDiagnostic::VisibilityInsideSpec { location, .. }
-            | AnalysisDiagnostic::RecursionDetected { location, .. } => location,
+            | AnalysisDiagnostic::RecursionDetected { location, .. }
+            | AnalysisDiagnostic::StackDepthExceeded { location, .. } => location,
         }
     }
 
@@ -266,6 +275,7 @@ impl AnalysisDiagnostic {
             AnalysisDiagnostic::CombinedUnaryOperators { .. } => "A033",
             AnalysisDiagnostic::VisibilityInsideSpec { .. } => "A034",
             AnalysisDiagnostic::RecursionDetected { .. } => "A035",
+            AnalysisDiagnostic::StackDepthExceeded { .. } => "A036",
         }
     }
 }
@@ -538,6 +548,16 @@ mod tests {
         assert_eq!(
             AnalysisDiagnostic::ReturnInsideNonDetBlock { location: test_location(), block_kind: "forall" }.rule_id(),
             "A005"
+        );
+        assert_eq!(
+            AnalysisDiagnostic::StackDepthExceeded {
+                chain: "a -> b".to_string(),
+                depth_bytes: 80_000,
+                budget_bytes: 65_536,
+                location: test_location(),
+            }
+            .rule_id(),
+            "A036"
         );
     }
 
@@ -817,6 +837,30 @@ mod tests {
             "A035 diagnostic must cite Power of 10, got: {text}"
         );
         assert_eq!(err.rule_id(), "A035");
+    }
+
+    #[test]
+    fn display_stack_depth_exceeded() {
+        let err = AnalysisDiagnostic::StackDepthExceeded {
+            chain: "main -> work -> alloc".to_string(),
+            depth_bytes: 98_304,
+            budget_bytes: 65_536,
+            location: test_location(),
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("main -> work -> alloc"),
+            "A036 diagnostic must include the call chain, got: {text}"
+        );
+        assert!(
+            text.contains("98304"),
+            "A036 diagnostic must include the depth in bytes, got: {text}"
+        );
+        assert!(
+            text.contains("65536"),
+            "A036 diagnostic must include the budget in bytes, got: {text}"
+        );
+        assert_eq!(err.rule_id(), "A036");
     }
 
     #[test]

--- a/core/analysis/src/lib.rs
+++ b/core/analysis/src/lib.rs
@@ -67,6 +67,14 @@
 //!
 //! - A035: Direct or indirect (mutual) recursion is forbidden (Power of 10, Rule 1)
 //!
+//! ### Stack Depth (A036)
+//!
+//! - A036: Cumulative shadow-stack usage along a call chain must not exceed the
+//!   64 KB stack budget. Because A035 makes the call graph acyclic, the
+//!   worst-case usage is the maximum-weight root-to-leaf path (node weight =
+//!   that function's compound-frame size). The estimator over-approximates each
+//!   frame to stay sound against codegen; see [`rules::stack_depth`].
+//!
 //! ## Pipeline Position
 //!
 //! ```text
@@ -89,12 +97,15 @@
 
 use inference_type_checker::typed_context::TypedContext;
 
+mod call_graph;
 pub mod errors;
 pub mod rule;
 pub mod rules;
 mod walker;
 
 use errors::{AnalysisErrors, AnalysisResult, Severity};
+
+pub use rules::stack_depth::estimate_frame_sizes;
 
 /// Performs static analysis on the typed AST.
 ///
@@ -172,6 +183,7 @@ mod tests {
             AnalysisDiagnostic::CombinedUnaryOperators { op_outer: "-", op_inner: "~", location: dummy_location() },
             AnalysisDiagnostic::VisibilityInsideSpec { spec_name: "S".to_string(), def_name: "f".to_string(), def_kind: "fn", location: dummy_location() },
             AnalysisDiagnostic::RecursionDetected { cycle: "f -> f".to_string(), location: dummy_location() },
+            AnalysisDiagnostic::StackDepthExceeded { chain: "a -> b".to_string(), depth_bytes: 80_000, budget_bytes: 65_536, location: dummy_location() },
         ];
 
         let rules = rules::all_rules();

--- a/core/analysis/src/rules/mod.rs
+++ b/core/analysis/src/rules/mod.rs
@@ -21,6 +21,7 @@ pub mod nested_compound_depth;
 pub mod recursion;
 pub mod return_inside_loop;
 pub mod return_inside_nondet_block;
+pub mod stack_depth;
 pub mod standalone_uzumaki;
 pub mod top_level_const;
 pub mod uninitialized_variable;
@@ -54,6 +55,7 @@ use nested_compound_depth::NestedCompoundDepth;
 use recursion::RecursionDetected;
 use return_inside_loop::ReturnInsideLoop;
 use return_inside_nondet_block::ReturnInsideNonDetBlock;
+use stack_depth::StackDepthExceeded;
 use standalone_uzumaki::StandaloneUzumaki;
 use top_level_const::TopLevelConstNotSupported;
 use uninitialized_variable::UninitializedVariable;
@@ -105,5 +107,6 @@ pub fn all_rules() -> &'static [&'static dyn crate::rule::Rule] {
         &CombinedUnaryOperators,
         &VisibilityInsideSpec,
         &RecursionDetected,
+        &StackDepthExceeded,
     ]
 }

--- a/core/analysis/src/rules/recursion.rs
+++ b/core/analysis/src/rules/recursion.rs
@@ -1,59 +1,22 @@
 //! A035: Direct and mutual/indirect recursion is forbidden (Power of 10, Rule 1).
 //!
 //! Inference forbids all recursion so that the maximum stack depth of a program
-//! is statically bounded. This rule builds a directed call graph keyed by the
-//! canonical function name (mirroring the codegen [`FnKey`] Display scheme) and
-//! reports each call cycle exactly once via a white/gray/black DFS, pointing the
-//! diagnostic at the call site that closes the cycle.
+//! is statically bounded. This rule builds a directed call graph (see
+//! [`crate::call_graph`]) keyed by the canonical function name (mirroring the
+//! codegen `FnKey` Display scheme) and reports each call cycle exactly once via
+//! a white/gray/black DFS, pointing the diagnostic at the call site that closes
+//! the cycle.
 //!
-//! # Call resolution
-//!
-//! A call site carries only the callee *expression*, never the resolved callee
-//! `DefId`. Rather than re-running full name resolution, the graph keys mirror
-//! the strings codegen lowers to, which guarantees the same call targets the
-//! compiler would actually emit. Resolution is deliberately conservative: an
-//! edge is created only when it can be resolved to an existing graph node, so
-//! the rule never produces a false positive.
-//!
-//! Resolved forms (see [`resolve_callee_raw`]):
-//! - `Expr::Identifier(name)` — a free or spec-inner free function.
-//! - `Expr::TypeMemberAccess { Type::assoc }` — an associated function `T.assoc`.
-//! - `Expr::MemberAccess { recv.m }` — a method, when the receiver's type is a
-//!   known struct; otherwise the edge is dropped.
-//! - any other callee form (e.g. a function-valued expression) is dropped.
-//!
-//! [`FnKey`]: (codegen-internal; mirrored here, not imported)
+//! The call-graph construction and spec-first edge resolution are shared with
+//! the stack-depth analysis (A036); see [`crate::call_graph`] for the
+//! resolution rules and their known limitations.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use inference_ast::arena::AstArena;
-use inference_ast::ids::{BlockId, DefId, ExprId, NodeId, StmtId};
-use inference_ast::nodes::{Def, Expr, Location, Stmt, TypeNode};
-use inference_type_checker::type_info::TypeInfoKind;
+use inference_ast::nodes::Location;
 
+use crate::call_graph::{build_call_graph, resolve_adjacency, FnNode, BLACK, GRAY, WHITE};
 use crate::errors::AnalysisDiagnostic;
-use crate::rule::TypedContext;
-use crate::walker::{for_each_stmt_expr, walk_expr};
-
-/// One outgoing call edge: the resolved *raw* (un-spec-prefixed) callee key, the
-/// enclosing spec of the caller (for spec-first resolution), and the call-site
-/// location used for the diagnostic.
-struct CallEdge {
-    callee_raw: String,
-    spec: Option<String>,
-    location: Location,
-}
-
-/// A function node in the call graph.
-///
-/// `key` is the canonical name matching the codegen `FnKey` Display scheme
-/// (free `f`, spec-free `S.f`, method `T.m`, spec-method `S.T.m`). `display` is
-/// the human-facing label used to render a cycle chain; today it equals `key`.
-struct FnNode {
-    key: String,
-    display: String,
-    edges: Vec<CallEdge>,
-}
 
 crate::rule! {
     /// Direct and mutual recursion is forbidden (Power of 10, Rule 1).
@@ -67,204 +30,9 @@ crate::rule! {
     }
 }
 
-/// Builds the whole-program call graph across every source file.
-fn build_call_graph(ctx: &TypedContext) -> Vec<FnNode> {
-    let arena = ctx.arena();
-    let mut nodes: Vec<FnNode> = Vec::new();
-    for source_file in ctx.source_files() {
-        collect_defs(ctx, arena, &source_file.defs, None, None, &mut nodes);
-    }
-    nodes
-}
-
-/// Recurses through definitions (same shape as `missing_return::check_defs`),
-/// tracking the enclosing spec name and struct/type name so the graph keys
-/// match the codegen `FnKey` Display scheme. `ExternFunction` has no body and is
-/// never a node.
-fn collect_defs(
-    ctx: &TypedContext,
-    arena: &AstArena,
-    def_ids: &[DefId],
-    spec: Option<&str>,
-    type_name: Option<&str>,
-    nodes: &mut Vec<FnNode>,
-) {
-    for &def_id in def_ids {
-        match &arena[def_id].kind {
-            Def::Function { name, body, .. } => {
-                let fname = arena[*name].name.clone();
-                let key = fn_key(spec, type_name, &fname);
-                let mut edges = Vec::new();
-                collect_calls_in_block(ctx, arena, *body, spec, &mut edges);
-                nodes.push(FnNode {
-                    display: key.clone(),
-                    key,
-                    edges,
-                });
-            }
-            Def::Struct { name, methods, .. } => {
-                let tn = arena[*name].name.clone();
-                collect_defs(ctx, arena, methods, spec, Some(&tn), nodes);
-            }
-            Def::Spec { name, defs, .. } => {
-                let sn = arena[*name].name.clone();
-                collect_defs(ctx, arena, defs, Some(&sn), type_name, nodes);
-            }
-            Def::Module { defs: Some(d), .. } => {
-                collect_defs(ctx, arena, d, spec, type_name, nodes);
-            }
-            Def::Enum { .. }
-            | Def::Constant { .. }
-            | Def::ExternFunction { .. }
-            | Def::TypeAlias { .. }
-            | Def::Module { defs: None, .. } => {}
-        }
-    }
-}
-
-/// Visits every statement of `body` (recursing into nested `If`/`Loop`/`Block`
-/// sub-blocks) and every sub-expression, collecting one edge per
-/// `Expr::FunctionCall` whose callee resolves.
-fn collect_calls_in_block(
-    ctx: &TypedContext,
-    arena: &AstArena,
-    body: BlockId,
-    spec: Option<&str>,
-    edges: &mut Vec<CallEdge>,
-) {
-    for &stmt_id in &arena[body].stmts {
-        collect_calls_in_stmt(ctx, arena, stmt_id, spec, edges);
-    }
-}
-
-fn collect_calls_in_stmt(
-    ctx: &TypedContext,
-    arena: &AstArena,
-    stmt_id: StmtId,
-    spec: Option<&str>,
-    edges: &mut Vec<CallEdge>,
-) {
-    for_each_stmt_expr(&arena[stmt_id].kind, arena, &mut |expr_id| {
-        walk_expr(arena, expr_id, &mut |sub| {
-            if let Expr::FunctionCall { function, .. } = &arena[sub].kind
-                && let Some(raw) = resolve_callee_raw(ctx, *function)
-            {
-                edges.push(CallEdge {
-                    callee_raw: raw,
-                    spec: spec.map(str::to_string),
-                    location: arena[sub].location,
-                });
-            }
-        });
-    });
-    // `for_each_stmt_expr` yields only a statement's own expressions; it does
-    // not descend into nested control-flow blocks, so recurse explicitly.
-    match &arena[stmt_id].kind {
-        Stmt::If {
-            then_block,
-            else_block,
-            ..
-        } => {
-            collect_calls_in_block(ctx, arena, *then_block, spec, edges);
-            if let Some(else_id) = else_block {
-                collect_calls_in_block(ctx, arena, *else_id, spec, edges);
-            }
-        }
-        Stmt::Loop { body, .. } => collect_calls_in_block(ctx, arena, *body, spec, edges),
-        Stmt::Block(b) => collect_calls_in_block(ctx, arena, *b, spec, edges),
-        _ => {}
-    }
-}
-
-/// Builds a canonical node key matching the codegen `FnKey` Display scheme.
-fn fn_key(spec: Option<&str>, type_name: Option<&str>, fname: &str) -> String {
-    match (spec, type_name) {
-        (Some(s), Some(t)) => format!("{s}.{t}.{fname}"),
-        (Some(s), None) => format!("{s}.{fname}"),
-        (None, Some(t)) => format!("{t}.{fname}"),
-        (None, None) => fname.to_string(),
-    }
-}
-
-/// Resolves a callee expression to a *raw* (un-spec-prefixed) key, or `None`
-/// when the callee form is unsupported or its receiver type is unknown.
-///
-/// Known limitation: a `recv.method()` whose receiver type only resolves via
-/// [`TypedContext::lookup_struct`] is dropped when that lookup misses. The
-/// symbol table does not recurse into `Def::Module.defs`, so a method of a
-/// module-nested struct is not visible there and its recursion would go
-/// undetected. This is unreachable today (the grammar has no module-body
-/// syntax — see the `unimplemented!` in `core/ast/src/builder.rs`) but must be
-/// revisited when modules land, alongside the matching `lookup_struct` gap.
-fn resolve_callee_raw(ctx: &TypedContext, function: ExprId) -> Option<String> {
-    let arena = ctx.arena();
-    match &arena[function].kind {
-        Expr::Identifier(id) => Some(arena[*id].name.clone()),
-        Expr::TypeMemberAccess { expr, name } => {
-            let tn = type_name_of(arena, *expr)?;
-            Some(format!("{tn}.{}", arena[*name].name))
-        }
-        Expr::MemberAccess { expr, name } => {
-            let recv = ctx.get_node_typeinfo(NodeId::Expr(*expr))?;
-            let tn = match &recv.kind {
-                TypeInfoKind::Struct(t) => t.clone(),
-                TypeInfoKind::Custom(t) if ctx.lookup_struct(t).is_some() => t.clone(),
-                _ => return None,
-            };
-            Some(format!("{tn}.{}", arena[*name].name))
-        }
-        _ => None,
-    }
-}
-
-/// Extracts a type name from the left-hand side of a `TypeMemberAccess`
-/// (`Type::assoc()`), accepting either a bare identifier or a `Custom` type.
-fn type_name_of(arena: &AstArena, expr: ExprId) -> Option<String> {
-    match &arena[expr].kind {
-        Expr::Identifier(id) => Some(arena[*id].name.clone()),
-        Expr::Type(ty) => match &arena[*ty].kind {
-            TypeNode::Custom(id) => Some(arena[*id].name.clone()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-const WHITE: u8 = 0;
-const GRAY: u8 = 1;
-const BLACK: u8 = 2;
-
 /// Detects every call cycle in the graph and emits one diagnostic per cycle.
-///
-/// Each raw edge is resolved to a node index using spec-first resolution
-/// (matching codegen's spec-active call probe): a bare name inside spec `S` is
-/// first tried as `S.name`, then as the top-level `name`; if neither names an
-/// existing node the edge is dropped. Because edges only ever target existing
-/// nodes, the graph cannot manufacture a false cycle.
 fn detect_cycles(nodes: &[FnNode]) -> Vec<AnalysisDiagnostic> {
-    let index: HashMap<&str, usize> = nodes
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (n.key.as_str(), i))
-        .collect();
-    let known: HashSet<&str> = index.keys().copied().collect();
-
-    let adj: Vec<Vec<(usize, Location)>> = nodes
-        .iter()
-        .map(|n| {
-            n.edges
-                .iter()
-                .filter_map(|e| {
-                    let spec_key = e.spec.as_ref().map(|s| format!("{s}.{}", e.callee_raw));
-                    let resolved = spec_key
-                        .as_deref()
-                        .filter(|k| known.contains(k))
-                        .or_else(|| known.get(e.callee_raw.as_str()).copied());
-                    resolved.and_then(|k| index.get(k).map(|&j| (j, e.location)))
-                })
-                .collect()
-        })
-        .collect();
+    let adj = resolve_adjacency(nodes);
 
     let mut color = vec![WHITE; nodes.len()];
     let mut stack: Vec<usize> = Vec::new();
@@ -351,25 +119,12 @@ fn render_cycle(nodes: &[FnNode], cycle: &[usize]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::call_graph::{test_node, CallEdge, FnNode};
+    use inference_ast::ids::idx_from_u32;
+    use inference_ast::nodes::Location;
 
     fn loc() -> Location {
         Location::default()
-    }
-
-    /// Builds a node whose outgoing edges are top-level (spec-free) raw keys.
-    fn node(key: &str, callees: &[&str]) -> FnNode {
-        FnNode {
-            key: key.to_string(),
-            display: key.to_string(),
-            edges: callees
-                .iter()
-                .map(|c| CallEdge {
-                    callee_raw: (*c).to_string(),
-                    spec: None,
-                    location: loc(),
-                })
-                .collect(),
-        }
     }
 
     fn cycles(diags: &[AnalysisDiagnostic]) -> Vec<String> {
@@ -384,7 +139,7 @@ mod tests {
 
     #[test]
     fn direct_self_recursion_reports_one_cycle() {
-        let nodes = vec![node("f", &["f"])];
+        let nodes = vec![test_node("f", &["f"])];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
         assert_eq!(cycles(&diags), vec!["f -> f"]);
@@ -392,7 +147,7 @@ mod tests {
 
     #[test]
     fn two_cycle_reported_once() {
-        let nodes = vec![node("a", &["b"]), node("b", &["a"])];
+        let nodes = vec![test_node("a", &["b"]), test_node("b", &["a"])];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
         assert_eq!(cycles(&diags), vec!["a -> b -> a"]);
@@ -400,7 +155,7 @@ mod tests {
 
     #[test]
     fn three_cycle_reported_once() {
-        let nodes = vec![node("a", &["b"]), node("b", &["c"]), node("c", &["a"])];
+        let nodes = vec![test_node("a", &["b"]), test_node("b", &["c"]), test_node("c", &["a"])];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
         assert_eq!(cycles(&diags), vec!["a -> b -> c -> a"]);
@@ -408,7 +163,7 @@ mod tests {
 
     #[test]
     fn non_recursive_chain_has_no_cycle() {
-        let nodes = vec![node("a", &["b"]), node("b", &["c"]), node("c", &[])];
+        let nodes = vec![test_node("a", &["b"]), test_node("b", &["c"]), test_node("c", &[])];
         let diags = detect_cycles(&nodes);
         assert!(diags.is_empty(), "expected no cycle, got: {:?}", cycles(&diags));
     }
@@ -416,7 +171,7 @@ mod tests {
     #[test]
     fn edge_to_unknown_callee_is_dropped() {
         // `a` calls an extern/unknown `ext` which is not a node: no cycle.
-        let nodes = vec![node("a", &["ext"])];
+        let nodes = vec![test_node("a", &["ext"])];
         let diags = detect_cycles(&nodes);
         assert!(diags.is_empty());
     }
@@ -424,10 +179,10 @@ mod tests {
     #[test]
     fn two_independent_cycles_reported_separately() {
         let nodes = vec![
-            node("a", &["b"]),
-            node("b", &["a"]),
-            node("c", &["d"]),
-            node("d", &["c"]),
+            test_node("a", &["b"]),
+            test_node("b", &["a"]),
+            test_node("c", &["d"]),
+            test_node("d", &["c"]),
         ];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 2);
@@ -440,10 +195,10 @@ mod tests {
     fn shared_cycle_reached_from_multiple_roots_deduped() {
         // Both `a` and `x` lead into the same `b <-> c` cycle.
         let nodes = vec![
-            node("a", &["b"]),
-            node("b", &["c"]),
-            node("c", &["b"]),
-            node("x", &["c"]),
+            test_node("a", &["b"]),
+            test_node("b", &["c"]),
+            test_node("c", &["b"]),
+            test_node("x", &["c"]),
         ];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
@@ -462,8 +217,12 @@ mod tests {
                     spec: Some("S".to_string()),
                     location: loc(),
                 }],
+                def_id: idx_from_u32(0),
+                body: idx_from_u32(0),
+                location: loc(),
+                struct_name: None,
             },
-            node("f", &[]),
+            test_node("f", &[]),
         ];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
@@ -481,17 +240,13 @@ mod tests {
                 spec: None,
                 location: loc(),
             }],
+            def_id: idx_from_u32(0),
+            body: idx_from_u32(0),
+            location: loc(),
+            struct_name: None,
         }];
         let diags = detect_cycles(&nodes);
         assert_eq!(diags.len(), 1);
         assert_eq!(cycles(&diags), vec!["T.m -> T.m"]);
-    }
-
-    #[test]
-    fn fn_key_matches_codegen_display_scheme() {
-        assert_eq!(fn_key(None, None, "f"), "f");
-        assert_eq!(fn_key(Some("S"), None, "f"), "S.f");
-        assert_eq!(fn_key(None, Some("T"), "m"), "T.m");
-        assert_eq!(fn_key(Some("S"), Some("T"), "m"), "S.T.m");
     }
 }

--- a/core/analysis/src/rules/stack_depth.rs
+++ b/core/analysis/src/rules/stack_depth.rs
@@ -1,0 +1,669 @@
+//! A036: Cumulative shadow-stack depth must not exceed the stack budget.
+//!
+//! Inference compiles to WebAssembly with a downward-growing shadow stack
+//! (`__stack_pointer`) of [`STACK_BUDGET_BYTES`]. Only functions that allocate
+//! array or struct frames consume it; scalar locals live in WASM locals and
+//! never touch linear memory. Codegen already bounds each *individual* frame,
+//! but the *cumulative* depth across a call chain is unchecked and only traps
+//! opaquely at runtime (a `memory.fill` out-of-bounds in the frame prologue).
+//!
+//! Because A035 forbids recursion, the whole-program call graph is a DAG, so the
+//! worst-case shadow-stack usage is the **maximum-weight root-to-leaf path**,
+//! where each node's weight is its compound-frame size. This rule computes that
+//! maximum and emits a compile-time error naming the offending chain when it
+//! exceeds the budget.
+//!
+//! # Soundness
+//!
+//! The per-function weight is a conservative **upper bound** on codegen's real
+//! [`FrameLayout`] size: it must never under-approximate, or the analysis would
+//! accept a program that codegen overflows. The estimator computes the **exact**
+//! codegen byte size for every compound type (mirroring
+//! `compute_struct_field_layout` field-by-field, including each field's natural
+//! alignment), so a type's intrinsic size matches codegen precisely — even for
+//! an array of structs, whose size is `exact_size(elem) * length` with no
+//! per-element inflation. The only over-approximation is at *slot placement*:
+//! each slot sits at an unknown frame offset that codegen aligns to the type's
+//! natural alignment (at most 8 bytes — `i64`/`u64`), so up to 7 leading padding
+//! bytes can appear before it. The estimator therefore adds [`MAX_SLOT_PADDING`]
+//! once **per slot** — not per field, not per array element — which always
+//! covers codegen's real `padding + size`. Summing those charges and rounding up
+//! to a 16-byte frame boundary yields a value at least codegen's
+//! `FrameLayout.total_size` for every function. `if`/`else` branches take the
+//! per-branch maximum (mirroring codegen, which reuses the offset across the two
+//! arms) rather than the sum.
+//!
+//! # Limitation
+//!
+//! v1 treats *any* node as a potential root: the maximum is taken over every
+//! function, not only exported or `spec` entry points. This is a sound
+//! over-approximation — it may flag a heavy chain that no real entry point can
+//! reach — and keeps the rule independent of entry-point discovery. A future
+//! refinement could restrict the roots to reachable entry points.
+
+use std::collections::HashSet;
+
+use inference_ast::ids::{BlockId, NodeId};
+use inference_ast::nodes::{ArgData, ArgKind, Def, Location, Stmt};
+use inference_type_checker::type_info::{NumberType, TypeInfo, TypeInfoKind};
+
+use crate::call_graph::{build_call_graph, resolve_adjacency, FnNode, BLACK, GRAY, WHITE};
+use crate::errors::AnalysisDiagnostic;
+use crate::rule::TypedContext;
+
+/// The shadow-stack budget in bytes.
+///
+/// Mirrors `core/wasm-codegen/src/memory.rs::STACK_SIZE` (one WASM page). The
+/// two constants must stay in sync: a cross-crate `const` import would require
+/// a new shared dependency, so the value is duplicated here deliberately. If
+/// codegen's stack region size changes, update this constant to match.
+const STACK_BUDGET_BYTES: u32 = 65_536;
+
+/// Frame alignment in bytes, mirroring
+/// `core/wasm-codegen/src/memory.rs::FRAME_ALIGNMENT`. Every per-function frame
+/// size is rounded up to this boundary.
+const FRAME_ALIGNMENT: u32 = 16;
+
+/// Worst-case alignment padding charged per compound slot.
+///
+/// Every supported array element and struct field has a natural alignment of at
+/// most 8 bytes (`i64`/`u64`), so codegen inserts at most 7 padding bytes before
+/// any one slot. Charging this maximum to every slot guarantees the estimate is
+/// never below codegen's real layout.
+///
+/// This `≤ 8` alignment invariant is now defended on both sides. On the codegen
+/// side the test `every_supported_type_aligns_within_max_slot_padding` in
+/// `core/wasm-codegen/src/memory.rs` fails for a future 16-byte-aligned type
+/// (i128/v128). On the analysis side the exhaustive `NumberType` matches in
+/// [`exact_byte_size_visited`] and [`alignment_of`] fail to compile when a new
+/// numeric variant is added, forcing this constant to be revisited.
+const MAX_SLOT_PADDING: u32 = 7;
+
+crate::rule! {
+    /// Cumulative shadow-stack usage across a call chain must fit the budget.
+    #[id = "A036"]
+    #[name = "Stack depth exceeded"]
+    #[severity = error]
+    pub struct StackDepthExceeded;
+    fn check(ctx: &TypedContext) -> Vec<AnalysisDiagnostic> {
+        let nodes = build_call_graph(ctx);
+        check_stack_depth(ctx, &nodes)
+    }
+}
+
+/// Computes each node's frame weight and reports the deepest weighted path when
+/// it exceeds the budget.
+fn check_stack_depth(ctx: &TypedContext, nodes: &[FnNode]) -> Vec<AnalysisDiagnostic> {
+    if nodes.is_empty() {
+        return Vec::new();
+    }
+    let weights: Vec<u32> = nodes
+        .iter()
+        .map(|n| estimate_frame_size(ctx, n))
+        .collect();
+    let adj = resolve_adjacency(nodes);
+
+    let Some((depth_bytes, path)) = deepest_path(&adj, &weights) else {
+        return Vec::new();
+    };
+    if depth_bytes <= STACK_BUDGET_BYTES {
+        return Vec::new();
+    }
+    vec![AnalysisDiagnostic::StackDepthExceeded {
+        chain: render_chain(nodes, &path),
+        depth_bytes,
+        budget_bytes: STACK_BUDGET_BYTES,
+        location: nodes[path[0]].location,
+    }]
+}
+
+/// Returns the maximum total weight over all root-to-leaf paths and the node
+/// indices of that path, or `None` for an empty graph.
+///
+/// `max_depth(u) = weight(u) + max over edges u->v of max_depth(v)`, memoized
+/// and cycle-safe: a GRAY (back-edge) target is not descended into, leaving the
+/// recursion diagnostic to A035. Because every node may be a root (see the
+/// module limitation), the global maximum is taken over all start nodes.
+fn deepest_path(adj: &[Vec<(usize, Location)>], weights: &[u32]) -> Option<(u32, Vec<usize>)> {
+    let n = weights.len();
+    if n == 0 {
+        return None;
+    }
+    let mut color = vec![WHITE; n];
+    // Memoized best (total_bytes, successor_path) for the subtree rooted at each
+    // node. `None` until computed.
+    let mut best: Vec<Option<(u32, Vec<usize>)>> = vec![None; n];
+
+    for start in 0..n {
+        if color[start] == WHITE {
+            longest_from(start, adj, weights, &mut color, &mut best);
+        }
+    }
+
+    (0..n)
+        .filter_map(|i| best[i].clone())
+        .max_by_key(|(bytes, _)| *bytes)
+}
+
+/// Computes the memoized longest weighted path starting at `u`.
+fn longest_from(
+    u: usize,
+    adj: &[Vec<(usize, Location)>],
+    weights: &[u32],
+    color: &mut [u8],
+    best: &mut [Option<(u32, Vec<usize>)>],
+) {
+    color[u] = GRAY;
+    let mut best_child: Option<(u32, Vec<usize>)> = None;
+    for &(v, _) in &adj[u] {
+        // Skip back edges into the current DFS path; A035 owns recursion.
+        if color[v] == GRAY {
+            continue;
+        }
+        if best[v].is_none() && color[v] == WHITE {
+            longest_from(v, adj, weights, color, best);
+        }
+        if let Some((child_bytes, child_path)) = &best[v]
+            && best_child
+                .as_ref()
+                .is_none_or(|(cur, _)| *child_bytes > *cur)
+        {
+            best_child = Some((*child_bytes, child_path.clone()));
+        }
+    }
+
+    let (child_bytes, mut path) = best_child.unwrap_or((0, Vec::new()));
+    let total = weights[u].saturating_add(child_bytes);
+    let mut full_path = Vec::with_capacity(path.len() + 1);
+    full_path.push(u);
+    full_path.append(&mut path);
+    best[u] = Some((total, full_path));
+    color[u] = BLACK;
+}
+
+/// Renders a path as `a -> b -> c` using node display labels.
+fn render_chain(nodes: &[FnNode], path: &[usize]) -> String {
+    path.iter()
+        .map(|&i| nodes[i].display.as_str())
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+/// Returns each function's estimated stack-frame size in bytes, keyed by
+/// canonical function name.
+///
+/// Exposed so the codegen↔analysis frame-size soundness invariant
+/// (estimate ≥ real) can be checked cross-crate; see the parity test in
+/// `inference-tests`. Keys match codegen's [`FnKey`] display scheme
+/// (free `f`, spec-free `S.f`, method `T.m`, spec-method `S.T.m`).
+///
+/// [`FnKey`]: (codegen-internal; mirrored by `crate::call_graph::fn_key`)
+#[must_use]
+pub fn estimate_frame_sizes(ctx: &TypedContext) -> std::collections::BTreeMap<String, u32> {
+    build_call_graph(ctx)
+        .iter()
+        .map(|node| (node.key.clone(), estimate_frame_size(ctx, node)))
+        .collect()
+}
+
+/// Estimates a conservative upper bound on a function's codegen frame size.
+///
+/// Mirrors codegen's slot rules: array/struct/custom params, a mutable `self`,
+/// and array/struct/custom `let`/`const` bindings each get a slot; scalars and
+/// enums get none. See the module-level soundness note for why this is always
+/// at least codegen's real `FrameLayout.total_size`.
+fn estimate_frame_size(ctx: &TypedContext, node: &FnNode) -> u32 {
+    let arena = ctx.arena();
+    let mut bytes: u32 = 0;
+
+    if let Def::Function { args, .. } = &arena[node.def_id].kind {
+        bytes = bytes.saturating_add(params_frame_bytes(ctx, args, node.struct_name.as_deref()));
+    }
+
+    bytes = bytes.saturating_add(body_frame_bytes(ctx, node.body));
+
+    if bytes == 0 {
+        return 0;
+    }
+    align_to(bytes, FRAME_ALIGNMENT)
+}
+
+/// Accumulates the slot bytes for compound parameters and a mutable `self`.
+fn params_frame_bytes(ctx: &TypedContext, args: &[ArgData], struct_name: Option<&str>) -> u32 {
+    let arena = ctx.arena();
+    let mut bytes: u32 = 0;
+    for arg in args {
+        match &arg.kind {
+            ArgKind::Named { ty, .. } => {
+                let type_info = TypeInfo::from_type_id(arena, *ty);
+                bytes = bytes.saturating_add(slot_bytes(ctx, &type_info.kind));
+            }
+            ArgKind::SelfRef { is_mut: true } => {
+                if let Some(name) = struct_name {
+                    bytes = bytes
+                        .saturating_add(slot_bytes(ctx, &TypeInfoKind::Custom(name.to_string())));
+                }
+            }
+            _ => {}
+        }
+    }
+    bytes
+}
+
+/// Walks a block accumulating slot bytes for compound bindings, mirroring
+/// codegen's `collect_compound_slots`: descends `Block`/`Loop`, and for an
+/// `If` with an `else` takes the per-branch maximum rather than the sum.
+fn body_frame_bytes(ctx: &TypedContext, block_id: BlockId) -> u32 {
+    let arena = ctx.arena();
+    let mut bytes: u32 = 0;
+    for &stmt_id in &arena[block_id].stmts {
+        match &arena[stmt_id].kind {
+            Stmt::VarDef { .. } | Stmt::ConstDef(_) => {
+                if let Some(type_info) = ctx.get_node_typeinfo(NodeId::Stmt(stmt_id)) {
+                    bytes = bytes.saturating_add(slot_bytes(ctx, &type_info.kind));
+                }
+            }
+            Stmt::Block(inner) => {
+                bytes = bytes.saturating_add(body_frame_bytes(ctx, *inner));
+            }
+            Stmt::Loop { body, .. } => {
+                bytes = bytes.saturating_add(body_frame_bytes(ctx, *body));
+            }
+            Stmt::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                let then_bytes = body_frame_bytes(ctx, *then_block);
+                let branch_bytes = match else_block {
+                    Some(else_id) => then_bytes.max(body_frame_bytes(ctx, *else_id)),
+                    None => then_bytes,
+                };
+                bytes = bytes.saturating_add(branch_bytes);
+            }
+            _ => {}
+        }
+    }
+    bytes
+}
+
+/// Returns the upper-bound slot contribution for a binding/parameter of the
+/// given type: `0` for scalars and enums (no frame slot), otherwise the exact
+/// compound byte size plus the worst-case per-slot leading alignment padding.
+fn slot_bytes(ctx: &TypedContext, kind: &TypeInfoKind) -> u32 {
+    match kind {
+        TypeInfoKind::Array(..) | TypeInfoKind::Struct(_) => {
+            exact_byte_size(ctx, kind).saturating_add(MAX_SLOT_PADDING)
+        }
+        // A `Custom` name gets a slot only when it resolves to a struct; enum
+        // and unresolved names are scalars (or invalid) and get none.
+        TypeInfoKind::Custom(name) if ctx.lookup_struct(name).is_some() => {
+            exact_byte_size(ctx, kind).saturating_add(MAX_SLOT_PADDING)
+        }
+        _ => 0,
+    }
+}
+
+/// Computes the **exact** codegen byte size of a type, mirroring codegen's
+/// `type_byte_size` / `compute_struct_field_layout` (`core/wasm-codegen/src/
+/// memory.rs`) field-by-field. Structs are laid out with each field aligned to
+/// its natural alignment against a running offset and the total rounded up to
+/// the struct's maximum field alignment; arrays are `exact_size(elem) * length`.
+/// The result equals codegen's deterministic layout — there is no
+/// over-approximation here. Per-slot leading-padding margin is added separately
+/// by [`slot_bytes`].
+///
+/// The inner [`NumberType`] match is exhaustive (no wildcard): a future numeric
+/// variant fails compilation here rather than being silently sized as zero,
+/// which would under-approximate the frame and make A036 unsound. The outer
+/// `_ => 0` arm covers only genuinely non-frame `TypeInfoKind` variants
+/// (`String`/`Unit`/`Generic`/etc.) that never reach a frame slot.
+///
+/// A visited set guards against cyclic struct definitions (defense-in-depth;
+/// the type checker and A026 reject these first).
+fn exact_byte_size(ctx: &TypedContext, kind: &TypeInfoKind) -> u32 {
+    let mut visited = HashSet::new();
+    exact_byte_size_visited(ctx, kind, &mut visited)
+}
+
+fn exact_byte_size_visited(
+    ctx: &TypedContext,
+    kind: &TypeInfoKind,
+    visited: &mut HashSet<String>,
+) -> u32 {
+    match kind {
+        TypeInfoKind::Bool => 1,
+        TypeInfoKind::Number(nt) => match nt {
+            NumberType::I8 | NumberType::U8 => 1,
+            NumberType::I16 | NumberType::U16 => 2,
+            NumberType::I32 | NumberType::U32 => 4,
+            NumberType::I64 | NumberType::U64 => 8,
+        },
+        TypeInfoKind::Enum(_) => 4,
+        TypeInfoKind::Array(elem, length) => {
+            let elem_sz = exact_byte_size_visited(ctx, &elem.kind, visited);
+            elem_sz.saturating_mul(*length)
+        }
+        TypeInfoKind::Struct(name) | TypeInfoKind::Custom(name) => {
+            if !visited.insert(name.clone()) {
+                return 0;
+            }
+            let size = if let Some(struct_info) = ctx.lookup_struct(name) {
+                // Mirror `compute_struct_field_layout`: place each field at its
+                // natural alignment against a running offset, then round the
+                // total up to the struct's maximum field alignment.
+                let mut current: u32 = 0;
+                let mut max_align: u32 = 1;
+                for field in &struct_info.fields {
+                    let a = alignment_of(ctx, &field.type_info.kind, visited);
+                    let field_sz = exact_byte_size_visited(ctx, &field.type_info.kind, visited);
+                    current = align_to(current, a).saturating_add(field_sz);
+                    max_align = max_align.max(a);
+                }
+                align_to(current, max_align)
+            } else if ctx.lookup_enum(name).is_some() {
+                4
+            } else {
+                0
+            };
+            visited.remove(name);
+            size
+        }
+        // String/Unit/Generic/etc. never reach a frame slot in valid programs.
+        _ => 0,
+    }
+}
+
+/// Returns the natural alignment in bytes of a type, mirroring codegen's
+/// `natural_alignment_for_type` / `natural_alignment` (`core/wasm-codegen/src/
+/// memory.rs`). Every supported type aligns within [`MAX_SLOT_PADDING`] + 1
+/// bytes (the `≤ 8` invariant the codegen guard test enforces).
+///
+/// The inner [`NumberType`] match is exhaustive (no wildcard): a future numeric
+/// variant fails compilation here rather than being silently aligned to one,
+/// which would under-approximate slot padding and make A036 unsound. The outer
+/// `_ => 1` arm covers only byte-aligned `Bool`/`i8`/`u8` and genuinely
+/// non-frame `TypeInfoKind` variants (`String`/`Unit`/`Generic`/unresolved
+/// names) that never reach a frame slot.
+///
+/// A visited set guards against cyclic struct definitions (defense-in-depth),
+/// matching the pattern in [`exact_byte_size_visited`].
+fn alignment_of(ctx: &TypedContext, kind: &TypeInfoKind, visited: &mut HashSet<String>) -> u32 {
+    match kind {
+        TypeInfoKind::Number(nt) => match nt {
+            NumberType::I8 | NumberType::U8 => 1,
+            NumberType::I16 | NumberType::U16 => 2,
+            NumberType::I32 | NumberType::U32 => 4,
+            NumberType::I64 | NumberType::U64 => 8,
+        },
+        TypeInfoKind::Enum(_) => 4,
+        TypeInfoKind::Array(elem, _) => alignment_of(ctx, &elem.kind, visited),
+        TypeInfoKind::Struct(name) | TypeInfoKind::Custom(name) => {
+            if !visited.insert(name.clone()) {
+                return 1;
+            }
+            let align = if let Some(struct_info) = ctx.lookup_struct(name) {
+                let mut max_align: u32 = 1;
+                for field in &struct_info.fields {
+                    max_align = max_align.max(alignment_of(ctx, &field.type_info.kind, visited));
+                }
+                max_align
+            } else if ctx.lookup_enum(name).is_some() {
+                4
+            } else {
+                1
+            };
+            visited.remove(name);
+            align
+        }
+        // Bool and i8/u8 are byte-aligned; String/Unit/Generic and unresolved
+        // names never reach a frame slot in valid programs and align to 1.
+        _ => 1,
+    }
+}
+
+/// Rounds `value` up to the next multiple of `alignment` (a power of two).
+fn align_to(value: u32, alignment: u32) -> u32 {
+    value
+        .saturating_add(alignment - 1)
+        & !(alignment - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::call_graph::test_node;
+
+    /// Builds an adjacency list directly (bypassing key resolution) so the
+    /// longest-path tests can use hand-built graphs without arena setup.
+    fn adj(edges: &[&[usize]]) -> Vec<Vec<(usize, Location)>> {
+        edges
+            .iter()
+            .map(|succs| succs.iter().map(|&v| (v, Location::default())).collect())
+            .collect()
+    }
+
+    #[test]
+    fn single_node_path_is_its_own_weight() {
+        let weights = vec![100];
+        let adj = adj(&[&[]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        assert_eq!(bytes, 100);
+        assert_eq!(path, vec![0]);
+    }
+
+    #[test]
+    fn linear_chain_sums_weights_along_path() {
+        // 0 -> 1 -> 2, weights 10 + 20 + 30 = 60.
+        let weights = vec![10, 20, 30];
+        let adj = adj(&[&[1], &[2], &[]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        assert_eq!(bytes, 60);
+        assert_eq!(path, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn branching_takes_the_heavier_child() {
+        // 0 -> {1, 2}; 1 -> 3 (light), 2 -> 4 (heavy).
+        // 0:5, 1:1, 2:1, 3:2, 4:100 => 0->2->4 = 106.
+        let weights = vec![5, 1, 1, 2, 100];
+        let adj = adj(&[&[1, 2], &[3], &[4], &[], &[]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        assert_eq!(bytes, 106);
+        assert_eq!(path, vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn diamond_picks_single_deepest_path_not_double_counting() {
+        // 0 -> {1, 2}; 1 -> 3; 2 -> 3 (shared leaf). Weight must not be summed
+        // across both branches into 3.
+        let weights = vec![10, 20, 30, 40];
+        let adj = adj(&[&[1, 2], &[3], &[3], &[]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        // 0 -> 2 -> 3 = 10 + 30 + 40 = 80 (heavier than 0->1->3 = 70).
+        assert_eq!(bytes, 80);
+        assert_eq!(path, vec![0, 2, 3]);
+    }
+
+    #[test]
+    fn cycle_does_not_hang_or_panic() {
+        // 0 -> 1 -> 2 -> 0 (a cycle A035 would reject). The back edge into the
+        // gray ancestor is skipped, so traversal terminates.
+        let weights = vec![10, 20, 30];
+        let adj = adj(&[&[1], &[2], &[0]]);
+        let result = deepest_path(&adj, &weights);
+        assert!(result.is_some(), "cycle traversal must terminate with a result");
+        let (bytes, _) = result.unwrap();
+        // The deepest acyclic walk visits all three nodes once: 10+20+30 = 60.
+        assert_eq!(bytes, 60);
+    }
+
+    #[test]
+    fn self_loop_is_cycle_safe() {
+        let weights = vec![42];
+        let adj = adj(&[&[0]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        assert_eq!(bytes, 42);
+        assert_eq!(path, vec![0]);
+    }
+
+    #[test]
+    fn under_budget_chain_yields_no_diagnostic() {
+        // Wire weights through resolve_adjacency by exercising check via a tiny
+        // longest-path that stays under budget.
+        let weights = vec![1000, 2000];
+        let adj = adj(&[&[1], &[]]);
+        let (bytes, _) = deepest_path(&adj, &weights).unwrap();
+        assert!(bytes <= STACK_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn over_budget_chain_is_detected() {
+        let weights = vec![40_000, 40_000];
+        let adj = adj(&[&[1], &[]]);
+        let (bytes, path) = deepest_path(&adj, &weights).unwrap();
+        assert!(bytes > STACK_BUDGET_BYTES);
+        assert_eq!(bytes, 80_000);
+        assert_eq!(path, vec![0, 1]);
+    }
+
+    #[test]
+    fn render_chain_joins_with_arrows() {
+        let nodes = vec![test_node("a", &[]), test_node("b", &[]), test_node("c", &[])];
+        assert_eq!(render_chain(&nodes, &[0, 1, 2]), "a -> b -> c");
+        assert_eq!(render_chain(&nodes, &[1]), "b");
+    }
+
+    #[test]
+    fn align_to_rounds_up_to_frame_boundary() {
+        assert_eq!(align_to(0, FRAME_ALIGNMENT), 0);
+        assert_eq!(align_to(1, FRAME_ALIGNMENT), 16);
+        assert_eq!(align_to(16, FRAME_ALIGNMENT), 16);
+        assert_eq!(align_to(17, FRAME_ALIGNMENT), 32);
+    }
+
+    /// Builds a `TypedContext` with the given structs registered, mirroring the
+    /// `register_test_struct` pattern used by `core/wasm-codegen` unit tests.
+    fn ctx_with_structs(structs: &[(&str, &[(&str, TypeInfoKind)])]) -> TypedContext {
+        use inference_ast::nodes::Visibility;
+        let mut ctx = TypedContext::default();
+        for (name, fields) in structs {
+            let field_specs: Vec<_> = fields
+                .iter()
+                .map(|(fname, kind)| {
+                    (
+                        (*fname).to_string(),
+                        TypeInfo {
+                            kind: kind.clone(),
+                            type_params: vec![],
+                        },
+                        Visibility::Public,
+                    )
+                })
+                .collect();
+            ctx.register_test_struct(name, &field_specs).unwrap();
+        }
+        ctx
+    }
+
+    fn num(n: NumberType) -> TypeInfoKind {
+        TypeInfoKind::Number(n)
+    }
+
+    /// `{ i8, i64, i8, i16 }`: i8@0, i64@8, i8@16, i16@18..20, rounded to the
+    /// max field alignment (8) = 24. Mirrors codegen's `compute_struct_field_layout`.
+    #[test]
+    fn exact_byte_size_struct_mixed_alignment_is_24() {
+        let ctx = ctx_with_structs(&[(
+            "S",
+            &[
+                ("a", num(NumberType::I8)),
+                ("b", num(NumberType::I64)),
+                ("c", num(NumberType::I8)),
+                ("d", num(NumberType::I16)),
+            ],
+        )]);
+        assert_eq!(
+            exact_byte_size(&ctx, &TypeInfoKind::Struct("S".to_string())),
+            24
+        );
+    }
+
+    /// A packed two-byte struct `{ i8, i8 }` has size 2 (align 1, no padding).
+    /// An array of 8000 such structs is `2 * 8000 = 16000` bytes exactly — the
+    /// over-approximation bug previously multiplied per-field padding by 8000.
+    #[test]
+    fn exact_byte_size_array_of_structs_is_not_inflated() {
+        let ctx = ctx_with_structs(&[("P", &[("a", num(NumberType::I8)), ("b", num(NumberType::I8))])]);
+        let elem = TypeInfo {
+            kind: TypeInfoKind::Struct("P".to_string()),
+            type_params: vec![],
+        };
+        assert_eq!(
+            exact_byte_size(&ctx, &TypeInfoKind::Struct("P".to_string())),
+            2,
+            "{{ i8, i8 }} packs to 2 bytes"
+        );
+        assert_eq!(
+            exact_byte_size(&ctx, &TypeInfoKind::Array(Box::new(elem), 8000)),
+            16_000,
+            "[{{ i8, i8 }}; 8000] is exactly 2 * 8000, not per-field inflated"
+        );
+    }
+
+    /// One level of struct nesting mirrors codegen: `Inner { i32, i32 }` = 8,
+    /// `Outer { Inner, i32 }` = 12.
+    #[test]
+    fn exact_byte_size_nested_struct() {
+        let ctx = ctx_with_structs(&[
+            ("Inner", &[("x", num(NumberType::I32)), ("y", num(NumberType::I32))]),
+            (
+                "Outer",
+                &[
+                    ("inner", TypeInfoKind::Struct("Inner".to_string())),
+                    ("val", num(NumberType::I32)),
+                ],
+            ),
+        ]);
+        assert_eq!(
+            exact_byte_size(&ctx, &TypeInfoKind::Struct("Inner".to_string())),
+            8
+        );
+        assert_eq!(
+            exact_byte_size(&ctx, &TypeInfoKind::Struct("Outer".to_string())),
+            12
+        );
+    }
+
+    /// `alignment_of` mirrors codegen's `natural_alignment`: a struct's alignment
+    /// is its widest field's alignment, an array's is its element's.
+    #[test]
+    fn alignment_of_mirrors_codegen() {
+        let ctx = ctx_with_structs(&[(
+            "S",
+            &[("a", num(NumberType::I8)), ("b", num(NumberType::I64))],
+        )]);
+        let mut v = HashSet::new();
+        assert_eq!(alignment_of(&ctx, &num(NumberType::I8), &mut v), 1);
+        assert_eq!(alignment_of(&ctx, &num(NumberType::I16), &mut v), 2);
+        assert_eq!(alignment_of(&ctx, &num(NumberType::I32), &mut v), 4);
+        assert_eq!(alignment_of(&ctx, &num(NumberType::I64), &mut v), 8);
+        assert_eq!(
+            alignment_of(&ctx, &TypeInfoKind::Struct("S".to_string()), &mut v),
+            8,
+            "struct alignment = widest field (i64) = 8"
+        );
+        let arr = TypeInfoKind::Array(
+            Box::new(TypeInfo {
+                kind: num(NumberType::I16),
+                type_params: vec![],
+            }),
+            10,
+        );
+        assert_eq!(
+            alignment_of(&ctx, &arr, &mut v),
+            2,
+            "array alignment = element alignment (i16) = 2"
+        );
+    }
+}

--- a/core/wasm-codegen/src/compiler.rs
+++ b/core/wasm-codegen/src/compiler.rs
@@ -97,6 +97,11 @@ pub(crate) enum FunctionOrigin {
     SpecInner(String),
 }
 
+/// The triple yielded by [`Compiler::finish_and_take`]: the assembled WASM
+/// binary, the per-spec function indices, and the per-function shadow-stack
+/// frame sizes (canonical [`FnKey`] string → bytes).
+type FinishedModule = (Vec<u8>, FxHashMap<String, Vec<u32>>, FxHashMap<String, u32>);
+
 /// Structured key for `func_name_to_idx`, `func_array_returns`, and
 /// `func_struct_returns` values.
 ///
@@ -401,6 +406,13 @@ pub(crate) struct Compiler {
     /// can emit per-spec `Definition <mod>__<SpecName>_specs : list N`
     /// definitions.
     spec_func_indices_by_spec: FxHashMap<String, Vec<u32>>,
+    /// Real shadow-stack frame size in bytes for each function, keyed by its
+    /// canonical [`FnKey`] display string. Recorded in
+    /// [`Self::visit_function_definition`] right after the frame layout is
+    /// computed; frameless functions record 0. Moved out by
+    /// [`Self::finish_and_take`] so the analysis↔codegen frame-size soundness
+    /// invariant (A036's estimate ≥ this) can be checked cross-crate.
+    frame_sizes: FxHashMap<String, u32>,
 }
 
 impl Compiler {
@@ -430,6 +442,7 @@ impl Compiler {
             parent_blocks_stack: Vec::new(),
             init_zero_elision: false,
             spec_func_indices_by_spec: FxHashMap::default(),
+            frame_sizes: FxHashMap::default(),
         }
     }
 
@@ -873,6 +886,18 @@ impl Compiler {
 
         self.frame_layout =
             Self::compute_frame_layout(arena, body_id, ctx, local_idx, &args, method_struct_name)?;
+
+        // Record the real frame size (0 for frameless functions) keyed by the
+        // canonical FnKey so A036's estimate can be checked against it. The key
+        // was set above and is always present here.
+        let frame_size = self.frame_layout.as_ref().map_or(0, |l| l.total_size);
+        self.frame_sizes.insert(
+            self.current_fn_key
+                .as_ref()
+                .expect("current_fn_key is set at the top of visit_function_definition")
+                .to_string(),
+            frame_size,
+        );
 
         if self.frame_layout.is_some() {
             self.has_memory = true;
@@ -3896,13 +3921,16 @@ impl Compiler {
     }
 
     /// Assembles the complete WASM binary from accumulated sections AND
-    /// returns the recorded spec function indices alongside it.
+    /// returns the recorded spec function indices and per-function frame sizes
+    /// alongside it.
     ///
-    /// Consumes `self` so the recorded spec map is moved out exactly once;
-    /// there is no separate drain step and no flag to track. The custom
+    /// Consumes `self` so the recorded maps are moved out exactly once; there is
+    /// no separate drain step and no flag to track. The custom
     /// `inference.spec_funcs` section is emitted from `self.spec_func_indices_by_spec`
-    /// before the move.
-    pub(crate) fn finish_and_take(self) -> (Vec<u8>, FxHashMap<String, Vec<u32>>) {
+    /// before the move. The `frame_sizes` map (canonical [`FnKey`] string →
+    /// real shadow-stack frame bytes) is surfaced for the cross-crate A036
+    /// frame-size soundness check.
+    pub(crate) fn finish_and_take(self) -> FinishedModule {
         let mut module = Module::new();
 
         let mut type_section = TypeSection::new();
@@ -3995,7 +4023,11 @@ impl Compiler {
             module.section(&spec_section);
         }
 
-        (module.finish(), self.spec_func_indices_by_spec)
+        (
+            module.finish(),
+            self.spec_func_indices_by_spec,
+            self.frame_sizes,
+        )
     }
 }
 
@@ -4043,7 +4075,7 @@ mod tests {
     #[test]
     fn finish_without_memory_omits_memory_section() {
         let compiler = Compiler::new("test");
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         assert!(!wasm.is_empty());
         assert!(!has_memory_section(&wasm));
     }
@@ -4053,7 +4085,7 @@ mod tests {
         cov_mark::check!(wasm_codegen_emit_memory_section);
         let mut compiler = Compiler::new("test");
         compiler.enable_memory();
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         assert!(has_memory_section(&wasm));
     }
 
@@ -4061,7 +4093,7 @@ mod tests {
     fn finish_with_memory_validates_via_wasmparser() {
         let mut compiler = Compiler::new("test");
         compiler.enable_memory();
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         inf_wasmparser::validate(&wasm)
             .unwrap_or_else(|e| panic!("Generated WASM with memory is invalid: {e}"));
     }
@@ -4070,7 +4102,7 @@ mod tests {
     fn finish_with_memory_exports_memory_and_stack_pointer() {
         let mut compiler = Compiler::new("test");
         compiler.enable_memory();
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         let wat =
             wasmprinter::print_bytes(&wasm).unwrap_or_else(|e| panic!("Failed to print WAT: {e}"));
         assert!(
@@ -4087,7 +4119,7 @@ mod tests {
     fn finish_with_memory_has_correct_stack_pointer_init() {
         let mut compiler = Compiler::new("test");
         compiler.enable_memory();
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         let wat =
             wasmprinter::print_bytes(&wasm).unwrap_or_else(|e| panic!("Failed to print WAT: {e}"));
         assert!(
@@ -4100,7 +4132,7 @@ mod tests {
     fn finish_with_memory_has_mutable_global() {
         let mut compiler = Compiler::new("test");
         compiler.enable_memory();
-        let (wasm, _spec_map) = compiler.finish_and_take();
+        let (wasm, _spec_map, _frame_sizes) = compiler.finish_and_take();
         let wat =
             wasmprinter::print_bytes(&wasm).unwrap_or_else(|e| panic!("Failed to print WAT: {e}"));
         assert!(

--- a/core/wasm-codegen/src/lib.rs
+++ b/core/wasm-codegen/src/lib.rs
@@ -139,7 +139,7 @@ pub fn codegen(
     // the section is emitted in a single pass that moves out the recorded
     // spec map alongside the WASM bytes.
     let has_main = compiler.has_main();
-    let (wasm, spec_func_indices_by_spec) = compiler.finish_and_take();
+    let (wasm, spec_func_indices_by_spec, frame_sizes) = compiler.finish_and_take();
     debug_assert!(
         mode != CompilationMode::Compile || spec_func_indices_by_spec.is_empty(),
         "compile mode must not record any spec function indices"
@@ -153,7 +153,8 @@ pub fn codegen(
         module_name.to_string(),
         has_main,
         spec_func_indices_by_spec,
-    ))
+    )
+    .with_frame_sizes(frame_sizes))
 }
 
 /// Traverses the typed AST and compiles all function and method definitions.

--- a/core/wasm-codegen/src/memory.rs
+++ b/core/wasm-codegen/src/memory.rs
@@ -300,6 +300,15 @@ pub(crate) struct FrameLayout {
 /// Returns the byte size of a single element for the given type.
 ///
 /// Used by `compute_frame_layout` and store/load instruction selection.
+///
+/// # Cross-crate invariant
+///
+/// Every supported type's natural alignment is at most 8 bytes. The analysis
+/// crate's A036 (`inference-analysis`, `rules::stack_depth::MAX_SLOT_PADDING`)
+/// relies on this to bound per-slot frame padding at 7 bytes; a wider type
+/// (e.g. i128/v128) would break that soundness invariant. Adding one here must
+/// also update `MAX_SLOT_PADDING` and the guard test
+/// `every_supported_type_aligns_within_max_slot_padding` in this module.
 #[must_use = "returns element size in bytes"]
 pub(crate) fn element_size(kind: &TypeInfoKind) -> u32 {
     match kind {
@@ -366,6 +375,14 @@ fn type_byte_size_with_visited(
 ///
 /// A visited set guards against cycles as defense-in-depth, matching the
 /// pattern used in [`type_byte_size`] and [`compute_struct_field_layout`].
+///
+/// # Cross-crate invariant
+///
+/// The result is at most 8 bytes for every supported type. A036 in
+/// `inference-analysis` (`rules::stack_depth::MAX_SLOT_PADDING`) depends on this
+/// bound; a type aligned wider than 8 would make A036 under-approximate codegen
+/// frames and become unsound. The guard test
+/// `every_supported_type_aligns_within_max_slot_padding` enforces it here.
 pub(crate) fn natural_alignment_for_type(
     kind: &TypeInfoKind,
     ctx: &TypedContext,
@@ -1527,6 +1544,93 @@ mod tests {
             8,
             "Mixed {{ a: bool, b: i64 }} alignment = max(1, 8) = 8"
         );
+    }
+
+    /// Soundness guard for `inference-analysis`'s A036
+    /// (`rules::stack_depth::MAX_SLOT_PADDING = 7`): every supported type must
+    /// align within 8 bytes, so codegen never inserts more than 7 padding bytes
+    /// per slot. If a wider-aligned type (i128/f128/v128/SIMD) is ever added,
+    /// this test fails — and `MAX_SLOT_PADDING` must be revisited before A036
+    /// silently under-approximates a real frame.
+    ///
+    /// The `NumberType` coverage is a non-wildcard `match`: adding a variant
+    /// breaks compilation here, forcing the new type through this check.
+    #[test]
+    fn every_supported_type_aligns_within_max_slot_padding() {
+        /// Maximum natural alignment A036 assumes for any single slot.
+        const MAX_ALIGN: u32 = 8;
+
+        let mut ctx = TypedContext::default();
+        ctx.register_test_enum("Color", &["Red", "Green", "Blue"])
+            .unwrap();
+        ctx.register_test_struct(
+            "Wide",
+            &[
+                (
+                    "a".to_string(),
+                    TypeInfo {
+                        kind: TypeInfoKind::Bool,
+                        type_params: vec![],
+                    },
+                    Visibility::Public,
+                ),
+                (
+                    "b".to_string(),
+                    TypeInfo {
+                        kind: TypeInfoKind::Number(NumberType::I64),
+                        type_params: vec![],
+                    },
+                    Visibility::Public,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let assert_within = |kind: &TypeInfoKind| {
+            let align = natural_alignment_for_type(kind, &ctx)
+                .unwrap_or_else(|e| panic!("alignment lookup failed for {kind:?}: {e:?}"));
+            assert!(
+                align <= MAX_ALIGN,
+                "{kind:?} aligns to {align} bytes, exceeding MAX_SLOT_PADDING's {MAX_ALIGN}-byte assumption",
+            );
+        };
+
+        assert_within(&TypeInfoKind::Bool);
+
+        // Exhaustive over NumberType: a new variant makes this `match`
+        // non-exhaustive and forces the type through the alignment guard.
+        for nt in NumberType::ALL {
+            match nt {
+                NumberType::I8
+                | NumberType::I16
+                | NumberType::I32
+                | NumberType::I64
+                | NumberType::U8
+                | NumberType::U16
+                | NumberType::U32
+                | NumberType::U64 => {
+                    let kind = TypeInfoKind::Number(*nt);
+                    assert!(
+                        element_size(&kind) <= MAX_ALIGN,
+                        "{kind:?} has element size exceeding {MAX_ALIGN} bytes",
+                    );
+                    assert_within(&kind);
+                }
+            }
+        }
+
+        assert_within(&TypeInfoKind::Enum("Color".to_string()));
+
+        let array_of_i64 = TypeInfoKind::Array(
+            Box::new(TypeInfo {
+                kind: TypeInfoKind::Number(NumberType::I64),
+                type_params: vec![],
+            }),
+            4,
+        );
+        assert_within(&array_of_i64);
+
+        assert_within(&TypeInfoKind::Struct("Wide".to_string()));
     }
 
     #[test]

--- a/core/wasm-codegen/src/output.rs
+++ b/core/wasm-codegen/src/output.rs
@@ -85,6 +85,13 @@ pub struct CodegenOutput {
     /// per-spec `Definition <mod>__<SpecName>_specs : list N` lists consumed
     /// by the corresponding `ValidModule` theorems.
     spec_func_indices_by_spec: FxHashMap<String, Vec<u32>>,
+
+    /// Per-function shadow-stack frame sizes in bytes, keyed by canonical
+    /// function name (matching `FnKey`/analysis key scheme).
+    ///
+    /// Exposed for testing and diagnostics; empty unless populated by the
+    /// codegen entry point.
+    frame_sizes: FxHashMap<String, u32>,
 }
 
 impl CodegenOutput {
@@ -107,7 +114,29 @@ impl CodegenOutput {
             module_name,
             has_main,
             spec_func_indices_by_spec,
+            frame_sizes: FxHashMap::default(),
         }
+    }
+
+    /// Attaches per-function shadow-stack frame sizes to this output.
+    ///
+    /// Builder-style setter so the public [`Self::new`] signature stays
+    /// non-breaking. The map is keyed by canonical function name (matching the
+    /// `FnKey`/analysis key scheme) with the value in bytes.
+    #[must_use]
+    pub fn with_frame_sizes(mut self, frame_sizes: FxHashMap<String, u32>) -> Self {
+        self.frame_sizes = frame_sizes;
+        self
+    }
+
+    /// Returns the per-function shadow-stack frame sizes in bytes, keyed by
+    /// canonical function name (matching the `FnKey`/analysis key scheme).
+    ///
+    /// Exposed for testing and diagnostics; empty unless populated by the
+    /// codegen entry point.
+    #[must_use]
+    pub fn frame_sizes(&self) -> &FxHashMap<String, u32> {
+        &self.frame_sizes
     }
 
     /// Returns the WASM function indices for functions originating in `spec`

--- a/tests/src/analysis/mod.rs
+++ b/tests/src/analysis/mod.rs
@@ -11,4 +11,5 @@ mod rules_a032;
 mod rules_a033;
 mod rules_a034;
 mod rules_a035;
+mod rules_a036;
 mod walker_tests;

--- a/tests/src/analysis/rules_a036.rs
+++ b/tests/src/analysis/rules_a036.rs
@@ -1,0 +1,639 @@
+/// Integration tests for analysis rule A036.
+///
+/// - A036: StackDepthExceeded — the cumulative shadow-stack usage along a
+///   root-to-leaf call chain must not exceed the stack budget
+///   (`STACK_BUDGET_BYTES = 65_536`). Only array/struct frames consume the
+///   shadow stack; scalars live in WASM locals. Because A035 forbids recursion
+///   the call graph is a DAG, so A036 reports the maximum-weight call chain.
+///
+/// These tests are the cross-crate guard for two properties that the rule's
+/// in-crate unit tests cannot exercise: (1) the rule fires through a real
+/// parse -> type-check -> analyze pipeline on Inference source, and (2) the
+/// rule closes a gap that codegen alone leaves open — codegen bounds each
+/// *individual* frame but not the *cumulative* depth across a chain.
+#[cfg(test)]
+mod analysis_rules_tests {
+    use crate::utils::{build_ast, codegen_output_no_analysis};
+    use inference_analysis::errors::{AnalysisDiagnostic, AnalysisErrors, AnalysisResult};
+    use inference_type_checker::typed_context::TypedContext;
+
+    fn type_check(source: &str) -> TypedContext {
+        let arena = build_ast(source.to_string());
+        inference_type_checker::TypeCheckerBuilder::build_typed_context(arena)
+            .expect("type checking should succeed for analysis test input")
+            .typed_context()
+    }
+
+    fn analyze(source: &str) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = type_check(source);
+        inference_analysis::analyze(&ctx)
+    }
+
+    /// Returns true if any analysis error is a `StackDepthExceeded` (A036).
+    /// Filters by variant rather than asserting a total error count, since the
+    /// surface may also trip unrelated rules.
+    fn has_stack_depth_exceeded(source: &str) -> bool {
+        match analyze(source) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::StackDepthExceeded { .. })),
+        }
+    }
+
+    fn stack_depth_diag(source: &str) -> AnalysisDiagnostic {
+        analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .find(|e| matches!(e, AnalysisDiagnostic::StackDepthExceeded { .. }))
+            .expect("expected a StackDepthExceeded diagnostic")
+            .clone()
+    }
+
+    /// A chain `a -> b -> c` where each frame (~24 KB for `[i32; 6000]`) is well
+    /// under the 64 KB budget but their sum (~72 KB) exceeds it. The arrays are
+    /// initialized via uzumaki inside a `forall` block so they count as compound
+    /// locals without needing a 6000-element literal (which would also trip A025
+    /// if left uninitialized).
+    #[test]
+    fn a036_over_budget_chain_rejected() {
+        let source = r#"
+            fn a() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return b();
+            }
+            fn b() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return c();
+            }
+            fn c() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return 0;
+            }
+        "#;
+        assert!(
+            has_stack_depth_exceeded(source),
+            "expected StackDepthExceeded for the cumulative chain a -> b -> c"
+        );
+    }
+
+    #[test]
+    fn a036_over_budget_chain_names_the_chain() {
+        let source = r#"
+            fn a() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return b();
+            }
+            fn b() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return c();
+            }
+            fn c() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return 0;
+            }
+        "#;
+        let diag = stack_depth_diag(source);
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("a -> b -> c"),
+            "diagnostic should name the chain `a -> b -> c`, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A036");
+    }
+
+    /// Same call shape as the over-budget chain but with tiny arrays
+    /// (`[i32; 16]` ~ 64 bytes/frame), so the cumulative depth stays far below
+    /// the budget and A036 must not fire.
+    #[test]
+    fn a036_under_budget_chain_accepted() {
+        let source = r#"
+            fn a() -> i32 {
+                forall {
+                    let arr: [i32; 16] = @;
+                    let x: i32 = arr[0];
+                }
+                return b();
+            }
+            fn b() -> i32 {
+                forall {
+                    let arr: [i32; 16] = @;
+                    let x: i32 = arr[0];
+                }
+                return c();
+            }
+            fn c() -> i32 {
+                forall {
+                    let arr: [i32; 16] = @;
+                    let x: i32 = arr[0];
+                }
+                return 0;
+            }
+        "#;
+        assert!(
+            !has_stack_depth_exceeded(source),
+            "small-array call chain must not trip A036"
+        );
+    }
+
+    /// A single function whose lone array local (`[i32; 20000]` ~ 80 KB) exceeds
+    /// the budget on its own. The point is that A036 catches this at analysis
+    /// time rather than letting codegen emit a frame that traps at runtime.
+    #[test]
+    fn a036_single_oversized_frame_rejected() {
+        let source = r#"
+            fn big() -> i32 {
+                forall {
+                    let arr: [i32; 20000] = @;
+                    let x: i32 = arr[0];
+                }
+                return 0;
+            }
+        "#;
+        assert!(
+            has_stack_depth_exceeded(source),
+            "single oversized frame must trip A036 at analysis time"
+        );
+    }
+
+    /// A recursive (cyclic) program with array frames. A036's traversal must be
+    /// cycle-safe: it must terminate (no hang) and not panic, while A035 owns the
+    /// recursion diagnostic. Arrays are kept small — the point is cycle safety,
+    /// not budget overflow.
+    #[test]
+    fn a036_recursive_program_is_cycle_safe_and_a035_owns_recursion() {
+        let source = r#"
+            fn a() -> i32 {
+                forall {
+                    let arr: [i32; 8] = @;
+                    let x: i32 = arr[0];
+                }
+                return b();
+            }
+            fn b() -> i32 {
+                forall {
+                    let arr: [i32; 8] = @;
+                    let x: i32 = arr[0];
+                }
+                return a();
+            }
+        "#;
+        let result = analyze(source);
+        let errors = result.expect_err("expected analysis errors for the recursive program");
+        let has_recursion = errors
+            .errors()
+            .iter()
+            .any(|e| matches!(e, AnalysisDiagnostic::RecursionDetected { .. }));
+        assert!(
+            has_recursion,
+            "recursion must be reported by A035 (RecursionDetected)"
+        );
+    }
+
+    /// Behavioral parity test — the gap A036 closes.
+    ///
+    /// Each individual frame here (~24 KB for `[i32; 6000]`) is under the 64 KB
+    /// budget, so codegen's per-frame bound is satisfied and `codegen` (run with
+    /// analysis SKIPPED) succeeds — proving codegen alone does NOT catch the
+    /// cumulative overflow. Running the analysis pass on the same source yields
+    /// an A036 error, proving the rule closes that gap.
+    ///
+    /// Exact numeric per-function parity against codegen's private
+    /// `FrameLayout.total_size` is validated by-construction rather than
+    /// asserted here: that field is not exposed across crates, and the
+    /// estimator's documented soundness argument (it charges worst-case padding,
+    /// `size + 7` per slot rounded up to 16, so its per-function estimate is
+    /// always >= codegen's real layout) is what guarantees A036 never
+    /// under-approximates. This cross-crate behavioral test is the guard that the
+    /// over-approximation is still tight enough to flag a real cumulative
+    /// overflow that codegen would have emitted as a runtime trap.
+    #[test]
+    fn a036_closes_gap_codegen_leaves_open() {
+        let source = r#"
+            fn a() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return b();
+            }
+            fn b() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return c();
+            }
+            fn c() -> i32 {
+                forall {
+                    let arr: [i32; 6000] = @;
+                    let x: i32 = arr[0];
+                }
+                return 0;
+            }
+        "#;
+        let _output = codegen_output_no_analysis(source);
+
+        assert!(
+            has_stack_depth_exceeded(source),
+            "A036 must reject the cumulative overflow that codegen alone accepts"
+        );
+    }
+
+    // --- Part A: compound-type frame coverage ---------------------------------
+    //
+    // The tests above exercise only flat `[i32; N]` arrays. A036's per-function
+    // frame estimate must also be sound for structs, mixed-alignment fields,
+    // nested structs, arrays of structs, and a mutable `self` slot — the shapes
+    // where the estimate's padding/alignment model could diverge from codegen's
+    // real `FrameLayout`. The fixtures below drive each shape over (or, where a
+    // property is the point, deliberately under) the 64 KB budget. Sizes are
+    // chosen with comfortable margin from the budget; the exact estimate/real
+    // numbers are pinned by the cross-crate parity test in Part B.
+
+    /// A struct with two large scalar-array fields, one struct local per
+    /// function, chained `p -> q`. Each frame (~56 KB) is under budget alone but
+    /// their sum (~112 KB) exceeds it. Guards that a struct binding contributes a
+    /// frame slot sized by the sum of its fields.
+    #[test]
+    fn a036_struct_local_over_budget_chain_rejected() {
+        let source = r#"
+            struct Blk { a: [i32; 7000]; b: [i32; 7000]; }
+            fn p() -> i32 {
+                forall { let x: Blk = @; }
+                return q();
+            }
+            fn q() -> i32 {
+                forall { let x: Blk = @; }
+                return 0;
+            }
+        "#;
+        assert!(
+            has_stack_depth_exceeded(source),
+            "struct-local chain p -> q must trip A036"
+        );
+    }
+
+    /// A struct with interleaved small/large fields (`i8, i64, i8, i16` ahead of
+    /// a large array). The per-field padding model must charge enough that the
+    /// estimate stays >= codegen's aligned layout; a chain `p -> q` pushes the
+    /// cumulative depth over budget. Guards the mixed-alignment field path.
+    #[test]
+    fn a036_mixed_alignment_struct_over_budget_chain_rejected() {
+        let source = r#"
+            struct M { a: i8; b: i64; c: i8; d: i16; pad: [i32; 9000]; }
+            fn p() -> i32 {
+                forall { let x: M = @; }
+                return q();
+            }
+            fn q() -> i32 {
+                forall { let x: M = @; }
+                return 0;
+            }
+        "#;
+        assert!(
+            has_stack_depth_exceeded(source),
+            "mixed-alignment struct chain p -> q must trip A036"
+        );
+    }
+
+    /// One level of struct nesting (A026's limit): `Outer { inner: Inner; .. }`
+    /// where `Inner` holds a large scalar array. `Inner` is built via uzumaki (a
+    /// scalar-array struct, allowed by A027), then wrapped in an `Outer` literal
+    /// in the same block; both the `Inner` and `Outer` bindings get frame slots.
+    /// The chain `p -> q` exceeds budget. Guards the nested-struct size walk.
+    #[test]
+    fn a036_nested_struct_over_budget_chain_rejected() {
+        let source = r#"
+            struct Inner { big: [i32; 4500]; }
+            struct Outer { inner: Inner; tag: i32; }
+            fn p() -> i32 {
+                forall {
+                    let i: Inner = @;
+                    let o: Outer = Outer { inner: i, tag: 1 };
+                    let t: i32 = o.tag;
+                }
+                return q();
+            }
+            fn q() -> i32 {
+                forall {
+                    let i: Inner = @;
+                    let o: Outer = Outer { inner: i, tag: 1 };
+                    let t: i32 = o.tag;
+                }
+                return 0;
+            }
+        "#;
+        assert!(
+            has_stack_depth_exceeded(source),
+            "nested-struct chain p -> q must trip A036"
+        );
+    }
+
+    /// Array-of-structs frame slot. The over-budget direction is unreachable
+    /// through a valid program: a `[S; N]` local can only be initialized by a
+    /// struct-element array *literal* (uzumaki on an array of structs is rejected
+    /// by A028, and codegen's `element_size` panics on a struct element via the
+    /// uzumaki fill path), and a literal large enough to cross 64 KB is not
+    /// practical. This test therefore covers the *sizing* of an array-of-structs
+    /// slot with a small literal and asserts A036 stays silent under budget; the
+    /// estimate >= real soundness for this shape is pinned by Part B's corpus.
+    #[test]
+    fn a036_array_of_structs_local_under_budget_accepted() {
+        let source = r#"
+            struct Pt { x: i32; y: i32; }
+            fn aos() -> i32 {
+                let a: [Pt; 3] = [Pt { x: 1, y: 2 }, Pt { x: 3, y: 4 }, Pt { x: 5, y: 6 }];
+                return a[0].x;
+            }
+        "#;
+        assert!(
+            !has_stack_depth_exceeded(source),
+            "small array-of-structs literal must not trip A036"
+        );
+    }
+
+    /// Builds a `[Pt; n]` array literal of `Pt { x: i, y: i }` elements as a
+    /// single source line. Array-of-structs locals have no repeat syntax and
+    /// uzumaki on an array of structs is rejected by A028, so a large
+    /// array-of-structs frame must be written as an explicit literal of `n`
+    /// struct literals (mirroring how `stack_overflow_traps_at_runtime` in
+    /// `codegen::wasm::base` generates large literals via `format!`).
+    fn array_of_pt_literal(n: usize) -> String {
+        let elems = (0..n)
+            .map(|i| format!("Pt {{ x: {i}, y: {i} }}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{elems}]")
+    }
+
+    /// Genuine over-budget array-of-structs call chain. Each function holds a
+    /// `[Pt; 5000]` literal local: `Pt { x: i32; y: i32; }` is 8 bytes, so the
+    /// real frame is `8 * 5000 = 40000` bytes (< 64 KB, so codegen accepts each
+    /// frame), and the estimate is `align_to(40000 + 7, 16) = 40016`. `p` calls
+    /// `q`, so the chain estimate `40016 + 40016 = 80032` exceeds the 64 KB
+    /// budget and A036 must fire and name `p -> q`. This is the AoS analogue of
+    /// `a036_struct_local_over_budget_chain_rejected`.
+    #[test]
+    fn a036_array_of_structs_over_budget_chain_rejected() {
+        let lit = array_of_pt_literal(5000);
+        let source = format!(
+            r#"
+            struct Pt {{ x: i32; y: i32; }}
+            fn p() -> i32 {{
+                let a: [Pt; 5000] = {lit};
+                return q() + a[0].x;
+            }}
+            fn q() -> i32 {{
+                let b: [Pt; 5000] = {lit};
+                return b[0].y;
+            }}
+            "#
+        );
+        let diag = stack_depth_diag(&source);
+        let msg = diag.to_string();
+        assert!(
+            has_stack_depth_exceeded(&source),
+            "array-of-structs chain p -> q (~40 KB each) must trip A036"
+        );
+        assert_eq!(diag.rule_id(), "A036");
+        assert!(
+            msg.contains("p -> q"),
+            "diagnostic should name the chain `p -> q`, got: {msg}"
+        );
+    }
+
+    /// Regression guard — before the estimator fix, A036 over-approximated
+    /// array-of-structs ~3x and would have falsely rejected this valid ~24 KB
+    /// frame. A single function holds a `[Pt; 3000]` literal local:
+    /// `Pt { x: i32; y: i32; }` is 8 bytes, so the real frame is
+    /// `8 * 3000 = 24000` bytes and the (fixed) estimate is
+    /// `align_to(24000 + 7, 16) = 24016` — both comfortably under the 64 KB
+    /// budget, and the function is not chained, so A036 must stay silent. The
+    /// old estimator inflated each element by `+7` per field before multiplying
+    /// by the length (`(4 + 7) + (4 + 7) = 22` bytes/element, `22 * 3000 =
+    /// 66000`, or ~3x the real 24000 = ~72000), either of which crosses 65536
+    /// and would have falsely fired here.
+    #[test]
+    fn a036_large_array_of_structs_that_fits_is_accepted() {
+        let lit = array_of_pt_literal(3000);
+        let source = format!(
+            r#"
+            struct Pt {{ x: i32; y: i32; }}
+            fn fits() -> i32 {{
+                let a: [Pt; 3000] = {lit};
+                return a[1].x + a[2999].y;
+            }}
+            "#
+        );
+        assert!(
+            !has_stack_depth_exceeded(&source),
+            "a valid ~24 KB array-of-structs frame must not trip A036 (regression guard)"
+        );
+    }
+
+    /// A `mut self` method allocates a frame slot for the (by-value) `self` copy.
+    /// `caller` (a large array frame) calls `C.bump` (a large array frame); the
+    /// chain `caller -> C.bump` exceeds budget. This is the only path that
+    /// exercises the mutable-self frame slot, and the diagnostic must name the
+    /// method by its canonical key `C.bump`.
+    #[test]
+    fn a036_mutable_self_method_over_budget_chain_rejected() {
+        let source = r#"
+            struct C { a: i32;
+                fn bump(mut self) -> i32 {
+                    forall { let b: [i32; 10000] = @; let t: i32 = b[0]; }
+                    return 0;
+                }
+            }
+            fn caller() -> i32 {
+                forall { let d: [i32; 10000] = @; let t: i32 = d[0]; }
+                let c: C = C { a: 1 };
+                return c.bump();
+            }
+        "#;
+        let diag = stack_depth_diag(source);
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("caller -> C.bump"),
+            "diagnostic should name the chain `caller -> C.bump`, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A036");
+    }
+
+    /// `if`/`else` branches must be *maxed*, not *summed*. Each branch declares a
+    /// `[i32; 9000]` array (~36 KB). Summing the two branches (~72 KB) would
+    /// exceed the 64 KB budget; taking the per-branch maximum (~36 KB) stays
+    /// under it. The function has no callees, so its whole frame is the branch
+    /// contribution. A036 must therefore stay silent — proving the estimator
+    /// (and codegen) reuse the offset across arms rather than summing them.
+    #[test]
+    fn a036_if_else_branches_are_maxed_not_summed_accepted() {
+        let source = r#"
+            fn branchy(n: i32) -> i32 {
+                if n > 0 {
+                    forall { let x: [i32; 9000] = @; let tx: i32 = x[0]; }
+                } else {
+                    forall { let y: [i32; 9000] = @; let ty: i32 = y[0]; }
+                }
+                return 0;
+            }
+        "#;
+        assert!(
+            !has_stack_depth_exceeded(source),
+            "if/else branches must be maxed not summed: max(branch) is under budget"
+        );
+    }
+
+    // --- Part B: cross-crate frame-size parity --------------------------------
+
+    /// Enforced cross-crate soundness guard for A036.
+    ///
+    /// A036 may *over*-approximate codegen's real per-function frame (it charges
+    /// worst-case 7-byte padding per slot and rounds up to 16), but it must never
+    /// *under*-approximate: if the analysis estimate were below codegen's real
+    /// `FrameLayout.total_size` for any function, A036 could accept a program
+    /// that codegen lays out larger and overflows the shadow stack at runtime.
+    ///
+    /// This test replaces the prior "sound by construction" prose claim with a
+    /// machine-checked invariant. For a corpus spanning every frame-bearing
+    /// shape — flat arrays, a plain struct, a mixed-alignment struct, a nested
+    /// struct, an array of structs (literal init), and a `mut self` method — it
+    /// asserts `estimate[key] >= real[key]` for every function codegen emits a
+    /// frame for. The corpus is built with analysis skipped so over-budget
+    /// sources still produce a `CodegenOutput` whose real frame sizes are
+    /// readable. A non-vacuity check asserts the corpus exercises at least one
+    /// non-zero real frame.
+    ///
+    /// If this test ever fails with `est < real`, that is a real A036 soundness
+    /// bug — fix the estimator, do not weaken the assertion.
+    #[test]
+    fn a036_estimate_is_sound_upper_bound_of_codegen_frame() {
+        let corpus: &[&str] = &[
+            // Flat scalar arrays across a chain.
+            r#"
+                fn a() -> i32 { forall { let arr: [i32; 6000] = @; let x: i32 = arr[0]; } return b(); }
+                fn b() -> i32 { forall { let arr: [i32; 6000] = @; let x: i32 = arr[0]; } return 0; }
+            "#,
+            // Mixed scalar widths in one array-bearing struct.
+            r#"
+                struct Blk { a: [i32; 1000]; b: [i64; 500]; }
+                fn s() -> i32 { forall { let x: Blk = @; } return 0; }
+            "#,
+            // Mixed-alignment struct (small fields ahead of a large array).
+            r#"
+                struct M { a: i8; b: i64; c: i8; d: i16; pad: [i32; 2000]; }
+                fn s() -> i32 { forall { let x: M = @; } return 0; }
+            "#,
+            // One level of struct nesting.
+            r#"
+                struct Inner { big: [i32; 1500]; }
+                struct Outer { inner: Inner; tag: i32; }
+                fn s() -> i32 {
+                    forall {
+                        let i: Inner = @;
+                        let o: Outer = Outer { inner: i, tag: 1 };
+                        let t: i32 = o.tag;
+                    }
+                    return 0;
+                }
+            "#,
+            // Array of structs via literal init.
+            r#"
+                struct Pt { x: i32; y: i32; }
+                fn s() -> i32 {
+                    let a: [Pt; 4] = [Pt { x: 1, y: 2 }, Pt { x: 3, y: 4 }, Pt { x: 5, y: 6 }, Pt { x: 7, y: 8 }];
+                    return a[2].y;
+                }
+            "#,
+            // Mutable-self method plus its caller.
+            r#"
+                struct C { a: i32;
+                    fn bump(mut self) -> i32 {
+                        forall { let b: [i32; 2000] = @; let t: i32 = b[0]; }
+                        return 0;
+                    }
+                }
+                fn caller() -> i32 {
+                    forall { let d: [i32; 2000] = @; let t: i32 = d[0]; }
+                    let c: C = C { a: 1 };
+                    return c.bump();
+                }
+            "#,
+            // if/else branches (codegen and estimate both max the arms).
+            r#"
+                fn branchy(n: i32) -> i32 {
+                    if n > 0 {
+                        forall { let x: [i32; 1000] = @; let tx: i32 = x[0]; }
+                    } else {
+                        forall { let y: [i32; 1200] = @; let ty: i32 = y[0]; }
+                    }
+                    return 0;
+                }
+            "#,
+        ];
+
+        // A non-trivial array-of-structs frame (`[Pt; 3000]` ~ 24 KB, built as
+        // an explicit literal since AoS has no repeat syntax and uzumaki on it
+        // is rejected by A028), so the estimate >= real invariant is exercised
+        // on a meaningful AoS frame rather than only the tiny 3/4-element
+        // literals above.
+        let aos_lit = array_of_pt_literal(3000);
+        let aos_src = format!(
+            r#"
+                struct Pt {{ x: i32; y: i32; }}
+                fn aos() -> i32 {{
+                    let a: [Pt; 3000] = {aos_lit};
+                    return a[2999].x;
+                }}
+            "#
+        );
+        let sources: Vec<&str> = corpus
+            .iter()
+            .copied()
+            .chain(std::iter::once(aos_src.as_str()))
+            .collect();
+
+        let mut saw_nonzero_real_frame = false;
+        for src in sources {
+            let ctx = type_check(src);
+            let estimate = inference_analysis::estimate_frame_sizes(&ctx);
+            let output = codegen_output_no_analysis(src);
+            let real = output.frame_sizes();
+            for (key, &real_bytes) in real {
+                if real_bytes > 0 {
+                    saw_nonzero_real_frame = true;
+                }
+                let est = estimate.get(key).copied().unwrap_or(0);
+                assert!(
+                    est >= real_bytes,
+                    "A036 estimate {est} < codegen real frame {real_bytes} for fn `{key}` in source:\n{src}"
+                );
+            }
+        }
+        assert!(
+            saw_nonzero_real_frame,
+            "parity corpus must exercise at least one non-zero real frame (non-vacuity)"
+        );
+    }
+}

--- a/tests/src/codegen/wasm/base.rs
+++ b/tests/src/codegen/wasm/base.rs
@@ -2683,6 +2683,12 @@ mod base_codegen_tests {
         );
     }
 
+    /// The runtime `memory.fill` overflow trap is a defense-in-depth backstop:
+    /// analysis rule A036 (`StackDepthExceeded`) is the *primary* guard and now
+    /// rejects this two-frame chain at compile time (see
+    /// `analysis::rules_a036`). Codegen is exercised with analysis skipped here
+    /// to confirm the runtime backstop still traps when the chain reaches the
+    /// generator unchecked.
     #[test]
     fn stack_overflow_traps_at_runtime() {
         use wasmtime::{Engine, Module, Store, TypedFunc};
@@ -2697,7 +2703,7 @@ mod base_codegen_tests {
                  return a[0] + callee();\
              }}"
         );
-        let wasm_bytes = wasm_codegen(&source);
+        let wasm_bytes = wasm_codegen_no_analysis(&source);
         let engine = Engine::default();
         let module = Module::new(&engine, &wasm_bytes).expect("compile");
         let mut store = Store::new(&engine, ());


### PR DESCRIPTION
## Summary

Closes #166. Adds static-analysis rule **A036 (`StackDepthExceeded`)**: it rejects programs whose **cumulative** shadow-stack usage along a call chain exceeds the 64 KB stack budget, turning the previously opaque runtime `memory.fill` out-of-bounds trap into a precise **compile-time** error that names the offending call chain.

### Why this works now
The just-merged A035 (recursion ban) makes the whole-program call graph **acyclic**, so worst-case shadow-stack usage is the **maximum-weight root-to-leaf path**, where each node's weight is that function's compound (array/struct) frame size. A036 reuses A035's call graph and reports the deepest chain when it crosses the budget. Scalar locals live in WASM locals and contribute nothing.

### Soundness — the critical property
A036's per-function estimate must always be **≥** codegen's real `FrameLayout.total_size`, or it would wave through a program that overflows the stack.

- The estimator computes each compound type's **exact** codegen size (mirroring `compute_struct_field_layout` field-by-field, including array-of-structs) and adds a worst-case leading-padding margin **once per slot** (not per field/element), then rounds to the 16-byte frame boundary. Margin over real is 0–32 bytes.
- The `NumberType` match is **exhaustive** (no wildcard), so a future numeric type fails to compile here rather than silently under-sizing. The ≤8-byte max-alignment invariant `MAX_SLOT_PADDING` relies on is guarded by a codegen test.
- Soundness is **enforced cross-crate**: new `inference_analysis::estimate_frame_sizes()` and `CodegenOutput::frame_sizes()` expose per-function sizes (keyed by canonical name), and a parity test asserts `estimate ≥ real` over a corpus of struct, mixed-alignment, nested, array-of-struct, mutable-self, and if/else cases.

### Behavior
- Diagnostic: `error[A036]: maximum stack depth a -> b -> c uses 98352 bytes, exceeding the 65536-byte stack; ...`
- The longest-path DFS is cycle-safe (white/gray/black coloring): a recursive program is reported by A035 while A036 does not hang.
- The runtime `memory.fill` trap is retained as defense-in-depth behind A036; the pre-existing `stack_overflow_traps_at_runtime` codegen test now runs with analysis skipped to still exercise it.

## ⚠️ Note for reviewers — bundled refactor
This PR also extracts the shared call-graph construction (previously inline in the A035 recursion rule) into `core/analysis/src/call_graph.rs`, consumed by both A035 and A036. The refactor is **behavior-preserving for A035** — its diagnostics, dedup, and spec-first resolution are byte-identical and all its tests pass unchanged. It's bundled here because A036 depends on it (a refactor-only commit would leave A036's new `FnNode` fields unread and trip dead-code warnings). Per the "don't mix refactoring with features" guideline, **flagging for explicit sign-off** — happy to split into a prep PR if preferred.

## Files
- **New**: `core/analysis/src/rules/stack_depth.rs` (the rule + estimator + longest-path), `core/analysis/src/call_graph.rs` (shared graph), `tests/src/analysis/rules_a036.rs` (integration + parity tests).
- **Modified**: analysis wiring (`errors.rs`, `lib.rs`, `rules/mod.rs`, `recursion.rs`), codegen frame-size channel (`compiler.rs`, `lib.rs`, `output.rs`) + alignment guard (`memory.rs`), docs (`README.md`, `CHANGELOG.md`).

## Testing
- **2392 tests pass, 0 failures** across default members; `cargo clippy` clean (analysis, codegen, tests).
- New coverage: estimator unit tests (exact struct/AoS sizing, `alignment_of` parity), 15 A036 integration tests (over/under-budget chains, single oversized frame, cycle-safety, AoS over-budget + a regression guard that the old over-approximating estimator would have falsely rejected), and the cross-crate `estimate ≥ real` parity test.
- Manual: `infs build` on an over-budget chain emits the A036 diagnostic instead of compiling to a module that traps at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)