### PR TITLE
A038, A039

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,6 +363,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   struct-literal field (e.g. `Outer { i: @ }`); it previously slipped past A027 and
   panicked proof-mode codegen with "Struct/Array uzumaki ... has no enclosing
   variable name" ([#225])
+- A039 `StructUzumakiAsArgument`: reject a struct-typed uzumaki (@) passed directly as a
+  function argument (e.g. `f(@)` where the parameter is a struct); the array case was
+  already A014, but the struct case slipped through and panicked codegen with
+  "Struct uzumaki ... has no enclosing variable name". Sibling of #225 ([#225])
 
 ### AST
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function argument (e.g. `f(@)` where the parameter is a struct); the array case was
   already A014, but the struct case slipped through and panicked codegen with
   "Struct uzumaki ... has no enclosing variable name". Sibling of #225 ([#225])
+- A040 `UzumakiOnCompoundArrayElement`: reject a struct- or array-typed uzumaki (@)
+  element of an array literal (e.g. `[Point { .. }, @]`); a scalar element `@` is now
+  supported (the type checker threads the declared element type onto it), but a compound
+  element has no enclosing variable name and panicked codegen. Distinct from A028
+  (whole-array `@`), and also covers a nested-array element such as the outer `@` in
+  `[@, [1, 2]]`. The array-element sibling of #225's struct-literal-field fix ([#225])
 
 ### AST
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The array length is read from the array sub-expression's `Array(_, length)` type info, so the check is zero-runtime-cost and fires in every build profile and compilation mode; the literal index is parsed as `i128` so out-of-`i32` values are caught too
   - A negative literal such as `arr[-1]` lowers to a single `NumberLiteral` whose text keeps the leading `-`, so it is rejected here as well; the diagnostic names the offending index and the array length
   - Dynamic (non-literal) indices are out of scope for the static rule and are guarded at run time in all Compile-mode builds (see Codegen)
+- A038 `UzumakiOnCompoundField`: reject uzumaki (@) on a struct- or array-typed
+  struct-literal field (e.g. `Outer { i: @ }`); it previously slipped past A027 and
+  panicked proof-mode codegen with "Struct/Array uzumaki ... has no enclosing
+  variable name" ([#225])
 
 ### AST
 
@@ -844,3 +848,4 @@ Initial tagged release.
 [#63]: https://github.com/Inferara/inference/issues/63
 [#223]: https://github.com/Inferara/inference/pull/223
 [#224]: https://github.com/Inferara/inference/issues/224
+[#225]: https://github.com/Inferara/inference/issues/225

--- a/core/analysis/src/errors.rs
+++ b/core/analysis/src/errors.rs
@@ -162,6 +162,9 @@ pub enum AnalysisDiagnostic {
     #[error("uzumaki (@) cannot initialize field `{field}` of type `{ty}` because it is a struct or array; in a struct literal, uzumaki is only supported for scalar fields — initialize a compound field with a literal whose scalar leaves use @ (e.g. `Inner {{ v: @ }}`)")]
     UzumakiOnCompoundField { field: String, ty: String, location: Location },
 
+    #[error("struct uzumaki (@) cannot be used as a function argument; assign to a variable first")]
+    StructUzumakiAsArgument { location: Location },
+
     #[error("compound literal cannot be assigned directly to a compound element; assign to a temporary variable first")]
     CompoundLiteralInCompoundAssign { location: Location },
 
@@ -237,6 +240,7 @@ impl AnalysisDiagnostic {
             | AnalysisDiagnostic::UzumakiOnNestedStruct { location, .. }
             | AnalysisDiagnostic::UzumakiOnStructInArray { location, .. }
             | AnalysisDiagnostic::UzumakiOnCompoundField { location, .. }
+            | AnalysisDiagnostic::StructUzumakiAsArgument { location }
             | AnalysisDiagnostic::CompoundLiteralInCompoundAssign { location }
             | AnalysisDiagnostic::UnsupportedCompoundReturnExpression { location }
             | AnalysisDiagnostic::TopLevelConstNotSupported { location, .. }
@@ -290,6 +294,7 @@ impl AnalysisDiagnostic {
             AnalysisDiagnostic::StackDepthExceeded { .. } => "A036",
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { .. } => "A037",
             AnalysisDiagnostic::UzumakiOnCompoundField { .. } => "A038",
+            AnalysisDiagnostic::StructUzumakiAsArgument { .. } => "A039",
         }
     }
 }
@@ -1150,6 +1155,23 @@ mod tests {
             "A038 diagnostic must explain uzumaki is only for scalar fields, got: {text}"
         );
         assert_eq!(err.rule_id(), "A038");
+    }
+
+    #[test]
+    fn display_struct_uzumaki_as_argument() {
+        let err = AnalysisDiagnostic::StructUzumakiAsArgument {
+            location: test_location(),
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("function argument"),
+            "A039 diagnostic must say it cannot be used as a function argument, got: {text}"
+        );
+        assert!(
+            text.contains("assign to a variable"),
+            "A039 diagnostic must suggest assigning to a variable first, got: {text}"
+        );
+        assert_eq!(err.rule_id(), "A039");
     }
 
     #[test]

--- a/core/analysis/src/errors.rs
+++ b/core/analysis/src/errors.rs
@@ -159,6 +159,9 @@ pub enum AnalysisDiagnostic {
     #[error("uzumaki (@) cannot be assigned to array of structs; arrays of structs do not support uzumaki")]
     UzumakiOnStructInArray { location: Location },
 
+    #[error("uzumaki (@) cannot initialize field `{field}` of type `{ty}` because it is a struct or array; in a struct literal, uzumaki is only supported for scalar fields — initialize a compound field with a literal whose scalar leaves use @ (e.g. `Inner {{ v: @ }}`)")]
+    UzumakiOnCompoundField { field: String, ty: String, location: Location },
+
     #[error("compound literal cannot be assigned directly to a compound element; assign to a temporary variable first")]
     CompoundLiteralInCompoundAssign { location: Location },
 
@@ -233,6 +236,7 @@ impl AnalysisDiagnostic {
             | AnalysisDiagnostic::NestedCompoundDepthExceeded { location, .. }
             | AnalysisDiagnostic::UzumakiOnNestedStruct { location, .. }
             | AnalysisDiagnostic::UzumakiOnStructInArray { location, .. }
+            | AnalysisDiagnostic::UzumakiOnCompoundField { location, .. }
             | AnalysisDiagnostic::CompoundLiteralInCompoundAssign { location }
             | AnalysisDiagnostic::UnsupportedCompoundReturnExpression { location }
             | AnalysisDiagnostic::TopLevelConstNotSupported { location, .. }
@@ -285,6 +289,7 @@ impl AnalysisDiagnostic {
             AnalysisDiagnostic::RecursionDetected { .. } => "A035",
             AnalysisDiagnostic::StackDepthExceeded { .. } => "A036",
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { .. } => "A037",
+            AnalysisDiagnostic::UzumakiOnCompoundField { .. } => "A038",
         }
     }
 }
@@ -1122,6 +1127,29 @@ mod tests {
             text.contains("length 5"),
             "A037 diagnostic must include the array length, got: {text}"
         );
+    }
+
+    #[test]
+    fn display_uzumaki_on_compound_field() {
+        let err = AnalysisDiagnostic::UzumakiOnCompoundField {
+            field: "i".to_string(),
+            ty: "Inner".to_string(),
+            location: test_location(),
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("`i`"),
+            "A038 diagnostic must name the offending field, got: {text}"
+        );
+        assert!(
+            text.contains("Inner"),
+            "A038 diagnostic must include the field type, got: {text}"
+        );
+        assert!(
+            text.contains("scalar"),
+            "A038 diagnostic must explain uzumaki is only for scalar fields, got: {text}"
+        );
+        assert_eq!(err.rule_id(), "A038");
     }
 
     #[test]

--- a/core/analysis/src/errors.rs
+++ b/core/analysis/src/errors.rs
@@ -165,6 +165,9 @@ pub enum AnalysisDiagnostic {
     #[error("struct uzumaki (@) cannot be used as a function argument; assign to a variable first")]
     StructUzumakiAsArgument { location: Location },
 
+    #[error("uzumaki (@) cannot initialize an array element of type `{ty}` because it is a struct or array; only scalar array elements may use @ — bind the value to a variable first, then use the variable as the element")]
+    UzumakiOnCompoundArrayElement { ty: String, location: Location },
+
     #[error("compound literal cannot be assigned directly to a compound element; assign to a temporary variable first")]
     CompoundLiteralInCompoundAssign { location: Location },
 
@@ -241,6 +244,7 @@ impl AnalysisDiagnostic {
             | AnalysisDiagnostic::UzumakiOnStructInArray { location, .. }
             | AnalysisDiagnostic::UzumakiOnCompoundField { location, .. }
             | AnalysisDiagnostic::StructUzumakiAsArgument { location }
+            | AnalysisDiagnostic::UzumakiOnCompoundArrayElement { location, .. }
             | AnalysisDiagnostic::CompoundLiteralInCompoundAssign { location }
             | AnalysisDiagnostic::UnsupportedCompoundReturnExpression { location }
             | AnalysisDiagnostic::TopLevelConstNotSupported { location, .. }
@@ -295,6 +299,7 @@ impl AnalysisDiagnostic {
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { .. } => "A037",
             AnalysisDiagnostic::UzumakiOnCompoundField { .. } => "A038",
             AnalysisDiagnostic::StructUzumakiAsArgument { .. } => "A039",
+            AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. } => "A040",
         }
     }
 }
@@ -1172,6 +1177,24 @@ mod tests {
             "A039 diagnostic must suggest assigning to a variable first, got: {text}"
         );
         assert_eq!(err.rule_id(), "A039");
+    }
+
+    #[test]
+    fn display_uzumaki_on_compound_array_element() {
+        let err = AnalysisDiagnostic::UzumakiOnCompoundArrayElement {
+            ty: "Point".to_string(),
+            location: test_location(),
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("Point"),
+            "A040 diagnostic must include the element type, got: {text}"
+        );
+        assert!(
+            text.contains("scalar"),
+            "A040 diagnostic must explain only scalar array elements may use @, got: {text}"
+        );
+        assert_eq!(err.rule_id(), "A040");
     }
 
     #[test]

--- a/core/analysis/src/lib.rs
+++ b/core/analysis/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! - A025: Variable declarations must have an initializer
 //!
-//! ### Codegen Restrictions (A012–A019, A022–A031)
+//! ### Codegen Restrictions (A012–A019, A022–A031, A038)
 //!
 //! These rules describe constructs that are valid in the type system but cannot
 //! be lowered by the current code generator.
@@ -58,6 +58,7 @@
 //! - A030: (removed — uzumaki on scalar arrays now supported at any depth)
 //! - A031: Unsupported expression form in compound-returning function return
 //! - A032: Top-level (module-scope) `const` declaration (not yet implemented)
+//! - A038: Uzumaki (`@`) on a struct- or array-typed struct-literal field
 //!
 //! ### Syntactic Restrictions (A033)
 //!
@@ -192,6 +193,7 @@ mod tests {
             AnalysisDiagnostic::RecursionDetected { cycle: "f -> f".to_string(), location: dummy_location() },
             AnalysisDiagnostic::StackDepthExceeded { chain: "a -> b".to_string(), depth_bytes: 80_000, budget_bytes: 65_536, location: dummy_location() },
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { index: "3".to_string(), length: 3, location: dummy_location() },
+            AnalysisDiagnostic::UzumakiOnCompoundField { field: "i".to_string(), ty: "Inner".to_string(), location: dummy_location() },
         ];
 
         let rules = rules::all_rules();

--- a/core/analysis/src/lib.rs
+++ b/core/analysis/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! - A025: Variable declarations must have an initializer
 //!
-//! ### Codegen Restrictions (A012–A019, A022–A031, A038)
+//! ### Codegen Restrictions (A012–A019, A022–A031, A038–A039)
 //!
 //! These rules describe constructs that are valid in the type system but cannot
 //! be lowered by the current code generator.
@@ -59,6 +59,7 @@
 //! - A031: Unsupported expression form in compound-returning function return
 //! - A032: Top-level (module-scope) `const` declaration (not yet implemented)
 //! - A038: Uzumaki (`@`) on a struct- or array-typed struct-literal field
+//! - A039: Struct uzumaki (`@`) passed directly as a function argument
 //!
 //! ### Syntactic Restrictions (A033)
 //!
@@ -194,6 +195,7 @@ mod tests {
             AnalysisDiagnostic::StackDepthExceeded { chain: "a -> b".to_string(), depth_bytes: 80_000, budget_bytes: 65_536, location: dummy_location() },
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { index: "3".to_string(), length: 3, location: dummy_location() },
             AnalysisDiagnostic::UzumakiOnCompoundField { field: "i".to_string(), ty: "Inner".to_string(), location: dummy_location() },
+            AnalysisDiagnostic::StructUzumakiAsArgument { location: dummy_location() },
         ];
 
         let rules = rules::all_rules();

--- a/core/analysis/src/lib.rs
+++ b/core/analysis/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! - A025: Variable declarations must have an initializer
 //!
-//! ### Codegen Restrictions (A012–A019, A022–A031, A038–A039)
+//! ### Codegen Restrictions (A012–A019, A022–A031, A038–A040)
 //!
 //! These rules describe constructs that are valid in the type system but cannot
 //! be lowered by the current code generator.
@@ -60,6 +60,7 @@
 //! - A032: Top-level (module-scope) `const` declaration (not yet implemented)
 //! - A038: Uzumaki (`@`) on a struct- or array-typed struct-literal field
 //! - A039: Struct uzumaki (`@`) passed directly as a function argument
+//! - A040: Uzumaki (`@`) on a struct- or array-typed array-literal element
 //!
 //! ### Syntactic Restrictions (A033)
 //!
@@ -196,6 +197,7 @@ mod tests {
             AnalysisDiagnostic::ArrayIndexConstOutOfBounds { index: "3".to_string(), length: 3, location: dummy_location() },
             AnalysisDiagnostic::UzumakiOnCompoundField { field: "i".to_string(), ty: "Inner".to_string(), location: dummy_location() },
             AnalysisDiagnostic::StructUzumakiAsArgument { location: dummy_location() },
+            AnalysisDiagnostic::UzumakiOnCompoundArrayElement { ty: "Point".to_string(), location: dummy_location() },
         ];
 
         let rules = rules::all_rules();

--- a/core/analysis/src/rules/mod.rs
+++ b/core/analysis/src/rules/mod.rs
@@ -28,6 +28,7 @@ pub mod struct_uzumaki_as_argument;
 pub mod top_level_const;
 pub mod uninitialized_variable;
 pub mod uzumaki_in_reassignment;
+pub mod uzumaki_on_compound_array_element;
 pub mod uzumaki_on_compound_field;
 pub mod uzumaki_on_nested_struct;
 pub mod uzumaki_on_struct_in_array;
@@ -65,6 +66,7 @@ use struct_uzumaki_as_argument::StructUzumakiAsArgument;
 use top_level_const::TopLevelConstNotSupported;
 use uninitialized_variable::UninitializedVariable;
 use uzumaki_in_reassignment::UzumakiInReassignment;
+use uzumaki_on_compound_array_element::UzumakiOnCompoundArrayElement;
 use uzumaki_on_compound_field::UzumakiOnCompoundField;
 use uzumaki_on_nested_struct::UzumakiOnNestedStruct;
 use uzumaki_on_struct_in_array::UzumakiOnStructInArray;
@@ -117,5 +119,6 @@ pub fn all_rules() -> &'static [&'static dyn crate::rule::Rule] {
         &ArrayIndexConstOob,
         &UzumakiOnCompoundField,
         &StructUzumakiAsArgument,
+        &UzumakiOnCompoundArrayElement,
     ]
 }

--- a/core/analysis/src/rules/mod.rs
+++ b/core/analysis/src/rules/mod.rs
@@ -24,6 +24,7 @@ pub mod return_inside_loop;
 pub mod return_inside_nondet_block;
 pub mod stack_depth;
 pub mod standalone_uzumaki;
+pub mod struct_uzumaki_as_argument;
 pub mod top_level_const;
 pub mod uninitialized_variable;
 pub mod uzumaki_in_reassignment;
@@ -60,6 +61,7 @@ use return_inside_loop::ReturnInsideLoop;
 use return_inside_nondet_block::ReturnInsideNonDetBlock;
 use stack_depth::StackDepthExceeded;
 use standalone_uzumaki::StandaloneUzumaki;
+use struct_uzumaki_as_argument::StructUzumakiAsArgument;
 use top_level_const::TopLevelConstNotSupported;
 use uninitialized_variable::UninitializedVariable;
 use uzumaki_in_reassignment::UzumakiInReassignment;
@@ -114,5 +116,6 @@ pub fn all_rules() -> &'static [&'static dyn crate::rule::Rule] {
         &StackDepthExceeded,
         &ArrayIndexConstOob,
         &UzumakiOnCompoundField,
+        &StructUzumakiAsArgument,
     ]
 }

--- a/core/analysis/src/rules/mod.rs
+++ b/core/analysis/src/rules/mod.rs
@@ -27,6 +27,7 @@ pub mod standalone_uzumaki;
 pub mod top_level_const;
 pub mod uninitialized_variable;
 pub mod uzumaki_in_reassignment;
+pub mod uzumaki_on_compound_field;
 pub mod uzumaki_on_nested_struct;
 pub mod uzumaki_on_struct_in_array;
 pub mod unsupported_compound_return_expr;
@@ -62,6 +63,7 @@ use standalone_uzumaki::StandaloneUzumaki;
 use top_level_const::TopLevelConstNotSupported;
 use uninitialized_variable::UninitializedVariable;
 use uzumaki_in_reassignment::UzumakiInReassignment;
+use uzumaki_on_compound_field::UzumakiOnCompoundField;
 use uzumaki_on_nested_struct::UzumakiOnNestedStruct;
 use uzumaki_on_struct_in_array::UzumakiOnStructInArray;
 use unsupported_compound_return_expr::UnsupportedCompoundReturnExpr;
@@ -111,5 +113,6 @@ pub fn all_rules() -> &'static [&'static dyn crate::rule::Rule] {
         &RecursionDetected,
         &StackDepthExceeded,
         &ArrayIndexConstOob,
+        &UzumakiOnCompoundField,
     ]
 }

--- a/core/analysis/src/rules/struct_uzumaki_as_argument.rs
+++ b/core/analysis/src/rules/struct_uzumaki_as_argument.rs
@@ -1,0 +1,65 @@
+//! A039: Struct uzumaki (@) cannot be used as a function argument.
+//!
+//! When a function parameter is a struct (or a custom non-enum type), passing
+//! `@` directly is not supported: codegen lowers a struct-typed `@` by filling a
+//! named frame slot, and a call argument has no such name -- so it reaches codegen
+//! with no enclosing variable and panics. Assign `@` to a variable first, then
+//! pass the variable. This is the struct sibling of A014 (the array case in the
+//! same position); arrays stay with A014, scalars and enums need no slot and are
+//! allowed.
+
+use inference_ast::ids::NodeId;
+use inference_ast::nodes::Expr;
+use inference_type_checker::type_info::TypeInfoKind;
+use inference_type_checker::typed_context::TypedContext;
+
+use crate::{
+    errors::{AnalysisDiagnostic, LabeledDiagnostic},
+    walker,
+};
+
+crate::rule! {
+    /// Struct uzumaki (@) cannot be used as a function argument.
+    #[id = "A039"]
+    #[name = "Struct uzumaki as argument"]
+    #[severity = error]
+    pub struct StructUzumakiAsArgument;
+    fn check(ctx: &TypedContext) -> Vec<LabeledDiagnostic> {
+        let mut errors = Vec::new();
+        let arena = ctx.arena();
+        walker::walk_function_bodies(ctx, &mut |stmt_id, walk_ctx| {
+            let module_path = walk_ctx.module_path.clone();
+            walker::for_each_stmt_expr(&arena[stmt_id].kind, arena, &mut |expr_id| {
+                walker::walk_expr(arena, expr_id, &mut |sub_id| {
+                    if let Expr::FunctionCall { args, .. } = &arena[sub_id].kind {
+                        for (_, arg_expr) in args {
+                            if matches!(arena[*arg_expr].kind, Expr::Uzumaki)
+                                && let Some(ti) = ctx.get_node_typeinfo(NodeId::Expr(*arg_expr))
+                                && arg_is_struct_like(ctx, &ti.kind)
+                            {
+                                errors.push(LabeledDiagnostic::new(
+                                    module_path.clone(),
+                                    AnalysisDiagnostic::StructUzumakiAsArgument {
+                                        location: arena[*arg_expr].location,
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                });
+            });
+        });
+        errors
+    }
+}
+
+/// A struct-typed `@` argument needs a named frame slot the call site cannot
+/// supply. Arrays are A014's; scalars and enums need no slot. A `Custom` name
+/// that resolves to an enum is scalar-like and allowed.
+fn arg_is_struct_like(ctx: &TypedContext, kind: &TypeInfoKind) -> bool {
+    match kind {
+        TypeInfoKind::Struct(_, _) => true,
+        TypeInfoKind::Custom(name) => ctx.lookup_enum(name).is_none(),
+        _ => false,
+    }
+}

--- a/core/analysis/src/rules/uzumaki_on_compound_array_element.rs
+++ b/core/analysis/src/rules/uzumaki_on_compound_array_element.rs
@@ -1,0 +1,79 @@
+//! A040: Uzumaki (@) on a struct- or array-typed array-literal element.
+//!
+//! In an array literal, `@` initializes one element directly. A scalar element
+//! (bool/number/enum) lowers to a single uzumaki opcode and needs no enclosing
+//! variable, but a struct- or array-typed element requires a named frame slot the
+//! element position cannot supply -- so `@` there reaches codegen with no variable
+//! name and panics. Reject it here. Initialize a compound element by binding the
+//! value to a variable first, then using the variable as the element.
+//!
+//! This is the array-literal-element analogue of A038 (uzumaki on a struct-literal
+//! field) and A014 (array uzumaki as a function argument): same root cause,
+//! different no-variable position. It is distinct from A028 (uzumaki on an array of
+//! structs), which flags the *whole-array* form `let a: [Point; 2] = @;` (a
+//! statement-position `@`); A040 flags an `@` *element* of an array literal. A040
+//! also rejects a nested-array element -- the outer `@` in `[@, [1, 2]]` typed
+//! `[[i32; 2]; 2]`, whose element type is itself an array -- which A028 does not
+//! cover.
+
+use inference_ast::ids::NodeId;
+use inference_ast::nodes::Expr;
+use inference_type_checker::type_info::TypeInfoKind;
+use inference_type_checker::typed_context::TypedContext;
+
+use crate::{
+    errors::{AnalysisDiagnostic, LabeledDiagnostic},
+    walker,
+};
+
+crate::rule! {
+    /// Uzumaki (@) cannot initialize a struct- or array-typed array-literal element.
+    #[id = "A040"]
+    #[name = "Uzumaki on compound array element"]
+    #[severity = error]
+    pub struct UzumakiOnCompoundArrayElement;
+    fn check(ctx: &TypedContext) -> Vec<LabeledDiagnostic> {
+        let mut errors = Vec::new();
+        let arena = ctx.arena();
+        walker::walk_function_bodies(ctx, &mut |stmt_id, walk_ctx| {
+            if walk_ctx.nondet_depth == 0 {
+                return;
+            }
+            let module_path = walk_ctx.module_path.clone();
+            walker::for_each_stmt_expr(&arena[stmt_id].kind, arena, &mut |expr_id| {
+                walker::walk_expr(arena, expr_id, &mut |sub_id| {
+                    if let Expr::ArrayLiteral { elements } = &arena[sub_id].kind {
+                        for &element in elements {
+                            if matches!(arena[element].kind, Expr::Uzumaki)
+                                && let Some(ti) = ctx.get_node_typeinfo(NodeId::Expr(element))
+                                && element_needs_named_slot(ctx, &ti.kind)
+                            {
+                                errors.push(LabeledDiagnostic::new(
+                                    module_path.clone(),
+                                    AnalysisDiagnostic::UzumakiOnCompoundArrayElement {
+                                        ty: ti.kind.to_string(),
+                                        location: arena[element].location,
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                });
+            });
+        });
+        errors
+    }
+}
+
+/// Whether an array-literal element of this type, initialized with `@`, needs a
+/// named frame slot the element position cannot supply. Scalars (bool/number) and
+/// enums lower `@` to a single opcode and are fine; structs and arrays (including
+/// scalar arrays like `[i32; 3]`, the element type of a multidimensional array)
+/// are not. A `Custom` name that resolves to an enum is scalar-like and allowed.
+fn element_needs_named_slot(ctx: &TypedContext, kind: &TypeInfoKind) -> bool {
+    match kind {
+        TypeInfoKind::Struct(_, _) | TypeInfoKind::Array(_, _) => true,
+        TypeInfoKind::Custom(name) => ctx.lookup_enum(name).is_none(),
+        _ => false,
+    }
+}

--- a/core/analysis/src/rules/uzumaki_on_compound_field.rs
+++ b/core/analysis/src/rules/uzumaki_on_compound_field.rs
@@ -1,0 +1,78 @@
+//! A038: Uzumaki (@) on a struct- or array-typed struct-literal field.
+//!
+//! In a struct literal, `@` initializes a field directly. A scalar field
+//! (bool/number/enum) lowers to a single uzumaki opcode and needs no enclosing
+//! variable, but a struct- or array-typed field requires a named frame slot the
+//! field position cannot supply -- so `@` there reaches codegen with no variable
+//! name and panics. Reject it here. Initialize a compound field with a literal
+//! whose scalar leaves use `@` instead (e.g. `Inner { v: @ }`).
+//!
+//! This is the struct-literal-field analogue of A014 (array uzumaki as a function
+//! argument): same root cause, different no-variable position. Unlike A027, which
+//! permits `let s: S = @;` when `S`'s fields are all scalars or 1D scalar arrays
+//! (codegen has a named slot to fill there), the field position has no slot at
+//! all, so even a scalar-array field must be rejected -- do not narrow this rule
+//! to A027's `has_compound_fields` predicate.
+
+use inference_ast::ids::NodeId;
+use inference_ast::nodes::Expr;
+use inference_type_checker::type_info::TypeInfoKind;
+use inference_type_checker::typed_context::TypedContext;
+
+use crate::{
+    errors::{AnalysisDiagnostic, LabeledDiagnostic},
+    walker,
+};
+
+crate::rule! {
+    /// Uzumaki (@) cannot initialize a struct- or array-typed struct-literal field.
+    #[id = "A038"]
+    #[name = "Uzumaki on compound field"]
+    #[severity = error]
+    pub struct UzumakiOnCompoundField;
+    fn check(ctx: &TypedContext) -> Vec<LabeledDiagnostic> {
+        let mut errors = Vec::new();
+        let arena = ctx.arena();
+        walker::walk_function_bodies(ctx, &mut |stmt_id, walk_ctx| {
+            if walk_ctx.nondet_depth == 0 {
+                return;
+            }
+            let module_path = walk_ctx.module_path.clone();
+            walker::for_each_stmt_expr(&arena[stmt_id].kind, arena, &mut |expr_id| {
+                walker::walk_expr(arena, expr_id, &mut |sub_id| {
+                    if let Expr::StructLiteral { fields, .. } = &arena[sub_id].kind {
+                        for &(field_name_id, field_expr) in fields {
+                            if matches!(arena[field_expr].kind, Expr::Uzumaki)
+                                && let Some(ti) = ctx.get_node_typeinfo(NodeId::Expr(field_expr))
+                                && field_needs_named_slot(ctx, &ti.kind)
+                            {
+                                errors.push(LabeledDiagnostic::new(
+                                    module_path.clone(),
+                                    AnalysisDiagnostic::UzumakiOnCompoundField {
+                                        field: arena[field_name_id].name.clone(),
+                                        ty: ti.kind.to_string(),
+                                        location: arena[field_expr].location,
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                });
+            });
+        });
+        errors
+    }
+}
+
+/// Whether a struct-literal field of this type, initialized with `@`, needs a
+/// named frame slot the field position cannot supply. Scalars (bool/number) and
+/// enums lower `@` to a single opcode and are fine; structs and arrays (including
+/// scalar arrays like `[i32; 3]`, which panic identically in codegen) are not. A
+/// `Custom` name that resolves to an enum is scalar-like and allowed.
+fn field_needs_named_slot(ctx: &TypedContext, kind: &TypeInfoKind) -> bool {
+    match kind {
+        TypeInfoKind::Struct(_, _) | TypeInfoKind::Array(_, _) => true,
+        TypeInfoKind::Custom(name) => ctx.lookup_enum(name).is_none(),
+        _ => false,
+    }
+}

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -1593,10 +1593,10 @@ impl TypeChecker {
     /// compiled before; it panicked codegen).
     ///
     /// `expected` must already be scope-resolved (a `Struct`/`Enum` carries a
-    /// canonical key, not a bare `Custom`/`Qualified`): all three call sites pass
+    /// canonical key, not a bare `Custom`/`Qualified`): all four call sites pass
     /// a type whose array element was resolved against the file that owns it (the
-    /// annotation's file for `let`/assignment, the defining file for a struct
-    /// field). The inner `resolve_custom_type` is therefore an idempotent no-op
+    /// annotation's file for `let`/`const`/assignment, the defining file for a
+    /// struct field). The inner `resolve_custom_type` is therefore an idempotent no-op
     /// kept as a guard; it must not be relied on to resolve a still-`Custom`
     /// element, which it would resolve against the current cursor scope.
     fn thread_array_uzumaki_types(

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -1253,6 +1253,17 @@ impl TypeChecker {
                 });
             }
         } else {
+            // A `const` array initializer may carry a `@` element (`const A:
+            // [i32; 2] = [0, @]`), which inherits the constant's element type.
+            // Thread it before inference (a no-op for non-array/non-uzumaki
+            // values) so the `@` is typed; this initializer is otherwise lowered
+            // element-by-element with no enclosing variable, so a `@` element
+            // panics codegen. A compound element is rejected by analysis (A040).
+            if matches!(ctx.arena()[value_id].kind, Expr::ArrayLiteral { .. })
+                && matches!(const_type.kind, TypeInfoKind::Array(_, _))
+            {
+                self.thread_array_uzumaki_types(ctx, value_id, const_type);
+            }
             let init_type = self.infer_expression(value_id, ctx);
             match init_type {
                 Some(init)
@@ -1572,6 +1583,42 @@ impl TypeChecker {
         self.symbol_table.pop_scope();
     }
 
+    /// Threads `expected` onto the uzumaki (`@`) leaves of an array-literal
+    /// initializer so codegen can choose an opcode/width for each `@`. Recurses
+    /// through nested array literals; a `@` element of a multidimensional array is
+    /// typed as its (array) element type, which lets analysis (A040) reject it as
+    /// a compound element. Only `@` leaves receive type info — number literals and
+    /// every other element kind keep their existing bottom-up inference, so no
+    /// previously-compiling program changes its emitted bytes (a `@` element never
+    /// compiled before; it panicked codegen).
+    ///
+    /// `expected` must already be scope-resolved (a `Struct`/`Enum` carries a
+    /// canonical key, not a bare `Custom`/`Qualified`): all three call sites pass
+    /// a type whose array element was resolved against the file that owns it (the
+    /// annotation's file for `let`/assignment, the defining file for a struct
+    /// field). The inner `resolve_custom_type` is therefore an idempotent no-op
+    /// kept as a guard; it must not be relied on to resolve a still-`Custom`
+    /// element, which it would resolve against the current cursor scope.
+    fn thread_array_uzumaki_types(
+        &mut self,
+        ctx: &mut TypedContext,
+        expr_id: ExprId,
+        expected: &TypeInfo,
+    ) {
+        match ctx.arena()[expr_id].kind.clone() {
+            Expr::Uzumaki => ctx.set_node_typeinfo(NodeId::Expr(expr_id), expected.clone()),
+            Expr::ArrayLiteral { elements } => {
+                if let TypeInfoKind::Array(elem_type, _) = &expected.kind {
+                    let elem_type = self.symbol_table.resolve_custom_type((**elem_type).clone());
+                    for e in elements {
+                        self.thread_array_uzumaki_types(ctx, e, &elem_type);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     fn infer_statement(&mut self, stmt_id: StmtId, return_type: &TypeInfo, ctx: &mut TypedContext) {
         let arena = ctx.arena();
@@ -1621,6 +1668,17 @@ impl TypeChecker {
                         });
                     }
                 } else {
+                    // An array-literal RHS may carry a `@` element (`a = [0, @]`),
+                    // which inherits the assignment target's element type. Thread
+                    // it before inference (a no-op for non-array/non-uzumaki RHS) so
+                    // the `@` is typed; this assignment position is otherwise
+                    // unguarded and a `@` element panics codegen. A compound element
+                    // is rejected by analysis (A040).
+                    if let Some(target) = &target_type
+                        && matches!(ctx.arena()[right].kind, Expr::ArrayLiteral { .. })
+                    {
+                        self.thread_array_uzumaki_types(ctx, right, target);
+                    }
                     let value_type = self.infer_expression(right, ctx);
                     // Compound-return-in-assignment check moved to analysis rule A017.
                     if let (Some(target), Some(val)) = (target_type, value_type)
@@ -1753,6 +1811,17 @@ impl TypeChecker {
                                 ctx.set_node_typeinfo(NodeId::Expr(elem_id), (**elem_type).clone());
                             }
                         }
+                    }
+                    // An array-literal initializer may carry a `@` element (`let a:
+                    // [i32; 2] = [0, @]`), which inherits the variable's element
+                    // type. Thread it after the number-literal pass and before
+                    // inference so the `@` is typed; an array-element `@` is
+                    // otherwise lowered with no enclosing variable and panics
+                    // codegen. A compound element is rejected by analysis (A040).
+                    if matches!(ctx.arena()[expr_id].kind, Expr::ArrayLiteral { .. })
+                        && matches!(target_type.kind, TypeInfoKind::Array(_, _))
+                    {
+                        self.thread_array_uzumaki_types(ctx, expr_id, &target_type);
                     }
                     let arena = ctx.arena();
                     if let Expr::Uzumaki = &arena[expr_id].kind {
@@ -2193,7 +2262,17 @@ impl TypeChecker {
                                         field_type.clone(),
                                     );
                                 } else {
-            
+                                    // An array-typed field whose value is an array
+                                    // literal may carry a `@` element (`Holder { arr:
+                                    // [0, @] }`), which inherits the field's element
+                                    // type. Thread it before inference (a no-op for a
+                                    // non-array/non-uzumaki value) so the `@` is typed;
+                                    // a compound element is rejected by analysis (A040).
+                                    self.thread_array_uzumaki_types(
+                                        ctx,
+                                        *field_value_expr,
+                                        &field_type,
+                                    );
                                     let init_type =
                                         self.infer_expression(*field_value_expr, ctx);
                                     if let Some(init) = init_type

--- a/tests/src/analysis/mod.rs
+++ b/tests/src/analysis/mod.rs
@@ -15,4 +15,5 @@ mod rules_a036;
 mod rules_a037;
 mod rules_a038;
 mod rules_a039;
+mod rules_a040;
 mod walker_tests;

--- a/tests/src/analysis/mod.rs
+++ b/tests/src/analysis/mod.rs
@@ -14,4 +14,5 @@ mod rules_a035;
 mod rules_a036;
 mod rules_a037;
 mod rules_a038;
+mod rules_a039;
 mod walker_tests;

--- a/tests/src/analysis/mod.rs
+++ b/tests/src/analysis/mod.rs
@@ -13,4 +13,5 @@ mod rules_a034;
 mod rules_a035;
 mod rules_a036;
 mod rules_a037;
+mod rules_a038;
 mod walker_tests;

--- a/tests/src/analysis/rules_a038.rs
+++ b/tests/src/analysis/rules_a038.rs
@@ -1,0 +1,544 @@
+/// Integration tests for analysis rule A038.
+///
+/// - A038: UzumakiOnCompoundField — in a struct literal, `@` may initialize a
+///   scalar field (bool/number/enum) but not a struct- or array-typed field. A
+///   compound field's `@` reaches codegen with no enclosing variable name and
+///   panics; the rule rejects it at the analysis phase instead. This is the
+///   struct-literal-field analogue of A014 (array uzumaki as a function argument).
+///
+/// These tests are the cross-crate guard that the rule fires through a real
+/// parse -> type-check -> analyze pipeline on Inference source, complementing the
+/// in-crate message/`rule_id` unit test in `core/analysis`. The rejected inputs
+/// are type-valid (only analysis rejects them), so `type_check` must succeed: the
+/// type checker threads each field-position `@` its declared field type.
+#[cfg(test)]
+mod analysis_rules_tests {
+    use crate::utils::build_ast;
+    use inference_analysis::errors::{AnalysisDiagnostic, AnalysisErrors, AnalysisResult};
+    use inference_type_checker::typed_context::TypedContext;
+
+    fn type_check(source: &str) -> TypedContext {
+        let arena = build_ast(source.to_string());
+        inference_type_checker::TypeCheckerBuilder::build_typed_context(arena)
+            .expect("type checking should succeed for analysis test input")
+            .typed_context()
+    }
+
+    fn analyze(source: &str) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = type_check(source);
+        inference_analysis::analyze(&ctx)
+    }
+
+    /// Returns true if any analysis error is an `UzumakiOnCompoundField` (A038).
+    /// Filters by variant rather than asserting a total error count, since the
+    /// surface may also trip unrelated rules.
+    fn has_a038(source: &str) -> bool {
+        match analyze(source) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundField { .. })),
+        }
+    }
+
+    fn a038_diag(source: &str) -> AnalysisDiagnostic {
+        analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .find(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundField { .. }))
+            .expect("expected an UzumakiOnCompoundField diagnostic")
+            .clone()
+    }
+
+    /// Counts how many `UzumakiOnCompoundField` (A038) diagnostics the analysis
+    /// emits for `source`. Filters by variant so unrelated rules tripped by the
+    /// same surface do not perturb the count.
+    fn count_a038(source: &str) -> usize {
+        match analyze(source) {
+            Ok(_) => 0,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .filter(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundField { .. }))
+                .count(),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Rejected: the issue #225 regression guard and its variants
+    // ---------------------------------------------------------------------
+
+    /// THE regression guard for issue #225: a struct-typed field initialized with
+    /// `@` inside a spec obligation. This exact program panicked proof-mode
+    /// codegen ("Struct uzumaki ... has no enclosing variable name") before A038.
+    #[test]
+    fn a038_issue_225_repro_struct_field_in_spec_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            spec Check {
+                fn obligation() {
+                    forall {
+                        let o: Outer = Outer { i: @ };
+                    }
+                }
+            }
+            pub fn main() {}
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for the struct-typed field `i: @` in the Outer literal (issue #225 repro)"
+        );
+    }
+
+    /// The same struct-typed field case in a plain free function (no spec):
+    /// the walker visits free-function bodies just as it does spec bodies.
+    #[test]
+    fn a038_struct_field_in_free_function_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn f() {
+                forall {
+                    let o: Outer = Outer { i: @ };
+                }
+            }
+            fn main() {}
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for the struct-typed field `i: @` in a free function"
+        );
+    }
+
+    /// A struct-typed field whose inner struct itself has multiple scalar fields
+    /// (still one nesting level) is rejected: the field position has no variable
+    /// name regardless of the inner struct's shape.
+    #[test]
+    fn a038_struct_field_with_multiscalar_inner_rejected() {
+        let source = r#"
+            struct Inner { x: i32; y: i32; z: i32; }
+            struct Outer { inner: Inner; tag: i32; }
+            fn main() {
+                forall {
+                    let o: Outer = Outer { inner: @, tag: 1 };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a struct-typed field even when the inner struct is all scalars"
+        );
+    }
+
+    /// A scalar-array field (`[i32; 3]`) initialized with `@` is rejected. Even
+    /// though A028 permits `let a: [i32; 3] = @;` at statement level (a slot
+    /// exists there), the field position supplies no variable name, so codegen
+    /// panics identically to a struct field.
+    #[test]
+    fn a038_scalar_array_field_rejected() {
+        let source = r#"
+            struct HasArr { a: [i32; 3]; }
+            fn main() {
+                forall {
+                    let h: HasArr = HasArr { a: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a scalar-array field `a: @` of type [i32; 3]"
+        );
+    }
+
+    /// An array-of-structs field (`[Inner; 3]`) initialized with `@` is rejected.
+    #[test]
+    fn a038_array_of_struct_field_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct HasArr { a: [Inner; 3]; }
+            fn main() {
+                forall {
+                    let h: HasArr = HasArr { a: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for an array-of-structs field `a: @` of type [Inner; 3]"
+        );
+    }
+
+    /// A multidimensional-array field (`[[i32; 2]; 3]`) initialized with `@` is
+    /// rejected.
+    #[test]
+    fn a038_multidim_array_field_rejected() {
+        let source = r#"
+            struct HasGrid { a: [[i32; 2]; 3]; }
+            fn main() {
+                forall {
+                    let h: HasGrid = HasGrid { a: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a multidimensional-array field `a: @` of type [[i32; 2]; 3]"
+        );
+    }
+
+    /// Two compound fields each initialized with `@` in one struct literal
+    /// produce exactly two A038 diagnostics, one per offending field.
+    #[test]
+    fn a038_two_bad_fields_counted() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { a: Inner; b: [i32; 3]; }
+            fn main() {
+                forall {
+                    let o: Outer = Outer { a: @, b: @ };
+                }
+            }
+        "#;
+        assert_eq!(
+            count_a038(source),
+            2,
+            "expected exactly two A038 diagnostics for two compound fields each set to @"
+        );
+    }
+
+    /// A compound field `@` inside an `exists` block is rejected: every non-det
+    /// block kind is walked, and the `nondet_depth` gate fires for all of them.
+    #[test]
+    fn a038_struct_field_in_exists_block_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                exists {
+                    let o: Outer = Outer { i: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a struct-typed field `i: @` inside an exists block"
+        );
+    }
+
+    /// A compound field `@` inside a `unique` block is rejected: the rule gates on
+    /// `nondet_depth`, not a specific block kind, so all four non-det block kinds
+    /// are covered.
+    #[test]
+    fn a038_struct_field_in_unique_block_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                unique {
+                    let o: Outer = Outer { i: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a struct-typed field `i: @` inside a unique block"
+        );
+    }
+
+    /// A compound field `@` inside an `assume` block is rejected; `assume`
+    /// increments `nondet_depth` like the other non-det block kinds.
+    #[test]
+    fn a038_struct_field_in_assume_block_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                forall {
+                    assume {
+                        let o: Outer = Outer { i: @ };
+                    }
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a struct-typed field `i: @` inside an assume block"
+        );
+    }
+
+    /// A compound field `@` in a `const` initializer is rejected. The walker
+    /// reaches `const` initializers via `Stmt::ConstDef` -- a distinct branch
+    /// from `let` -- so this guards that the const-init lowering path does not
+    /// bypass struct-literal-field analysis (mirrors the A027/A028 const tests).
+    #[test]
+    fn a038_compound_field_in_const_initializer_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                forall {
+                    const O: Outer = Outer { i: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a compound field `i: @` in a const initializer"
+        );
+    }
+
+    /// An array-of-enum field (`[Color; 3]`) initialized with `@` is rejected.
+    /// This guards the predicate's match ordering: `Array(_, _) => true` precedes
+    /// the `Custom`/enum exemption, so the enum exemption (which accepts a bare
+    /// `Color` field) must not leak through an enclosing array.
+    #[test]
+    fn a038_array_of_enum_field_rejected() {
+        let source = r#"
+            enum Color { Red, Green, Blue }
+            struct HasArr { a: [Color; 3]; }
+            fn main() {
+                forall {
+                    let h: HasArr = HasArr { a: @ };
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for an array-of-enum field `a: @` of type [Color; 3]; the enum exemption must not extend through an array"
+        );
+    }
+
+    /// A struct literal with a compound `@` field passed as a function argument is
+    /// rejected by A038 (the field still needs a frame slot the position cannot
+    /// supply). A012 (compound literal as argument) co-fires on the same literal;
+    /// the variant-filtered helper isolates A038, documenting that A038 owns the
+    /// field-`@` defect independently of the argument-position defect.
+    #[test]
+    fn a038_compound_field_in_struct_literal_argument_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn take(o: Outer) -> i32 {
+                return 0;
+            }
+            fn main() {
+                forall {
+                    let r: i32 = take(Outer { i: @ });
+                }
+            }
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a compound field `i: @` in a struct literal passed as an argument"
+        );
+    }
+
+    /// A compound field `@` inside a struct *method* body is rejected: the walker
+    /// descends into struct methods.
+    #[test]
+    fn a038_struct_field_in_method_body_rejected() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            struct Maker {
+                n: i32;
+                fn make(self) -> i32 {
+                    forall {
+                        let o: Outer = Outer { i: @ };
+                    }
+                    return self.n;
+                }
+            }
+            fn main() {}
+        "#;
+        assert!(
+            has_a038(source),
+            "expected A038 for a struct-typed field `i: @` inside a struct method body"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Diagnostic quality
+    // ---------------------------------------------------------------------
+
+    /// The diagnostic names the offending field and its type, explains that
+    /// uzumaki is only for scalar fields, and reports rule id A038.
+    #[test]
+    fn a038_diagnostic_names_field_and_type() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                forall {
+                    let o: Outer = Outer { i: @ };
+                }
+            }
+        "#;
+        let diag = a038_diag(source);
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("`i`"),
+            "A038 message must name the offending field, got: {msg}"
+        );
+        assert!(
+            msg.contains("Inner"),
+            "A038 message must include the field type (single-file canonical key is the bare name), got: {msg}"
+        );
+        assert!(
+            msg.contains("scalar"),
+            "A038 message must explain uzumaki is only for scalar fields, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A038");
+    }
+
+    // ---------------------------------------------------------------------
+    // Accepted: scalar and enum fields
+    // ---------------------------------------------------------------------
+
+    /// A scalar field (`x: i32`) initialized with `@` is accepted: a scalar `@`
+    /// lowers to a single uzumaki opcode and needs no enclosing variable.
+    #[test]
+    fn a038_scalar_field_accepted() {
+        let source = r#"
+            struct Point { x: i32; }
+            fn main() {
+                forall {
+                    let p: Point = Point { x: @ };
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "a scalar field `x: @` must not trip A038"
+        );
+    }
+
+    /// A `bool` field initialized with `@` is accepted: `bool` is scalar.
+    #[test]
+    fn a038_bool_field_accepted() {
+        let source = r#"
+            struct Flag { b: bool; }
+            fn main() {
+                forall {
+                    let f: Flag = Flag { b: @ };
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "a bool field `b: @` must not trip A038"
+        );
+    }
+
+    /// An enum-typed field initialized with `@` is accepted: an enum lowers to a
+    /// single scalar uzumaki opcode like any other scalar.
+    #[test]
+    fn a038_enum_field_accepted() {
+        let source = r#"
+            enum Color { Red, Green, Blue }
+            struct Painted { c: Color; }
+            fn main() {
+                forall {
+                    let p: Painted = Painted { c: @ };
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "an enum-typed field `c: @` must not trip A038 (enums are scalar-like)"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Accepted: the correct way to write it, and positions A038 does not own
+    // ---------------------------------------------------------------------
+
+    /// The correct way to initialize a compound field: nest a literal whose
+    /// scalar leaves use `@` (`Outer { i: Inner { v: @ } }`). The outer field `i`
+    /// is set to a struct *literal*, not `@`, so A038 does not fire; the inner
+    /// scalar field `v` uses `@`, which is allowed.
+    #[test]
+    fn a038_nested_literal_with_scalar_leaf_accepted() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                forall {
+                    let o: Outer = Outer { i: Inner { v: @ } };
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "a nested literal whose inner scalar leaf uses @ is the correct form and must not trip A038"
+        );
+    }
+
+    /// Whole-struct `let o: Outer = @;` is A027's position, not A038's. A038 must
+    /// stay silent here; the `@` is not in a struct-literal field.
+    #[test]
+    fn a038_whole_struct_uzumaki_not_flagged() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                forall {
+                    let o: Outer = @;
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "whole-struct `let o: Outer = @;` is A027's job, not A038's"
+        );
+    }
+
+    /// A struct-literal field `@` written OUTSIDE any non-det block must not trip
+    /// A038: the rule is `nondet_depth`-guarded, and A006 (uzumaki outside
+    /// non-det block) owns that position. This proves the gate.
+    #[test]
+    fn a038_compound_field_outside_nondet_block_not_flagged() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; }
+            fn main() {
+                let o: Outer = Outer { i: @ };
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "a struct-literal field `@` outside a non-det block is A006's job, not A038's"
+        );
+        let has_a006 = analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .any(|e| matches!(e, AnalysisDiagnostic::UzumakiOutsideNonDetBlock { .. }));
+        assert!(
+            has_a006,
+            "A006 should fire for the field `@` outside a non-det block"
+        );
+    }
+
+    /// A struct literal with no `@` field at all (all fields are concrete values)
+    /// must not trip A038, even inside a non-det block.
+    #[test]
+    fn a038_struct_literal_without_uzumaki_accepted() {
+        let source = r#"
+            struct Inner { v: i32; }
+            struct Outer { i: Inner; tag: i32; }
+            fn main() {
+                forall {
+                    let o: Outer = Outer { i: Inner { v: 1 }, tag: 2 };
+                }
+            }
+        "#;
+        assert!(
+            !has_a038(source),
+            "a struct literal with no field `@` must not trip A038"
+        );
+    }
+}

--- a/tests/src/analysis/rules_a039.rs
+++ b/tests/src/analysis/rules_a039.rs
@@ -295,10 +295,11 @@ mod analysis_rules_tests {
             !has_a039(source),
             "a scalar `@` argument must not trip A039"
         );
+        let result = analyze(source);
         assert!(
-            analyze(source).is_ok(),
+            result.is_ok(),
             "a scalar `@` argument must analyze cleanly: {:?}",
-            analyze(source).err()
+            result.err()
         );
     }
 
@@ -405,10 +406,11 @@ mod analysis_rules_tests {
             !has_a039(source),
             "a call passing a struct *variable* (not `@`) must not trip A039"
         );
+        let result = analyze(source);
         assert!(
-            analyze(source).is_ok(),
+            result.is_ok(),
             "passing a struct variable argument must analyze cleanly: {:?}",
-            analyze(source).err()
+            result.err()
         );
     }
 

--- a/tests/src/analysis/rules_a039.rs
+++ b/tests/src/analysis/rules_a039.rs
@@ -1,0 +1,425 @@
+/// Integration tests for analysis rule A039.
+///
+/// - A039: StructUzumakiAsArgument — a struct-typed (or custom non-enum) `@`
+///   passed directly as a function argument is rejected. Codegen lowers a
+///   struct-typed `@` by filling a named frame slot, and a call argument has no
+///   such name, so it reaches codegen with no enclosing variable and panics. This
+///   is the struct sibling of A014 (the array case in the same argument
+///   position); arrays stay with A014, scalars and enums need no slot and are
+///   allowed.
+///
+/// These tests are the cross-crate guard that the rule fires through a real
+/// parse -> type-check -> analyze pipeline on Inference source, complementing the
+/// in-crate message/`rule_id` unit test in `core/analysis`. The rejected inputs
+/// are type-valid (only analysis rejects them), so `type_check` must succeed: the
+/// type checker threads each argument-position `@` its parameter's declared type.
+#[cfg(test)]
+mod analysis_rules_tests {
+    use crate::utils::build_ast;
+    use inference_analysis::errors::{AnalysisDiagnostic, AnalysisErrors, AnalysisResult};
+    use inference_type_checker::typed_context::TypedContext;
+
+    fn type_check(source: &str) -> TypedContext {
+        let arena = build_ast(source.to_string());
+        inference_type_checker::TypeCheckerBuilder::build_typed_context(arena)
+            .expect("type checking should succeed for analysis test input")
+            .typed_context()
+    }
+
+    fn analyze(source: &str) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = type_check(source);
+        inference_analysis::analyze(&ctx)
+    }
+
+    /// Returns true if any analysis error is a `StructUzumakiAsArgument` (A039).
+    /// Filters by variant rather than asserting a total error count, since the
+    /// surface may also trip unrelated rules.
+    fn has_a039(source: &str) -> bool {
+        match analyze(source) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::StructUzumakiAsArgument { .. })),
+        }
+    }
+
+    fn a039_diag(source: &str) -> AnalysisDiagnostic {
+        analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .find(|e| matches!(e, AnalysisDiagnostic::StructUzumakiAsArgument { .. }))
+            .expect("expected a StructUzumakiAsArgument diagnostic")
+            .clone()
+    }
+
+    /// Counts how many `StructUzumakiAsArgument` (A039) diagnostics the analysis
+    /// emits for `source`. Filters by variant so unrelated rules tripped by the
+    /// same surface do not perturb the count.
+    fn count_a039(source: &str) -> usize {
+        match analyze(source) {
+            Ok(_) => 0,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .filter(|e| matches!(e, AnalysisDiagnostic::StructUzumakiAsArgument { .. }))
+                .count(),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Rejected: A039 fires
+    // ---------------------------------------------------------------------
+
+    /// THE regression guard: a struct-typed `@` passed as a free-function
+    /// argument. This exact program panicked codegen
+    /// ("Struct uzumaki ... has no enclosing variable name") before A039.
+    #[test]
+    fn a039_struct_uzumaki_as_argument_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            spec Check {
+                fn obligation() {
+                    forall {
+                        let r: i32 = consume(@);
+                    }
+                }
+            }
+            pub fn main() {}
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct-typed `@` passed as a function argument"
+        );
+    }
+
+    /// The same struct-typed `@` argument in a plain free function (no spec):
+    /// the walker visits free-function bodies just as it does spec bodies.
+    #[test]
+    fn a039_struct_uzumaki_argument_in_free_function_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn f() {
+                forall {
+                    let r: i32 = consume(@);
+                }
+            }
+            fn main() {}
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct-typed `@` argument in a free function"
+        );
+    }
+
+    /// A struct `@` mixed with scalar arguments is rejected: only the struct
+    /// parameter position needs a frame slot, and that is where `@` sits.
+    #[test]
+    fn a039_struct_uzumaki_argument_mixed_with_scalars_rejected() {
+        let source = r#"
+            struct Mid { v: i32; }
+            fn consume(a: i32, m: Mid, b: i32) -> i32 { return a + m.v + b; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(1, @, 3);
+                }
+            }
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct `@` in the middle of scalar arguments"
+        );
+    }
+
+    /// Two struct `@` arguments in one call produce exactly two A039
+    /// diagnostics, one per offending argument position.
+    #[test]
+    fn a039_two_struct_uzumaki_arguments_counted() {
+        let source = r#"
+            struct A { v: i32; }
+            struct B { w: i32; }
+            fn consume(a: A, b: B) -> i32 { return a.v + b.w; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(@, @);
+                }
+            }
+        "#;
+        assert_eq!(
+            count_a039(source),
+            2,
+            "expected exactly two A039 diagnostics for two struct `@` arguments"
+        );
+    }
+
+    /// A struct `@` argument outside any non-det block is still rejected by A039:
+    /// unlike A038, A039 has no `nondet_depth` guard (it checks all calls, like
+    /// its sibling A014). The bare `@` also trips A006, but A039 owns the
+    /// argument-position defect and must fire here too.
+    #[test]
+    fn a039_struct_uzumaki_argument_outside_nondet_block_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn main() {
+                let r: i32 = consume(@);
+            }
+        "#;
+        assert!(
+            has_a039(source),
+            "A039 has no nondet gate (like A014); a struct `@` argument is rejected outside a non-det block too"
+        );
+    }
+
+    /// A struct `@` argument inside an `exists` block is rejected; A039 fires
+    /// regardless of the enclosing non-det block kind.
+    #[test]
+    fn a039_struct_uzumaki_argument_in_exists_block_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn main() {
+                exists {
+                    let r: i32 = consume(@);
+                }
+            }
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct `@` argument inside an exists block"
+        );
+    }
+
+    /// A struct `@` argument inside a struct *method* body is rejected: the
+    /// walker descends into struct methods just as it does free functions.
+    #[test]
+    fn a039_struct_uzumaki_argument_in_method_body_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            struct Maker {
+                n: i32;
+                fn make(self) -> i32 {
+                    forall {
+                        let r: i32 = consume(@);
+                    }
+                    return self.n;
+                }
+            }
+            fn main() {}
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct `@` argument inside a struct method body"
+        );
+    }
+
+    /// A struct `@` passed to a *method* call (`obj.m(@)`) is rejected. A method
+    /// call lowers to `Expr::FunctionCall` whose `function` is the receiver
+    /// member-access and whose `args` hold `@`, so A039 sees the argument exactly
+    /// as it sees a free-function argument -- A039 inherits A014's call-coverage
+    /// model (all `Expr::FunctionCall` argument lists), and methods are not a
+    /// special case.
+    #[test]
+    fn a039_struct_uzumaki_as_method_argument_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            struct Sink {
+                n: i32;
+                fn absorb(self, p: Point) -> i32 { return self.n + p.x; }
+            }
+            fn main() {
+                let s: Sink = Sink { n: 0 };
+                forall {
+                    let r: i32 = s.absorb(@);
+                }
+            }
+        "#;
+        assert!(
+            has_a039(source),
+            "expected A039 for a struct `@` passed as a method-call argument"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Diagnostic quality
+    // ---------------------------------------------------------------------
+
+    /// The diagnostic explains the argument position is unsupported, suggests
+    /// assigning to a variable first, and reports rule id A039.
+    #[test]
+    fn a039_diagnostic_message_and_rule_id() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(@);
+                }
+            }
+        "#;
+        let diag = a039_diag(source);
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("function argument"),
+            "A039 message must say `@` cannot be used as a function argument, got: {msg}"
+        );
+        assert!(
+            msg.contains("assign to a variable"),
+            "A039 message must suggest assigning to a variable first, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A039");
+    }
+
+    // ---------------------------------------------------------------------
+    // Accepted: positions and types A039 does not own
+    // ---------------------------------------------------------------------
+
+    /// A scalar `@` argument is accepted: a scalar `@` lowers to a single uzumaki
+    /// opcode and needs no enclosing variable. The program must also type-check
+    /// and analyze cleanly (no A039, and no error at all).
+    #[test]
+    fn a039_scalar_uzumaki_argument_accepted() {
+        let source = r#"
+            fn consume(x: i32) -> i32 { return x; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(@);
+                }
+            }
+        "#;
+        assert!(
+            !has_a039(source),
+            "a scalar `@` argument must not trip A039"
+        );
+        assert!(
+            analyze(source).is_ok(),
+            "a scalar `@` argument must analyze cleanly: {:?}",
+            analyze(source).err()
+        );
+    }
+
+    /// An enum-typed `@` argument is accepted: an enum lowers to a single scalar
+    /// uzumaki opcode like any other scalar, so it needs no frame slot.
+    #[test]
+    fn a039_enum_uzumaki_argument_accepted() {
+        let source = r#"
+            enum Color { Red, Green, Blue }
+            fn consume(c: Color) -> i32 { return 0; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(@);
+                }
+            }
+        "#;
+        assert!(
+            !has_a039(source),
+            "an enum-typed `@` argument must not trip A039 (enums are scalar-like)"
+        );
+    }
+
+    /// An array `@` argument is A014's, not A039's: assert A014 fires and A039
+    /// does not. This guards against double-coverage between the two
+    /// argument-position uzumaki rules.
+    #[test]
+    fn a039_array_uzumaki_argument_is_a014_not_a039() {
+        let source = r#"
+            fn consume(a: [i32; 3]) -> i32 { return a[0]; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(@);
+                }
+            }
+        "#;
+        let errors = analyze(source).expect_err("expected analysis errors but got Ok");
+        let has_a014 = errors
+            .errors()
+            .iter()
+            .any(|e| matches!(e, AnalysisDiagnostic::ArrayUzumakiAsArgument { .. }));
+        let has_a039 = errors
+            .errors()
+            .iter()
+            .any(|e| matches!(e, AnalysisDiagnostic::StructUzumakiAsArgument { .. }));
+        assert!(has_a014, "expected A014 for an array `@` argument, got: {errors:?}");
+        assert!(
+            !has_a039,
+            "an array `@` argument is A014's job; A039 must not also fire, got: {errors:?}"
+        );
+    }
+
+    /// A struct *literal* (not `@`) passed as an argument is not A039's: the
+    /// argument is a literal, so A039 stays silent. A012 (compound literal as
+    /// argument) owns that defect; the inner scalar field `@` is allowed. This
+    /// guards that A039 keys on the argument being `@`, not on the parameter type.
+    #[test]
+    fn a039_struct_literal_argument_not_flagged() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn main() {
+                forall {
+                    let r: i32 = consume(Point { x: @, y: 0 });
+                }
+            }
+        "#;
+        assert!(
+            !has_a039(source),
+            "a struct literal argument is A012's job, not A039's; A039 keys on the argument being `@`"
+        );
+    }
+
+    /// Whole-struct `let p: Point = @;` is A027's position, not A039's: the `@`
+    /// is a `let` initializer, not a call argument, so A039 must stay silent.
+    #[test]
+    fn a039_struct_uzumaki_let_binding_not_flagged() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let p: Point = @;
+                }
+            }
+        "#;
+        assert!(
+            !has_a039(source),
+            "a whole-struct `let p: Point = @;` is A027's job, not A039's"
+        );
+    }
+
+    /// A call with no `@` argument at all (all arguments concrete) must not trip
+    /// A039, even inside a non-det block.
+    #[test]
+    fn a039_struct_argument_without_uzumaki_accepted() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn consume(p: Point) -> i32 { return p.x; }
+            fn main() {
+                let p: Point = Point { x: 1, y: 2 };
+                let r: i32 = consume(p);
+            }
+        "#;
+        assert!(
+            !has_a039(source),
+            "a call passing a struct *variable* (not `@`) must not trip A039"
+        );
+        assert!(
+            analyze(source).is_ok(),
+            "passing a struct variable argument must analyze cleanly: {:?}",
+            analyze(source).err()
+        );
+    }
+
+    // The predicate's `TypeInfoKind::Custom(name)` arm (rejecting a custom
+    // non-enum `@` argument) has no type-valid integration test here: a `type`
+    // alias to a struct does not behave as the struct for member access — a
+    // parameter typed by such an alias fails type-checking the moment its struct
+    // fields are used (`member access requires a struct type, found `P``), so no
+    // well-typed program reaches A039 with an unresolved `Custom` struct
+    // argument. The arm is a defensive guard matching codegen (which treats a
+    // `Custom` non-enum `@` as struct-like and panics on the missing slot) and
+    // mirroring A038's predicate; its enum-exemption branch is covered by
+    // `a039_enum_uzumaki_argument_accepted`.
+}

--- a/tests/src/analysis/rules_a040.rs
+++ b/tests/src/analysis/rules_a040.rs
@@ -499,4 +499,43 @@ mod analysis_rules_tests {
             "an array literal with no element `@` must not trip A040"
         );
     }
+
+    /// Boundary guard: an array literal with a `@` element passed *as a function
+    /// argument* (`take([0, @])`) is rejected by A012 (a compound literal cannot be
+    /// a function argument, regardless of its elements), so it never reaches codegen
+    /// and the `@` is never threaded a type. A040 therefore does not — and need not —
+    /// fire here. This pins the boundary so the (unreachable) argument path is not
+    /// later "fixed" by threading element types into it, which would be dead code
+    /// and risk masking removal of the A012 guard.
+    #[test]
+    fn a040_array_literal_uzumaki_element_as_argument_is_a012_not_a040() {
+        let source = r#"
+            fn take(a: [i32; 2]) -> i32 { return a[0]; }
+            spec C {
+                fn o() {
+                    forall {
+                        let r: i32 = take([0, @]);
+                    }
+                }
+            }
+            pub fn main() {}
+        "#;
+        let errors = analyze(source).expect_err("expected analysis errors but got Ok");
+        assert!(
+            errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::CompoundLiteralAsArgument { .. })),
+            "an array-literal argument must be rejected by A012, got: {:?}",
+            errors.errors()
+        );
+        assert!(
+            !errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. })),
+            "A040 must not fire for an array-literal argument (A012 owns that position), got: {:?}",
+            errors.errors()
+        );
+    }
 }

--- a/tests/src/analysis/rules_a040.rs
+++ b/tests/src/analysis/rules_a040.rs
@@ -1,0 +1,502 @@
+/// Integration tests for analysis rule A040.
+///
+/// - A040: UzumakiOnCompoundArrayElement — in an array literal, `@` may be a
+///   scalar element (bool/number/enum) but not a struct- or array-typed element.
+///   A compound element's `@` reaches codegen with no enclosing variable name and
+///   panics; the rule rejects it at the analysis phase instead. This is the
+///   array-element analogue of A038 (uzumaki on a compound struct-literal field)
+///   and A014 (array uzumaki as a function argument).
+///
+/// A040 is distinct from A028 (uzumaki on an array of structs): A028 flags the
+/// *whole-array* form `let a: [Point; 2] = @;` (a `NodeId::Stmt` position), while
+/// A040 flags an `@` *element* of an array literal `[p, @]`. A040 also rejects a
+/// nested-array element (the outer `@` in `[@, [1, 2]]` typed `[[i32; 2]; 2]`),
+/// which A028 does not cover.
+///
+/// These tests are the cross-crate guard that the rule fires through a real
+/// parse -> type-check -> analyze pipeline on Inference source, complementing the
+/// in-crate message/`rule_id` unit test in `core/analysis`. The rejected inputs
+/// are type-valid (only analysis rejects them), so `type_check` must succeed: the
+/// type checker threads each array-element `@` its declared element type.
+#[cfg(test)]
+mod analysis_rules_tests {
+    use crate::utils::build_ast;
+    use inference_analysis::errors::{AnalysisDiagnostic, AnalysisErrors, AnalysisResult};
+    use inference_type_checker::typed_context::TypedContext;
+
+    fn type_check(source: &str) -> TypedContext {
+        let arena = build_ast(source.to_string());
+        inference_type_checker::TypeCheckerBuilder::build_typed_context(arena)
+            .expect("type checking should succeed for analysis test input")
+            .typed_context()
+    }
+
+    fn analyze(source: &str) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = type_check(source);
+        inference_analysis::analyze(&ctx)
+    }
+
+    /// Returns true if any analysis error is an `UzumakiOnCompoundArrayElement`
+    /// (A040). Filters by variant rather than asserting a total error count, since
+    /// the surface may also trip unrelated rules.
+    fn has_a040(source: &str) -> bool {
+        match analyze(source) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. })),
+        }
+    }
+
+    fn a040_diag(source: &str) -> AnalysisDiagnostic {
+        analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .find(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. }))
+            .expect("expected an UzumakiOnCompoundArrayElement diagnostic")
+            .clone()
+    }
+
+    /// Counts how many `UzumakiOnCompoundArrayElement` (A040) diagnostics the
+    /// analysis emits for `source`. Filters by variant so unrelated rules tripped
+    /// by the same surface do not perturb the count.
+    fn count_a040(source: &str) -> usize {
+        match analyze(source) {
+            Ok(_) => 0,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .filter(|e| matches!(e, AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. }))
+                .count(),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Rejected: struct, array, and nested-array elements
+    // ---------------------------------------------------------------------
+
+    /// A struct-typed array element initialized with `@` (`[Point { .. }, @]`)
+    /// is rejected: the element position has no variable name, so a struct `@`
+    /// there panics codegen ("Struct uzumaki ... has no enclosing variable name").
+    #[test]
+    fn a040_struct_element_in_vardef_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` in `[Point {{..}}, @]`"
+        );
+    }
+
+    /// The same struct-element case inside a spec obligation (the proof-mode path
+    /// that originally panicked): the walker visits spec bodies just as it does
+    /// free-function bodies.
+    #[test]
+    fn a040_struct_element_in_spec_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            spec Check {
+                fn obligation() {
+                    forall {
+                        let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                    }
+                }
+            }
+            pub fn main() {}
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` inside a spec obligation"
+        );
+    }
+
+    /// A nested-array element initialized with `@` — the OUTER `@` of a 2D array
+    /// literal typed `[[i32; 2]; 2]` — is rejected. The element type is itself an
+    /// array (`[i32; 2]`), which has no enclosing variable name at the element
+    /// position. A028 (whole-array `@`) does NOT cover this; A040 does.
+    #[test]
+    fn a040_nested_array_outer_element_rejected() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [[i32; 2]; 2] = [@, [1, 2]];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for the outer array-typed element `@` in `[@, [1, 2]]` typed [[i32; 2]; 2]"
+        );
+    }
+
+    /// An array-of-struct element `@` inside an array-typed struct field's literal
+    /// is rejected. The struct field initializer is itself an array literal whose
+    /// element is a struct-typed `@`.
+    #[test]
+    fn a040_struct_element_in_struct_field_literal_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            struct Holder { ps: [Point; 2]; }
+            fn main() {
+                forall {
+                    let h: Holder = Holder { ps: [Point { x: 0, y: 0 }, @] };
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` in an array-typed struct field literal"
+        );
+    }
+
+    /// Two compound `@` elements in one array literal produce exactly two A040
+    /// diagnostics, one per offending element.
+    #[test]
+    fn a040_two_compound_elements_counted() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let a: [Point; 2] = [@, @];
+                }
+            }
+        "#;
+        assert_eq!(
+            count_a040(source),
+            2,
+            "expected exactly two A040 diagnostics for two struct-typed `@` elements"
+        );
+    }
+
+    /// A struct-typed array element `@` inside an `exists` block is rejected:
+    /// every non-det block kind is walked, and the `nondet_depth` gate fires for
+    /// all of them.
+    #[test]
+    fn a040_struct_element_in_exists_block_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                exists {
+                    let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` inside an exists block"
+        );
+    }
+
+    /// A struct-typed array element `@` inside a `unique` block is rejected; the
+    /// rule gates on `nondet_depth`, not a specific block kind.
+    #[test]
+    fn a040_struct_element_in_unique_block_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                unique {
+                    let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` inside a unique block"
+        );
+    }
+
+    /// A compound array element `@` in the RHS of an assignment is rejected. The
+    /// assignment position (`a = [.., @];`) is a distinct type-checker branch from
+    /// `let`; this guards that the assignment-position threading does not bypass
+    /// array-element analysis.
+    #[test]
+    fn a040_struct_element_in_assignment_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                let mut a: [Point; 2] = [Point { x: 0, y: 0 }, Point { x: 1, y: 1 }];
+                forall {
+                    a = [Point { x: 2, y: 2 }, @];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` on the RHS of an assignment"
+        );
+    }
+
+    /// A struct-typed array element `@` inside an `assume` block is rejected;
+    /// `assume` increments `nondet_depth` like the other non-det block kinds, so
+    /// all four kinds (forall/exists/unique/assume) are covered.
+    #[test]
+    fn a040_struct_element_in_assume_block_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    assume {
+                        let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                    }
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a struct-typed array element `@` inside an assume block"
+        );
+    }
+
+    /// A compound array element `@` in a `const` initializer is rejected. The
+    /// walker reaches `const` initializers via `Stmt::ConstDef` -- a distinct
+    /// branch from `let` -- so this guards that the const-init type-checker path
+    /// threads the element type onto the `@` (without which the element would
+    /// arrive untyped and codegen would panic rather than A040 firing).
+    #[test]
+    fn a040_compound_element_in_const_initializer_rejected() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    const A: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                }
+            }
+        "#;
+        assert!(
+            has_a040(source),
+            "expected A040 for a compound array element `@` in a const initializer"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Diagnostic quality
+    // ---------------------------------------------------------------------
+
+    /// The diagnostic names the offending element type, explains that only scalar
+    /// elements may use `@`, and reports rule id A040.
+    #[test]
+    fn a040_diagnostic_names_type() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+                }
+            }
+        "#;
+        let diag = a040_diag(source);
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("Point"),
+            "A040 message must include the element type (single-file canonical key is the bare name), got: {msg}"
+        );
+        assert!(
+            msg.contains("scalar"),
+            "A040 message must explain only scalar array elements may use @, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A040");
+    }
+
+    // ---------------------------------------------------------------------
+    // Accepted: scalar and enum elements
+    // ---------------------------------------------------------------------
+
+    /// A scalar array element `@` (`[0, @]` typed `[i32; 2]`) is accepted: a
+    /// scalar `@` lowers to a single uzumaki opcode and needs no enclosing
+    /// variable.
+    #[test]
+    fn a040_scalar_element_accepted() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [i32; 2] = [0, @];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "a scalar array element `@` in `[0, @]` must not trip A040"
+        );
+    }
+
+    /// The INNER `@` of a 2D array literal (`[[0, @], [1, 2]]` typed
+    /// `[[i32; 2]; 2]`) is a scalar element of the inner array and is accepted.
+    /// This guards that the recursion types inner elements with the scalar leaf
+    /// type, not the array type, so a genuinely scalar `@` is not over-rejected.
+    #[test]
+    fn a040_nested_array_inner_scalar_element_accepted() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [[i32; 2]; 2] = [[0, @], [1, 2]];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "the inner scalar element `@` of `[[0, @], [1, 2]]` must not trip A040"
+        );
+    }
+
+    /// A `bool` array element `@` is accepted: `bool` is scalar.
+    #[test]
+    fn a040_bool_element_accepted() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [bool; 2] = [true, @];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "a bool array element `@` must not trip A040"
+        );
+    }
+
+    /// An `i64` array element `@` is accepted: a 64-bit scalar lowers to the
+    /// i64 uzumaki opcode and needs no enclosing variable.
+    #[test]
+    fn a040_i64_element_accepted() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [i64; 2] = [0, @];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "an i64 array element `@` must not trip A040"
+        );
+    }
+
+    /// An enum-typed array element `@` is accepted: an enum lowers to a single
+    /// scalar uzumaki opcode like any other scalar.
+    #[test]
+    fn a040_enum_element_accepted() {
+        let source = r#"
+            enum Color { Red, Green, Blue }
+            fn main() {
+                forall {
+                    let a: [Color; 2] = [Color::Red, @];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "an enum-typed array element `@` must not trip A040 (enums are scalar-like)"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Accepted: positions A040 does not own
+    // ---------------------------------------------------------------------
+
+    /// Whole-array `let a: [i32; 2] = @;` is not an element position. A040 must
+    /// stay silent here; the `@` is the array value, not an array-literal element.
+    #[test]
+    fn a040_whole_scalar_array_uzumaki_not_flagged() {
+        let source = r#"
+            fn main() {
+                forall {
+                    let a: [i32; 2] = @;
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "whole-array `let a: [i32; 2] = @;` is not an array-element position; A040 must not fire"
+        );
+    }
+
+    /// Whole-array `let a: [Point; 2] = @;` is A028's position (uzumaki on an
+    /// array of structs), not A040's. A040 must stay silent; the `@` is not an
+    /// array-literal element.
+    #[test]
+    fn a040_whole_struct_array_uzumaki_not_flagged() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let a: [Point; 2] = @;
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "whole-array `let a: [Point; 2] = @;` is A028's job, not A040's"
+        );
+    }
+
+    /// A struct-literal field `@` (`Point { x: @ }`) is A038's position, not
+    /// A040's. A040 must stay silent; the `@` is a struct-literal field, not an
+    /// array-literal element.
+    #[test]
+    fn a040_struct_literal_field_uzumaki_not_flagged() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let p: Point = Point { x: @, y: 0 };
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "a struct-literal field `@` is A038's job, not A040's"
+        );
+    }
+
+    /// A compound array-element `@` written OUTSIDE any non-det block must not
+    /// trip A040: the rule is `nondet_depth`-guarded, and A006 (uzumaki outside
+    /// non-det block) owns that position. This proves the gate.
+    #[test]
+    fn a040_compound_element_outside_nondet_block_not_flagged() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                let a: [Point; 2] = [Point { x: 0, y: 0 }, @];
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "a compound array element `@` outside a non-det block is A006's job, not A040's"
+        );
+        let has_a006 = analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .any(|e| matches!(e, AnalysisDiagnostic::UzumakiOutsideNonDetBlock { .. }));
+        assert!(
+            has_a006,
+            "A006 should fire for the element `@` outside a non-det block"
+        );
+    }
+
+    /// An array literal with no `@` element at all (all concrete values) must not
+    /// trip A040, even inside a non-det block.
+    #[test]
+    fn a040_array_literal_without_uzumaki_accepted() {
+        let source = r#"
+            struct Point { x: i32; y: i32; }
+            fn main() {
+                forall {
+                    let a: [Point; 2] = [Point { x: 0, y: 0 }, Point { x: 1, y: 1 }];
+                }
+            }
+        "#;
+        assert!(
+            !has_a040(source),
+            "an array literal with no element `@` must not trip A040"
+        );
+    }
+}

--- a/tests/src/codegen/wasm/base.rs
+++ b/tests/src/codegen/wasm/base.rs
@@ -5891,6 +5891,127 @@ mod base_codegen_tests {
             .unwrap_or_else(|e| panic!("4D array uzumaki WASM is invalid: {e}"));
     }
 
+    // Array-element uzumaki: a scalar `@` element of an array literal (`[0, @]`)
+    // must compile end-to-end (type-check threads the element type onto the `@`,
+    // analysis A040 permits scalar elements, codegen lowers it to a single scalar
+    // uzumaki opcode). These run through `wasm_codegen` (analysis ON), so they
+    // also guard that A040 does not reject the scalar element position.
+
+    #[test]
+    fn array_element_uzumaki_i32_compiles() {
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            pub fn test() {
+                forall {
+                    let a: [i32; 2] = [0, @];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes)
+            .unwrap_or_else(|e| panic!("scalar i32 array-element uzumaki WASM is invalid: {e}"));
+    }
+
+    #[test]
+    fn array_element_uzumaki_i64_compiles() {
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i64, 1);
+        let source = r#"
+            pub fn test() {
+                forall {
+                    let a: [i64; 2] = [0, @];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes)
+            .unwrap_or_else(|e| panic!("scalar i64 array-element uzumaki WASM is invalid: {e}"));
+    }
+
+    #[test]
+    fn array_element_uzumaki_bool_compiles() {
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            pub fn test() {
+                forall {
+                    let a: [bool; 2] = [true, @];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes)
+            .unwrap_or_else(|e| panic!("scalar bool array-element uzumaki WASM is invalid: {e}"));
+    }
+
+    #[test]
+    fn nested_array_inner_element_uzumaki_compiles() {
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            pub fn test() {
+                forall {
+                    let a: [[i32; 2]; 2] = [[0, @], [1, 2]];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes).unwrap_or_else(|e| {
+            panic!("nested-array inner scalar element uzumaki WASM is invalid: {e}")
+        });
+    }
+
+    #[test]
+    fn array_element_uzumaki_in_struct_field_literal_compiles() {
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            struct Holder { arr: [i32; 3]; }
+            pub fn test() {
+                forall {
+                    let h: Holder = Holder { arr: [0, @, 2] };
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes).unwrap_or_else(|e| {
+            panic!("scalar array-element uzumaki in struct field literal WASM is invalid: {e}")
+        });
+    }
+
+    #[test]
+    fn array_element_uzumaki_enum_compiles() {
+        // An enum element is scalar-like: it lowers through the same i32 uzumaki
+        // opcode as a numeric scalar (compiler dispatches `Enum` to the i32 arm),
+        // so an enum array-element `@` must compile, not panic.
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            enum Color { Red, Green, Blue }
+            pub fn test() {
+                forall {
+                    let a: [Color; 2] = [Color::Red, @];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes)
+            .unwrap_or_else(|e| panic!("enum array-element uzumaki WASM is invalid: {e}"));
+    }
+
+    #[test]
+    fn const_array_element_uzumaki_compiles() {
+        // A `const` array initializer reaches a distinct lowering path from a
+        // `let`; its scalar `@` element must compile (it was a latent panic before
+        // the element type was threaded onto the `@` in the const-init path).
+        cov_mark::check_count!(wasm_codegen_emit_uzumaki_i32, 1);
+        let source = r#"
+            pub fn test() {
+                forall {
+                    const A: [i32; 2] = [0, @];
+                }
+            }
+        "#;
+        let wasm_bytes = wasm_codegen(source);
+        inf_wasmparser::validate(&wasm_bytes)
+            .unwrap_or_else(|e| panic!("const scalar array-element uzumaki WASM is invalid: {e}"));
+    }
+
     // nested_struct_with_array tests ---
 
     #[test]


### PR DESCRIPTION
Closes #225

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the three new rules fire only in positions that previously panicked codegen, the type-checker helper is strictly additive (only `@` leaves receive new type info), and the scalar acceptance path is validated end-to-end with WASM output.

All changed paths are additive: new analysis rules that reject previously-panicking patterns, a new type-threading helper that sets type info only on untyped `@` leaves, and no changes to existing rule logic. Each rule is tested with rejected inputs, accepted inputs, boundary tests against sibling rules, and diagnostic-content checks. The codegen tests confirm scalar array-element `@` compiles to valid WASM.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/analysis/src/errors.rs | Adds three new AnalysisDiagnostic variants (A038, A039, A040) with error messages, location extraction, and rule_id mappings; adds unit tests for message content and rule_id. |
| core/analysis/src/rules/uzumaki_on_compound_field.rs | New rule A038: walks struct literals inside nondet blocks and rejects any field initialized with @ whose type is Struct, Array, or Custom (non-enum); field_needs_named_slot predicate is symmetric with A040. |
| core/analysis/src/rules/struct_uzumaki_as_argument.rs | New rule A039: rejects struct-typed @ passed directly as a function argument; intentionally has no nondet_depth guard (like sibling A014), and explicitly excludes arrays (A014's domain) from arg_is_struct_like. |
| core/analysis/src/rules/uzumaki_on_compound_array_element.rs | New rule A040: walks array literals inside nondet blocks and rejects any element that is @ with a Struct, Array, or Custom (non-enum) type; element_needs_named_slot predicate mirrors field_needs_named_slot in A038. |
| core/type-checker/src/type_checker.rs | Adds thread_array_uzumaki_types helper and calls it from four positions (const init, let init, assignment RHS, struct field value) so @ elements in array literals receive their element type before inference — allowing A040 to reject compound ones and codegen to lower scalar ones. |
| tests/src/analysis/rules_a038.rs | 23 integration tests for A038 covering struct-typed fields, array-typed fields, all nondet block kinds, method bodies, const initializers, diagnostic content, and boundary cases. |
| tests/src/analysis/rules_a039.rs | 17 integration tests for A039 covering spec/free-function/method bodies, mixed scalar args, outside-nondet firing, diagnostic content, and boundary cases. |
| tests/src/analysis/rules_a040.rs | 21 integration tests for A040 covering struct/nested-array elements, all nondet block kinds, assignment and const-init paths, diagnostic content, and boundary cases. |
| tests/src/codegen/wasm/base.rs | Adds 6 end-to-end WASM codegen tests confirming scalar @ elements in array literals compile to valid WASM and emit exactly one uzumaki opcode each. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Source with @ (uzumaki)"] --> TC["Type Checker"]
    TC -->|"array literal with @ elements"| TAU["thread_array_uzumaki_types\n(new helper, 4 call sites)"]
    TAU -->|"@ leaf → typed with element type"| ANA["Analysis Phase"]
    TC -->|"other expressions"| ANA

    ANA --> A038{"A038: @ in struct-literal field?\n(nondet_depth > 0)"}
    ANA --> A039{"A039: struct-typed @ as\nfunction argument?"}
    ANA --> A040{"A040: compound-typed @ as\narray-literal element?\n(nondet_depth > 0)"}

    A038 -->|"field type = Struct/Array/Custom(non-enum)"| ERR038["❌ UzumakiOnCompoundField"]
    A038 -->|"field type = scalar/enum"| OK1["✅ Accepted"]

    A039 -->|"arg type = Struct/Custom(non-enum)"| ERR039["❌ StructUzumakiAsArgument"]
    A039 -->|"arg type = scalar/enum (arrays → A014)"| OK2["✅ Accepted"]

    A040 -->|"element type = Struct/Array/Custom(non-enum)"| ERR040["❌ UzumakiOnCompoundArrayElement"]
    A040 -->|"element type = scalar/enum"| CG["✅ Codegen (scalar uzumaki opcode)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Source with @ (uzumaki)"] --> TC["Type Checker"]
    TC -->|"array literal with @ elements"| TAU["thread_array_uzumaki_types\n(new helper, 4 call sites)"]
    TAU -->|"@ leaf → typed with element type"| ANA["Analysis Phase"]
    TC -->|"other expressions"| ANA

    ANA --> A038{"A038: @ in struct-literal field?\n(nondet_depth > 0)"}
    ANA --> A039{"A039: struct-typed @ as\nfunction argument?"}
    ANA --> A040{"A040: compound-typed @ as\narray-literal element?\n(nondet_depth > 0)"}

    A038 -->|"field type = Struct/Array/Custom(non-enum)"| ERR038["❌ UzumakiOnCompoundField"]
    A038 -->|"field type = scalar/enum"| OK1["✅ Accepted"]

    A039 -->|"arg type = Struct/Custom(non-enum)"| ERR039["❌ StructUzumakiAsArgument"]
    A039 -->|"arg type = scalar/enum (arrays → A014)"| OK2["✅ Accepted"]

    A040 -->|"element type = Struct/Array/Custom(non-enum)"| ERR040["❌ UzumakiOnCompoundArrayElement"]
    A040 -->|"element type = scalar/enum"| CG["✅ Codegen (scalar uzumaki opcode)"]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["add a test"](https://github.com/inferara/inference/commit/a85fe78deabf63f1c904b404a20c9ae208db4350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38619161)</sub>

<!-- /greptile_comment -->