### PR TITLE
Update book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,7 +10,13 @@
 - [Arithmetic Overflow in WASM Codegen](arithmetic-overflow-in-wasm-codegen.md)
 - [Unreachable Emission in Codegen](unreachable-emission-in-codegen.md)
 - [Compilation Targets](compilation_targets.md)
+
+# Projects & Tooling
+
+- [Module Hierarchy & Multi-File Compilation](module-hierarchy-and-multi-file-compilation.md)
+- [Projects & the infs Toolchain](projects-and-the-infs-toolchain.md)
 - [External Functions and WASM Linking](external-functions-and-wasm-linking.md)
+- [The WASM Linker](the-wasm-linker.md)
 
 # Appendix
 

--- a/book/src/compilation_targets.md
+++ b/book/src/compilation_targets.md
@@ -25,6 +25,8 @@ The contract between the generated `.wasm` binary, the per-spec function index m
 
 Pass `--mode {compile,proof}` to either CLI: `infs build path/to/file.inf --mode proof` or `infc path/to/file.inf --mode proof`. Equivalently, `infc -v` (emit Rocq) implies `--mode proof` unless `--mode compile` is also passed; mirror-rule: `--mode proof` implies `-v`. Without either flag, the default is compile mode.
 
+For project-aware builds — `Inference.toml`, project discovery, and the `infs build`/`run` workflow that resolves a mode from the manifest — see [Projects and the infs Toolchain](projects-and-the-infs-toolchain.md).
+
 | Property | Value | Rationale |
 |----------|-------|-----------|
 | Spec function optimization | `-O0` + `optnone` + `noinline` | 1:1 structural correspondence for Rocq translation |
@@ -52,6 +54,8 @@ In the linking scenario, a user:
 6. The user writes Rocq proofs establishing properties about the external function's behavior
 
 The external artifact remains as-is (potentially fully optimized). The `spec` code requires structural identity for Rocq readability. Execution code — whether from Inference source or external modules — is compiled at the target's default release optimization so that Rocq proofs cover the actual deployed artifact. Only spec functions receive `optnone`+`noinline` barriers; execution functions are optimized normally.
+
+The language-level constructs that import external functions (`external fn`, `use … from`) are documented in [External Functions and WASM Linking](external-functions-and-wasm-linking.md); the static merge that folds them into the verified artifact — feasibility tiers and the Tier-B provenance proof — in [The WASM Linker](the-wasm-linker.md).
 
 ## Targets
 

--- a/book/src/external-functions-and-wasm-linking.md
+++ b/book/src/external-functions-and-wasm-linking.md
@@ -124,6 +124,10 @@ After linking:
 - The unified module passes validation and flows into `wasm-to-v` as an ordinary
   module whose merged functions translate to Rocq `Definition`s.
 
+For the merge algorithm itself — transitive-closure computation, index re-encoding,
+the Tier-B provenance proof, and the full link-error taxonomy — see
+[The WASM Linker](the-wasm-linker.md).
+
 ## Memory-Merge Feasibility
 
 Not all external functions can be merged. The linker classifies each closure:
@@ -176,6 +180,8 @@ of each export, and merges the bodies into a single output module.
 
 ## Related Resources
 
+- [The WASM Linker](the-wasm-linker.md) — the subsystem deep-dive: merge algorithm, feasibility tiers, the Tier-B provenance proof, and the link-error taxonomy
+- [Projects and the infs Toolchain](projects-and-the-infs-toolchain.md) — declaring external `.wasm` modules in `Inference.toml` under `[wasm-dependencies]`
 - `core/wasm-linker/README.md` — the merge algorithm, tier classification, and entry point API
 - `core/wasm-codegen/docs/function-calls-lowering.md` — three-stage index pre-scan and import section emission
 - `core/type-checker` — `ExternOrigin`, `extern_origins()`, and the `A024 ExternFunctionCall` analysis rule

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -35,6 +35,20 @@ The chapters follow that order:
 - **[Compilation Targets](compilation_targets.md)** — compile vs. proof modes and
   the supported backends.
 
+A second group of chapters covers how programs are organised and built beyond a
+single source file:
+
+- **[Module Hierarchy & Multi-File Compilation](module-hierarchy-and-multi-file-compilation.md)**
+  — the file-as-module system, the `use` directive, and how a multi-file program
+  flattens into one WASM module and one proof.
+- **[Projects & the infs Toolchain](projects-and-the-infs-toolchain.md)** — the
+  `Inference.toml` manifest, project discovery, and the `infs build`/`run` workflow
+  that drives the compiler.
+- **[External Functions and WASM Linking](external-functions-and-wasm-linking.md)**
+  — declaring `external fn`s and binding them to pre-compiled `.wasm` modules.
+- **[The WASM Linker](the-wasm-linker.md)** — the static merge that folds external
+  function bodies into a single self-contained module.
+
 The appendix preserves historical notes from the project's earlier LLVM-based
 backend, retained for reference.
 

--- a/book/src/module-hierarchy-and-multi-file-compilation.md
+++ b/book/src/module-hierarchy-and-multi-file-compilation.md
@@ -1,0 +1,446 @@
+# Module Hierarchy & Multi-File Compilation
+
+This chapter explains how Inference distributes source code across multiple `.inf` files
+and flattens the whole program into a single self-contained WebAssembly module and a
+single Rocq `.v` file. It covers the file-as-module model, the two forms of the `use`
+directive, the import-closure walk, cross-file type identity, WASM function naming, and
+the implications for formal verification.
+
+## Why Multiple Files?
+
+A language that restricts all code to a single file does not scale to real programs. As a
+codebase grows, a single-file constraint forces either monolithic structures or custom
+tooling to concatenate sources before compilation — neither is acceptable.
+
+At the same time, Inference has a hard constraint inherited from its verification
+architecture: the Rocq output must be **one self-contained `.v` file**. The proof
+assistant reasons about the whole program simultaneously; splitting the proof into separate
+modules would require constructing cross-module proof obligations, a significant increase in
+complexity for proof authors. The same argument applies to the WebAssembly side: a
+self-contained `.wasm` with no outstanding imports is simpler to verify and deploy than a
+bundle of linked modules.
+
+The design goal is therefore: **code organisation without losing whole-program compilation
+or verification.** Multiple source files map to one output module.
+
+## File-Based Modules
+
+Each `.inf` file is a module. The module tree mirrors the directory tree under the source
+root. The source root is the directory that contains the entry file — the file named on the
+`infc` or `infs` command line.
+
+The module's **canonical path** is the list of path segments from the source root to the
+file, without the `.inf` extension:
+
+```text
+source root: src/
+
+  src/main.inf        →  module path: []          (the entry; empty)
+  src/util.inf        →  module path: ["util"]
+  src/lib/arith.inf   →  module path: ["lib", "arith"]
+  src/lib/geo.inf     →  module path: ["lib", "geo"]
+```
+
+The entry file always has the empty path. Its items keep unqualified names throughout
+the compilation pipeline, so a single-file program produces byte-identical output to a
+multi-file one where the entire code lives in the entry file.
+
+## The Two Forms of `use`
+
+The `use` directive has two syntactically distinct forms. They are easy to confuse but serve
+entirely different purposes.
+
+### Path-form `use` — source imports
+
+The path form names a sibling `.inf` file to include in the compilation:
+
+```inference
+use util;
+use lib::arith;
+use lib::geo::{Point};
+```
+
+- `use util;` makes the file `<root>/util.inf` part of the compilation. Items in that file
+  are accessed as `util::helper()`.
+- `use lib::arith;` names `<root>/lib/arith.inf`. Items are accessed as
+  `lib::arith::add(1, 2)`.
+- `use lib::geo::{Point};` names the same file `<root>/lib/geo.inf` as the brace-free
+  form. The braces select which items are accessible without the full path, but the file
+  imported is identical: a braced item import and its brace-free equivalent are both resolved
+  to the same file and both pull that file into the compilation closure.
+
+`use root;` is a reserved handle that refers to the entry file itself; a literal
+`src/root.inf` on disk is shadowed by the reserved name.
+
+Glob imports (`use lib::arith::*;`) are not supported and produce a diagnostic.
+
+### From-form `use` — external WASM imports
+
+The from form binds an `external fn` declaration to a pre-compiled `.wasm` library:
+
+```inference
+external fn sort(ptr: i32, len: i32);
+use { sort } from collections;
+```
+
+This form is **not** a source import. It names a logical WASM module identifier, not a
+file path. The compiler-time front end (`core/inference/src/project.rs`) skips it entirely
+when walking the import closure. The from form is resolved at link time by
+`inference-wasm-linker`.
+
+The distinction is crisp: if the directive contains `from`, it is an external WASM binding;
+otherwise it is a source file import. The two forms do not interact, and mixing them in one
+file is valid:
+
+```inference
+use lib::arith::{add};          // source import: lib/arith.inf
+use { sort } from collections;  // external WASM: resolved at link time
+```
+
+The from form is documented in detail in
+[External Functions and WASM Linking](external-functions-and-wasm-linking.md) and
+[The WASM Linker](the-wasm-linker.md).
+
+## Qualified Access with `::`
+
+Items from an imported file are accessed through the `::` path operator. The path is the
+module's canonical path with `::` as the separator:
+
+```inference
+use util;
+use lib::arith;
+use lib::geo::{Point};
+
+pub fn run() -> i32 {
+    let p: Point = Point::at(8);  // constructor from lib::geo
+    return util::helper();        // free function from util
+}
+```
+
+The `math::arith::add(1, 2)` form works transitively through re-exports (see
+[Re-exports](#re-exports) below).
+
+When `use lib::geo::{Point};` brings a name into scope without a path prefix, the type name
+is available unqualified, but the calling convention stays the same:
+
+```inference
+use lib::geo::{Point};
+
+pub fn run() -> i32 {
+    let p: Point = Point::at(8);  // `Point` unqualified; `Point::at` still uses `::`
+    return p.dist();
+}
+```
+
+The fixture in `tests/test_data/codegen/wasm/multi_file_golden/method_mangling/src/`
+demonstrates this pattern: `main.inf` imports `{Point}` from `lib::geo` and calls
+`Point::at(8)` and `p.dist()`.
+
+## Visibility
+
+Items are **private by default**. The `pub` keyword makes an item accessible from other
+files:
+
+```inference
+// lib/arith.inf — private fn is invisible outside this file
+fn internal_helper(x: i32) -> i32 { return x * 2; }
+
+// pub fn is accessible as lib::arith::add
+pub fn add(a: i32, b: i32) -> i32 { return a + b; }
+
+// pub struct is accessible as lib::arith::Point
+pub struct Point {
+    x: i32;    // fields inherit the struct's visibility; no per-field modifier
+    y: i32;
+}
+```
+
+Visibility rules:
+
+- A file's own private items are visible everywhere within that file.
+- Cross-file access requires `pub`.
+- Struct fields inherit the struct's visibility. There is no per-field `pub` modifier.
+- `external fn` declarations are always file-local; they cannot be re-exported or accessed
+  from other files.
+- Spec blocks see their own file's private items, but when a spec in file A references a
+  type or function from file B, only `pub` items in B are in scope.
+- **WASM exports**: only `pub fn`s defined in the entry file are exported from the generated
+  WASM module. A `pub fn` in an imported file has intra-project visibility — the function is
+  compiled and callable within the program, but it does not appear in the WASM export
+  section. This keeps the module's public ABI explicitly controlled.
+
+## Re-exports
+
+A `pub use` directive re-exports a module path, making it accessible through the
+re-exporting file's namespace:
+
+```inference
+// math.inf
+pub use lib::arith;
+```
+
+Callers that import `math` can then reach `lib::arith`'s items through the `math` namespace:
+
+```inference
+// main.inf
+use math;
+
+pub fn run() -> i32 {
+    return math::arith::add(1, 2);
+}
+```
+
+The fixture in `tests/test_data/codegen/wasm/multi_file_golden/re_export_chain/src/`
+demonstrates this: `math.inf` re-exports `lib::arith` with `pub use lib::arith;`, and
+`main.inf` calls `math::arith::add(1, 2)`.
+
+Re-exports also drive the import closure: if `math.inf` carries `pub use lib::arith;`, the
+compiler includes `lib/arith.inf` in the compilation even though `main.inf` names only
+`math`. Both `pub use` and plain `use` pull the named file into the closure; visibility
+affects name accessibility, not discovery.
+
+Re-export chains can be arbitrarily deep. Circular re-exports between files are permitted
+and terminate correctly (see [Import-Closure Walk](#import-closure-walk) below).
+
+## Cross-File Type Identity
+
+Two different files may each define a struct or enum with the same bare name:
+
+```inference
+// main.inf
+pub struct Pair {
+    a: i32;
+    b: i32;
+}
+
+// lib/shapes.inf
+pub struct Pair {
+    a: i64;
+    b: i32;
+}
+```
+
+These are **distinct types**. The type checker keys each type by its **canonical type key** —
+the `::` path of its defining file prefixed onto the bare name:
+
+```text
+Pair  defined in the entry file → canonical key:  "Pair"
+Pair  defined in lib/shapes.inf → canonical key:  "lib::shapes::Pair"
+```
+
+This key is computed from the type's defining scope (not the call site's scope) and threads
+consistently through every phase: the type checker uses it for identity comparisons and
+layout lookups; codegen uses the same derivation to key memory layout and frame-slot
+allocations. Two files may therefore define identically-named structs with completely
+different field layouts, and the compiler keeps them distinct without any source-level
+disambiguation.
+
+The fixture in `tests/test_data/codegen/wasm/multi_file_golden/dup_struct/src/` exercises
+this: both `main.inf` and `lib/shapes.inf` define `struct Pair`, but with different field
+types. The codegen produces correct, separate frame layouts for each, and the type checker
+rejects any attempt to use one where the other is expected.
+
+## Import-Closure Walk
+
+The compiler resolves the full set of files to compile through a **breadth-first walk** from
+the entry file. This walk is implemented in `core/inference/src/project.rs`.
+
+The algorithm:
+
+1. Start with the entry file (module path `[]`) in the visited set and in the work queue.
+2. Parse the front of the queue.
+3. Extract all path-form `use` directives (from-form `use` directives are skipped).
+4. For each named module path not already in the visited set, compute the corresponding
+   filesystem path (`<root>/a/b.inf` for `["a", "b"]`), verify the file exists, add it to
+   the visited set, and enqueue it.
+5. Repeat until the queue is empty.
+
+Properties of the walk:
+
+- **Import cycles terminate.** The visited set is keyed by canonical module path, so a file
+  reached by two different import chains is parsed once. A file that imports itself, or
+  two files that import each other, is handled correctly.
+- **All paths are src-root-relative.** A `use lib::arith;` directive written inside
+  `deep/inner.inf` resolves to `<root>/lib/arith.inf`, not to `<root>/deep/lib/arith.inf`.
+  All imports are relative to the one shared source root, not to the importer's location.
+- **Unreachable files warn.** After the walk, the compiler scans every `.inf` file under the
+  source root and emits a `ProjectWarning::UnreachableFile` for each file not reached by any
+  import chain. The build still succeeds; the warning is advisory.
+
+After discovery, the files are lowered into a single `AstArena` in **canonical order**:
+the entry file first, then all imported files sorted lexicographically by module path. This
+ordering is independent of discovery order (which is BFS and depends on the order `use`
+directives appear in source). A project with the same files and the same code produces the
+same canonical order regardless of which `use` comes first in any given file.
+
+```text
+entry: []
+imports (lexicographic):
+  ["lib", "arith"]
+  ["lib", "geo"]
+  ["math"]
+  ["util"]
+```
+
+## WASM Codegen and Function Naming
+
+All reachable files are flattened into **one WASM module**. The `FnKey` abstraction
+(`core/fn-key/src/lib.rs`) provides a structured identity for every function across the
+whole program, used by both codegen (to assign WASM function indices) and analysis (to build
+the call graph). The four variants of `FnKey` are:
+
+| Variant | Identifies |
+|---------|------------|
+| `Free` | A top-level free function with its defining file's module path |
+| `Method` | A struct method or associated function with its struct's defining file |
+| `SpecFree` | A spec-inner free function |
+| `SpecMethod` | A spec-inner method |
+
+Every variant carries the `module_path` of the **defining** file. This is what keeps two
+`fn add` functions in two different files as distinct internal keys.
+
+The function names written into the WASM name section (and visible in `.wat` output) use the
+bare function name (or `StructName.method_name` for methods), not a file-prefixed form.
+When two functions share a bare name across files, the WAT renderer deduplicates them with a
+numbered suffix like `#func2 there_b`. The `FnKey` dot-qualified string (`lib.arith.add`) is
+an internal key used for function-index lookup — it does not appear verbatim in the binary's
+name section.
+
+WASM exports are controlled by the entry file and by visibility. The rule:
+
+- Only a `pub fn` defined **in the entry file** becomes a WASM export.
+- A `pub fn` in an imported file is compiled and callable within the program, but is **not**
+  exported from the WASM module.
+- Methods and spec-inner functions are never exported.
+
+This makes the module's external ABI explicit: whatever the entry file declares `pub` is the
+interface; imported library code is internal.
+
+```wat
+;; root_only_export example: lib::arith::add is compiled but not exported
+(module $output
+  (export "run" (func $run))   ;; only the entry-file pub fn is exported
+  (func $run ...)
+  (func $add ...)              ;; add is compiled but unexported
+)
+```
+
+## Specs in Multi-File Proofs
+
+Spec blocks carry their own names in the Rocq output. When a spec is defined in a non-entry
+file, its name is file-qualified by joining the module path with underscores, then
+prepending to the bare spec name. This is done by the `fold_spec_name` function
+(`core/fn-key/src/lib.rs`):
+
+```text
+module path: ["lib", "checks"]
+spec name: "LibSpec"
+folded name: "lib_checks_LibSpec"
+```
+
+The entry file's specs keep their bare names (the empty module path folds to nothing).
+
+The fold uses underscores rather than dots because the result must be a legal Rocq
+identifier. The fold is intentionally non-injective: the paths `["lib", "checks"]` and
+`["lib_checks"]` both fold to the same prefix `lib_checks`. The `FnKey` type keeps the
+module path and the bare spec name structurally separate (not pre-folded) to preserve
+injectivity as an *internal key*; the fold is applied only at rendering time.
+
+The fixture in `tests/test_data/codegen/wasm/multi_file_golden/proof_specs/src/`
+illustrates this:
+
+```inference
+// lib/checks.inf
+spec LibSpec {
+    fn obligation() -> i32 {
+        return 2;
+    }
+}
+```
+
+```inference
+// main.inf
+use lib::checks;
+
+spec EntrySpec {
+    fn obligation() -> i32 {
+        return 1;
+    }
+}
+```
+
+`EntrySpec` (entry file, empty path) keeps its name in the Rocq output; `LibSpec` (defined
+in `lib/checks.inf`) is rendered as `lib_checks_LibSpec`.
+
+A file-qualified spec name must remain a valid Rocq identifier after folding. In particular,
+a file stem or spec name that contains a `__` run, or begins or ends with `_`, can produce a
+name that conflicts with Rocq's reserved `<module>__<spec>` separator in the emitted proof
+grammar. Codegen detects this and reports a `CodegenError::SpecNameReservesSeparator` with a
+rename suggestion before emitting any output. This restriction applies to spec names in proof
+mode; it is not a restriction on file names used by import directives.
+
+## Current Limitations
+
+- **No import aliasing.** `use lib::arith as ar;` is not supported. The module must be
+  accessed through its canonical path.
+- **No per-field visibility.** Struct fields inherit the struct's `pub` or private
+  visibility. There is no `pub` modifier on individual fields.
+- **Circular const/type-alias value initialization is an error.** Import cycles between
+  files are legal and handled correctly, but circular *value* initialization — a constant
+  whose value depends (through a chain of constants or type aliases) on itself — is rejected
+  with a `CircularDefinition` error.
+- **Bare `infc src/main.inf` treats `src/` as the source root.** In this mode, sibling
+  `.inf` files under `src/` that are not reachable from `main.inf` produce unreachable
+  warnings. The `infs` project toolchain (see
+  [Projects and the infs Toolchain](projects-and-the-infs-toolchain.md)) handles
+  project-level discovery and build coordination.
+
+## Comparison with Other Languages
+
+| Property | Rust | Zig | Inference |
+|---|---|---|---|
+| Module granularity | Declared with `mod`; file maps to module only when named by `mod file;` | Each file is a struct; imported with `@import("path.zig")` | Each `.inf` file is a module; imported with `use path;` |
+| Import cycles | Rejected at compile time | Allowed | Allowed; terminated via visited set |
+| Canonical order | Declaration order within `mod` | Import order | Entry-first, then lexicographic by module path |
+| Output granularity | One crate = one `.rlib` or binary | Configurable | One project = one `.wasm` + one `.v` |
+| Re-exports | `pub use module::item` | Return the imported struct | `pub use module::path` |
+| Visibility | `pub`, `pub(crate)`, `pub(super)`, private | `pub` or private | `pub` or private; no `pub(super)` |
+
+The Inference model is closer to Zig than to Rust: files are modules implicitly, without
+explicit `mod` declarations, and import cycles are allowed. Inference differs from both in
+that all files flatten into one compilation unit; there is no concept of separate crates or
+build artifacts for sub-libraries within a project.
+
+## Formal Implications
+
+The whole-program flattening has a direct consequence for formal verification: **every
+function the proof references is defined in the same `.v` file.** There are no cross-module
+lemma imports, no proof namespace hierarchies, and no linker-time proof composition. A proof
+obligation on `main::run` can refer directly to `lib::arith::add`'s definition without any
+module-qualification syntax in the Rocq source.
+
+The canonical per-file type identity ensures soundness across the flattening: two
+same-named structs from two different files carry distinct canonical keys through the
+type-checker, layout computation, and codegen. A Rocq proof that reasons about one struct
+cannot inadvertently apply to the other, because the generated `.v` definitions carry
+different names derived from the canonical keys.
+
+## Related Resources
+
+- `core/inference/src/project.rs` — `parse_project`, `discover_files`, import-closure walk,
+  `collect_unreachable_warnings`
+- `core/fn-key/src/lib.rs` — `FnKey` variants, `fold_spec_name`, `qualify_dotted`
+- `core/type-checker/src/symbol_table.rs` — `canonical_key_for_scope`,
+  `file_module_path_of_scope`
+- `core/ast/src/nodes.rs` — `Visibility`, `UseDirective`
+- `tests/test_data/codegen/wasm/multi_file_golden/` — golden fixture files for all
+  multi-file scenarios: `two_file`, `item_import`, `method_mangling`, `re_export_chain`,
+  `dup_struct`, `cross_file_struct`, `proof_specs`, `root_only_export`
+- [External Functions and WASM Linking](external-functions-and-wasm-linking.md) — the from
+  form of `use`, external WASM binding, and the link step
+- [The WASM Linker](the-wasm-linker.md) — merge algorithm for pre-compiled `.wasm`
+  dependencies
+- [Projects and the infs Toolchain](projects-and-the-infs-toolchain.md) — project-aware
+  build and the `infs` CLI
+- [Compilation Targets](compilation_targets.md) — compile vs. proof modes and the supported
+  backends

--- a/book/src/projects-and-the-infs-toolchain.md
+++ b/book/src/projects-and-the-infs-toolchain.md
@@ -1,0 +1,389 @@
+# Projects & the infs Toolchain
+
+## Motivation
+
+`infc` is a single-file compiler. Given one `.inf` source file it parses,
+type-checks, analyses, and emits a WASM binary. That model is fine for
+self-contained examples, but real codebases need more: a place to declare
+external `.wasm` dependencies, a way to express whether a build is meant to
+produce an executable or a Rocq proof, and a project root that tools can agree
+on so artifacts land in predictable locations.
+
+`infs` is the unified toolchain entry point that provides all of this. It
+discovers a project, reads its manifest, resolves the configuration, and spawns
+`infc` with the right arguments and working directory. The split is deliberate:
+`infc` stays a pure compiler that knows nothing about project structure; `infs`
+is the orchestrator that wraps it.
+
+## Project Layout
+
+`infs new myproject` scaffolds the following structure:
+
+```text
+myproject/
++-- Inference.toml       # manifest
++-- src/
+|   +-- main.inf         # entry point (project mode always compiles this)
++-- out/                 # created by the first build (gitignored)
+|   +-- main.wasm
++-- tests/
+|   +-- .gitkeep
++-- proofs/              # proof-mode artifacts land here by default
+|   +-- .gitkeep
++-- .gitignore
+```
+
+The layout mirrors Cargo's conventions: manifest at the root, sources under
+`src/`, build outputs under `out/`. The `out/` directory is not committed; it
+is created automatically by `infc` (relative to its working directory, which
+`infs` sets to the project root). `proofs/` is tracked via `.gitkeep` so that
+curated hand-authored proof sources stay in version control even when generated
+`.wasm`/`.v` artifacts are gitignored by extension.
+
+## The Manifest (`Inference.toml`)
+
+`Inference.toml` is the project manifest. Only `[package]` is required;
+all other sections default if absent.
+
+```toml
+[package]
+name = "myproject"
+version = "0.1.0"
+infc_version = "0.1.0"
+
+# Optional package fields:
+# description = "A brief description"
+# authors = ["Name <email@example.com>"]
+# license = "MIT"
+
+[build]
+# "compile" (default) or "proof"
+mode = "compile"
+# target and optimize are recognized but not yet consumed.
+
+[verification]
+# Output directory for proof artifacts (honored only in proof mode).
+# Defaults to "proofs/" if this section is omitted.
+# output-dir = "proofs/"
+
+[wasm-dependencies]
+# Logical module name -> compiled .wasm, resolved relative to this file.
+arith = { path = "libs/arith.wasm" }
+```
+
+The fields:
+
+| Field | Section | Type | Default | Description |
+|-------|---------|------|---------|-------------|
+| `name` | `[package]` | string | — | Project name; see name rules below |
+| `version` | `[package]` | string | — | Semver project version |
+| `infc_version` | `[package]` | string | detected | `infc` version used when scaffolding |
+| `description` | `[package]` | string | absent | Optional description |
+| `authors` | `[package]` | array | absent | Optional author list |
+| `license` | `[package]` | string | absent | Optional SPDX identifier |
+| `mode` | `[build]` | `"compile"` \| `"proof"` | `"compile"` | Build mode (see below) |
+| `output-dir` | `[verification]` | path string | `"proofs/"` | Proof artifact directory; proof mode only |
+| `<name>` | `[wasm-dependencies]` | `{ path = "…" }` | — | External `.wasm` module dependency |
+
+`mode` is case-sensitive: `"Proof"` is rejected. The field is validated on
+load; an invalid value is an immediate error with the allowed set named in the
+message.
+
+### Reserved Project Names
+
+Project names must start with a letter or underscore and contain only
+alphanumeric characters, underscores, or hyphens. Names that match Inference
+language keywords or conventional directory names are reserved and rejected
+(case-insensitively). The reserved set includes: `fn`, `let`, `mut`, `if`,
+`else`, `match`, `return`, `type`, `struct`, `impl`, `trait`, `pub`, `use`,
+`mod`, `ndet`, `assume`, `assert`, `forall`, `exists`, `spec`, `requires`,
+`ensures`, `invariant`, `const`, `enum`, `loop`, `break`, `continue`,
+`external`, `unique`; and the directory names `src`, `out`, `target`,
+`proofs`, `tests`, `self`, `super`, `crate`.
+
+### Real Manifest Examples
+
+From `scratch/raytracing-in-one-weekend/Inference.toml` (single WASM
+dependency):
+
+```toml
+[package]
+name = "raytracing-in-one-weekend"
+version = "0.1.0"
+infc_version = "0.1.0"
+
+[wasm-dependencies]
+fixmath = { path = "libs/fixmath.wasm" }
+```
+
+From `scratch/linker-e2e/Inference.toml` (multiple dependencies):
+
+```toml
+[package]
+name = "linker-e2e"
+version = "0.1.0"
+infc_version = "0.1.0"
+
+[wasm-dependencies]
+arith = { path = "libs/arith.wasm" }
+memlib = { path = "libs/memlib.wasm" }
+sortlib = { path = "libs/sortlib.wasm" }
+```
+
+Neither example sets `[build]` or `[verification]` — those sections are omitted
+when all values are at their defaults.
+
+## Project Discovery
+
+When `infs build` or `infs run` receives no path argument, it walks **up** the
+directory tree from the current working directory looking for `Inference.toml`.
+The nearest ancestor containing the file wins — the same convention Cargo uses,
+so a nested project's manifest shadows an outer one. The walk stops at the
+filesystem root; if no manifest is found, the command errors with a remediation
+message naming `infs new` and `infs init`.
+
+After discovery, `infc` is spawned with its **working directory set to the
+project root**. This means `out/` always lands at the root regardless of where
+the command was invoked from inside the project tree, and all source-relative
+paths in `.inf` files resolve from the same stable base.
+
+```text
+~/projects/myproject/src/utils/
+$ infs build           # walks up, finds ~/projects/myproject/Inference.toml
+                       # infc CWD = ~/projects/myproject/
+                       # artifact  = ~/projects/myproject/out/main.wasm
+```
+
+## `infs build`
+
+`infs build` has two modes of operation:
+
+```bash
+infs build                           # project mode: discovers Inference.toml, compiles src/main.inf
+infs build path/to/file.inf          # single-file mode: compiles that file directly
+```
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `-v` | Generate Rocq `.v` translation in addition to `.wasm` |
+| `--mode {compile,proof}` | Override compilation mode |
+| `-L <DIR>` / `--wasm-lib-dir <DIR>` | Add a directory to search for external `.wasm` modules; repeatable |
+
+**Mode resolution** (precedence, highest first):
+
+1. CLI `--mode` when present.
+2. Manifest `[build] mode = "proof"` — forwards `--mode proof` to `infc`.
+3. Manifest `[build] mode = "compile"` (explicit or defaulted) — forwards
+   **nothing**, leaving `infc`'s own `-v` ↔ proof implication intact.
+
+The rule about forwarding nothing for compile mode is deliberate: `infc`'s
+`normalize_args` function owns the `-v` ↔ `--mode proof` implication as its
+single source of truth. If `infs` also forwarded `--mode compile` it would
+suppress that implication for users who pass only `-v`, turning a spec-aware
+proof build into a spec-stripped one.
+
+**`--out-dir` and `[verification] output-dir`**: in effective proof mode (CLI
+`--mode proof` or manifest `mode = "proof"`), `infs` reads `[verification]
+output-dir` (defaulting to `proofs/`), normalizes it to a project-relative
+path, and forwards it to `infc` as `--out-dir`. This relocates both `.wasm`
+and `.v` artifacts to that directory. In compile mode, `[verification]
+output-dir` is ignored entirely — the compile artifact must always land under
+`out/`.
+
+Forwarding `--out-dir` requires `infc` ABI ≥ 1.1 (see [Relationship to
+`infc`](#relationship-to-infc) below). Using a non-default `output-dir` with
+an older `infc` is a hard error with remediation.
+
+### Artifacts per Mode
+
+| Mode | `-v` | `.wasm` location | `.v` location |
+|------|------|-----------------|--------------|
+| compile | no | `out/` | — |
+| compile | yes | `out/` | `out/` |
+| proof | (implied) | `[verification] output-dir` | `[verification] output-dir` |
+
+In single-file mode (`infs build path/to/file.inf`) the output always goes to
+`out/` relative to `infc`'s inherited CWD (the invoking shell's current
+directory), with no manifest `output-dir` forwarded.
+
+## `infs run`
+
+`infs run` builds and then executes the resulting WASM via wasmtime:
+
+```bash
+infs run                                 # project mode: build + invoke main
+infs run program.inf                     # single-file: compile and invoke main
+infs run program.inf --entry-point helper  # single-file: invoke helper()
+```
+
+In **project mode** (no path given):
+
+- Always builds in compile mode, regardless of `[build] mode` in the manifest.
+  Proof-mode WASM embeds custom non-deterministic opcodes (`0xfc` family) that
+  wasmtime cannot execute.
+- Always invokes `main`. Passing `--entry-point` to anything other than `main`
+  is rejected with guidance to use single-file mode instead.
+- Checks wasmtime availability before starting the build, failing fast if the
+  runtime is absent.
+- `out/main.wasm` is the expected artifact; if the build succeeds but the file
+  is absent, `run` errors before invoking wasmtime.
+
+In **single-file mode** (path given), `--entry-point` (default `main`) selects
+which exported function to invoke. `main` is called with `argc=0, argv=0`
+automatically; other functions receive the trailing arguments from the command
+line.
+
+Both modes require `wasmtime` in `PATH`. Installation instructions are printed
+when it is not found.
+
+## Scaffolding
+
+`infs new <name>` creates a new project directory with the layout shown above
+and optionally initializes a git repository (pass `--no-git` to skip).
+
+`infs init [name]` initializes the current directory as a project — it writes
+`Inference.toml` and `src/main.inf` without creating a new parent directory.
+The name defaults to the current directory's name. If `.git/` is present,
+`infs init` also creates `.gitignore` and `.gitkeep` files without overwriting
+anything that already exists.
+
+Both commands scaffold `src/main.inf` with a minimal entry point:
+
+```inference
+// Entry point for the Inference program
+
+pub fn main() -> i32 {
+    return 0;
+}
+```
+
+## Relationship to `infc`
+
+`infs` is a thin orchestrator. It does not link, parse, or type-check anything
+itself — all of that is `infc`'s responsibility. The relationship:
+
+```text
+infs build
+    |
+    +-- discover_and_load(Inference.toml)
+    |
+    +-- find_infc()          # INFC_PATH > system PATH > managed toolchain
+    |
+    +-- compatibility handshake
+    |       infc --commit-hash    # short-circuit: same-build binaries always compatible
+    |       infc --abi-version    # major mismatch → hard error; minor mismatch → warning
+    |
+    +-- spawn infc
+            CWD = <project root>
+            arg: src/main.inf
+            arg: --mode proof           (if effective proof mode)
+            arg: -v                     (if .v requested)
+            arg: --out-dir <dir>        (if effective proof mode + ABI ≥ 1.1)
+            arg: --wasm-dep name=path   (one per [wasm-dependencies] entry)
+            arg: -L <dir>               (repeated for each --wasm-lib-dir)
+```
+
+**`infc` flags** confirmed against `core/cli/src/parser.rs`:
+
+| Flag | Description |
+|------|-------------|
+| `--parse` | Run only the parse phase |
+| `--analyze` | Run parse + analyze phases |
+| `--codegen` | Run parse + analyze + codegen; no output without `-o` or `-v` |
+| `-o` | Write `.wasm` binary to output directory |
+| `-v` | Write Rocq `.v` translation; implies full pipeline and, without explicit `--mode`, implies `--mode proof` |
+| `--mode {compile,proof}` | Select compilation mode |
+| `--out-dir <path>` | Override output directory (default `out/` relative to CWD); both `.wasm` and `.v` land here |
+| `-L <dir>` / `--wasm-lib-dir <dir>` | Add external `.wasm` search directory; repeatable |
+| `--wasm-dep <name>=<path>` | Bind a logical module name directly to a `.wasm` file; takes precedence over `-L` |
+| `--commit-hash` | Print the build commit hash and exit; used by the `infs` handshake |
+| `--abi-version` | Print `<major>.<minor>` ABI version and exit; used by the `infs` handshake |
+| `--abi-version` output | Currently `1.1` |
+
+The default behavior when no phase flag is supplied is full compilation with
+WASM output written to disk — equivalent to `--codegen -o`.
+
+### ABI Versioning and the `--out-dir` Gate
+
+`infs` and `infc` communicate their compatibility through two probes run before
+every project build. First, `infc --commit-hash` is compared with `infs`'s
+build commit: a match means the two binaries came from the same tree and are
+guaranteed compatible, skipping further checks. Otherwise, `infc --abi-version`
+is parsed as `<major>.<minor>`:
+
+- **Major mismatch**: hard error with remediation (rebuild or set `INFC_PATH`).
+- **Minor mismatch**: warning only; compilation proceeds.
+- **Unknown/old** (`infc` exits non-zero or prints `unknown`): silent; treated
+  as graceful skip, equivalent to ABI unknown.
+
+The current ABI is `1.1` (`COMPILER_ABI_MAJOR = 1`, `COMPILER_ABI_MINOR = 1`
+in `core/compiler-interface/src/lib.rs`). The `--out-dir` flag was introduced
+at minor 1. `infs` gates its use: `--out-dir` is forwarded only to an `infc`
+that reports ABI minor ≥ 1 (or matches by commit hash). Pairing a manifest
+with a non-default `[verification] output-dir` against an older `infc` is a
+hard error:
+
+```text
+error: the resolved infc does not support `--out-dir` (requires infc ABI ≥ 1.1);
+       update the toolchain or remove `[verification] output-dir` from Inference.toml.
+```
+
+### Compiler Resolution
+
+`infs` locates `infc` by checking, in order:
+
+1. `INFC_PATH` environment variable — an explicit override, useful for
+   development and CI.
+2. System `PATH` (`which infc`).
+3. The managed toolchain directory (`~/.inference/toolchains/<version>/infc`).
+
+`INFERENCE_HOME` overrides the managed toolchain root (default `~/.inference`).
+
+## Comparison with Cargo
+
+The parallels to Cargo are intentional:
+
+| Concern | Cargo | Inference |
+|---------|-------|-----------|
+| Manifest | `Cargo.toml` | `Inference.toml` |
+| Entry source | `src/main.rs` (binary) | `src/main.inf` |
+| Artifact directory | `target/` | `out/` |
+| Discovery | walk up to `Cargo.toml` | walk up to `Inference.toml` |
+| Nearest manifest wins | yes | yes |
+| New project | `cargo new` | `infs new` |
+| Init in-place | `cargo init` | `infs init` |
+| External deps | crates via `Cargo.toml [dependencies]` | compiled `.wasm` via `[wasm-dependencies]` |
+| Build tool / compiler split | `cargo` / `rustc` | `infs` / `infc` |
+
+Where Inference is deliberately simpler: there are no build profiles beyond the
+compile/proof axis (debug vs. release optimization is not yet user-configurable
+via the manifest), no workspace support, and no package registry — external
+`.wasm` modules are referenced by filesystem path.
+
+## Current Limitations
+
+- **Fixed entry point in project mode.** Project mode always compiles
+  `src/main.inf` and invokes `main`. Custom entry files and custom exported
+  functions are only available in single-file mode.
+- **Single entry file.** `infc` follows the import-reachable closure from
+  `src/main.inf`; there is no mechanism to specify additional top-level files.
+- **No workspaces.** A single `Inference.toml` defines one project. Multi-crate
+  workspace support is not yet implemented.
+- **No package registry.** `[wasm-dependencies]` accepts only local filesystem
+  paths. Version-pinned or registry-sourced dependencies are reserved for a
+  future manifest extension.
+
+## Related Resources
+
+- [Compilation Targets](compilation_targets.md) — compile vs. proof modes,
+  optimization levels, and the WASM target matrix; the `--mode` flag is
+  specified in detail there.
+- [External Functions and WASM Linking](external-functions-and-wasm-linking.md)
+  — how `use { f } from <module>;` binds to `[wasm-dependencies]` entries and
+  how the linker merges them.
+- [The WASM Linker](the-wasm-linker.md) — the static merge algorithm that
+  folds external `.wasm` bodies into the output module.
+- [Module Hierarchy and Multi-File Compilation](module-hierarchy-and-multi-file-compilation.md)
+  — how `infc` follows imports across files within a project.

--- a/book/src/projects-and-the-infs-toolchain.md
+++ b/book/src/projects-and-the-infs-toolchain.md
@@ -300,7 +300,8 @@ infs build
 | `--wasm-dep <name>=<path>` | Bind a logical module name directly to a `.wasm` file; takes precedence over `-L` |
 | `--commit-hash` | Print the build commit hash and exit; used by the `infs` handshake |
 | `--abi-version` | Print `<major>.<minor>` ABI version and exit; used by the `infs` handshake |
-| `--abi-version` output | Currently `1.1` |
+
+> **Note:** The current ABI version is `1.1`.
 
 The default behavior when no phase flag is supplied is full compilation with
 WASM output written to disk — equivalent to `--codegen -o`.

--- a/book/src/the-wasm-linker.md
+++ b/book/src/the-wasm-linker.md
@@ -32,9 +32,9 @@ binaries and produces the self-contained module that flows into `wasm-to-v`:
     │
     ▼
   parse ──▶ type-check ──▶ analyze
-    │
-    ▼
- codegen (wasm-codegen)
+                                  │
+                                  ▼
+                            codegen (wasm-codegen)
     │
     ▼  main.wasm (import-bearing)
     │                               arith.wasm ──┐

--- a/book/src/the-wasm-linker.md
+++ b/book/src/the-wasm-linker.md
@@ -1,0 +1,454 @@
+# The WASM Linker
+
+The language-level constructs — `external fn`, `use … from`, resolution priority —
+are documented in
+[External Functions and WASM Linking](external-functions-and-wasm-linking.md).
+This chapter is the subsystem deep-dive: what `inference-wasm-linker` actually does
+to the bytes, why each decision was made, and where the approach diverges from
+conventional linkers.
+
+## Motivation
+
+Inference programs can call pre-compiled `.wasm` library functions, but verification
+requires a single self-contained module. Imports are the enemy of that goal: a
+module with a dangling `(import "arith" "sum" …)` cannot be fully verified, because
+the Rocq translator has no body to reason about. Dynamic linking trades one problem
+for another — it moves the unverifiable part from the import section to runtime.
+
+The solution is a **static whole-body merge**: after codegen emits an
+import-bearing module, the linker copies the needed function bodies in, rewrites
+every index reference into a unified index space, and removes the import section
+entirely. The output has no dangling imports, no relocation step, and no runtime
+loader. Verification then covers the actual deployed artifact, not a stand-in.
+
+## Where the Linker Fits in the Pipeline
+
+Codegen produces an intermediate module whose external calls lower to
+`(import …)` entries. The linker consumes that module plus the resolved `.wasm`
+binaries and produces the self-contained module that flows into `wasm-to-v`:
+
+```text
+.inf source
+    │
+    ▼
+  parse ──▶ type-check ──▶ analyze
+    │
+    ▼
+ codegen (wasm-codegen)
+    │
+    ▼  main.wasm (import-bearing)
+    │                               arith.wasm ──┐
+    │                               sortlib.wasm ─┤
+    └─────────────────────────────────────────────┤
+                                                  ▼
+                                       inference-wasm-linker
+                                                  │
+                                    unified.wasm (no imports)
+                                                  │
+                                    ┌─────────────┤
+                                    ▼             ▼
+                                  .out         wasm-to-v
+                                             (Rocq .v file)
+```
+
+The linker is provided by the `inference-wasm-linker` crate (`core/wasm-linker/`).
+Its public API is a single function:
+
+```rust
+use inference_wasm_linker::{link, LinkError};
+
+let unified: Vec<u8> = link(
+    main_wasm,
+    &[("arith", arith_wasm), ("sortlib", sortlib_wasm)],
+)?;
+```
+
+Each external is tagged with the logical module name codegen recorded for it. The
+merge resolves each import by matching both the logical module name **and** the
+export field name, so two libraries exporting the same field name under different
+logical modules are never conflated.
+
+## The Merge Algorithm
+
+For each import in the main module:
+
+1. Find which external module exports a function of that name under the right
+   logical module.
+2. Compute the **transitive closure** of that export inside its source module via
+   breadth-first search — the functions it calls recursively, plus any unexported
+   helpers.
+3. **Classify** the closure's feasibility tier (A, B, or C — see below).
+4. **Dedup** the closure's function types into the output type section (two
+   functions with identical signatures share one type entry; the key is a
+   byte-packed encoding of the parameter and result value types).
+5. **Append** the closure's bodies after the main module's local functions,
+   rewriting every index-bearing instruction into the unified index space.
+6. **Remove** the satisfied import and redirect the main module's calls from the
+   old import index onto the merged body's new index.
+
+### Index Space After Merging
+
+The output defines one function index space, with no import section:
+
+```text
+[0 .. main_local_count)       main module's local functions (imports removed)
+[main_local_count .. total)   merged external functions, in closure order
+```
+
+### Operator Re-encoding
+
+The `rewrite` module walks each copied body's operator stream and re-encodes
+only the index-bearing operators: `call`, `return_call`, `ref.func`,
+`call_indirect`, `return_call_indirect`, and `block`/`loop`/`if` when carrying a
+function type index. Every other operator is copied verbatim from the source
+bytes. The main module's own bodies are re-encoded for the same reason: removing
+imports shifts their local-function indices downward.
+
+### Dead-Code Exclusion
+
+The transitive closure walk collects only the functions actually reachable from
+each satisfied export. An `unused` function that the source module exports but
+that no satisfied import calls is never pulled into the closure, so it does not
+appear in the merged output.
+
+### The Example from the Repository
+
+The `scratch/linker-e2e/` demo links three external modules simultaneously. The
+Inference.toml declares them:
+
+```toml
+[wasm-dependencies]
+arith   = { path = "libs/arith.wasm"   }
+memlib  = { path = "libs/memlib.wasm"  }
+sortlib = { path = "libs/sortlib.wasm" }
+```
+
+The source uses all three:
+
+```inference
+external fn sum(a: i32, b: i32) -> i32;
+external fn neg(a: i32) -> i32;
+use { sum, neg } from arith;
+
+external fn store_at(ptr: i32, val: i32);
+external fn load_at(ptr: i32) -> i32;
+use { store_at, load_at } from memlib;
+
+external fn sort_pair(ptr: i32);
+use { sort_pair } from sortlib;
+```
+
+`arith` is pure arithmetic (Tier A). `memlib` and `sortlib` access memory only
+through the caller-supplied pointer (Tier B). `sort_pair` transitively calls a
+non-exported `swap` helper — the closure walk drags that helper in automatically,
+and both functions merge. After linking, the output has no imports and one
+reconciled linear memory shared by all three modules' bodies.
+
+## Feasibility Tiers
+
+Not all external functions can be merged without relocation metadata. The linker
+classifies each closure:
+
+| Tier | What the closure may touch | Merged? | Admission condition |
+|------|---------------------------|---------|---------------------|
+| A | No memory, globals, data segments, or tables — pure arithmetic | Yes | None beyond the operator allow-list |
+| B | Linear memory **only through caller-supplied pointers**; no own globals, data segments, or tables | Yes | Provenance proof: every memory address is parameter-derived (see below) |
+| C | Own static data segments, defined globals, or table/element entries | No | Rejected with `LinkError::RequiresRelocatableBuild` |
+
+### What Each Tier May Touch
+
+The classification logic inspects the parsed module structure and the closure's
+`ClosureEffects`, collected as a side effect of the operator allow-list scan:
+
+| Signal | Forces Tier C |
+|--------|---------------|
+| `module.data_count > 0` or closure uses `memory.init` / `data.drop` | owns static data segments |
+| `!module.globals.is_empty()` or closure uses `global.get` / `global.set` | defines or accesses module globals |
+| `!module.tables.is_empty()` or `module.element_count > 0` or closure uses `call_indirect` / `table.*` / `ref.func` / `elem.drop` | uses a table or element segment |
+
+If no Tier-C signals are present, the closure is Tier B when any body accesses
+linear memory (load, store, copy, fill, size, or grow), and Tier A otherwise.
+
+A Tier-A function carries no shared-memory surface at all: it reads its parameters,
+does arithmetic, and returns. Merge cost is a body copy, a type dedup, and an
+index rewrite.
+
+A Tier-B function shares the single linear memory the main module owns. No address
+relocation is needed because every address is caller-supplied at runtime. However,
+the linker must *prove* this property — it cannot assume it from the section
+structure alone.
+
+### Tier-C Rejection
+
+A Tier-C closure is rejected with `LinkError::RequiresRelocatableBuild` listing
+the specific reasons:
+
+```text
+error: external function `lookup` requires a relocatable build:
+         defines or initializes its own static data segments
+```
+
+The `reasons` field is a `Vec<String>` so a closure that simultaneously has its
+own globals and uses `memory.init` reports both signals in one diagnostic.
+
+## Tier-B Provenance Analysis
+
+The provenance analysis is the most novel part of the linker. Tier B's contract
+is that a merged external touches shared linear memory *only through addresses the
+caller passes in*. A function that fabricates an address from a constant or reads
+one from its own global would alias the host program's own linear memory at a
+fixed offset — a silent miscompile the section-inspection tier check cannot detect,
+because the function validates cleanly and its export signature matches.
+
+The linker proves the contract with a **sound, flow-sensitive, interprocedural
+abstract interpretation** over the whole closure.
+
+### The Provenance Lattice
+
+Every operand-stack slot and every local carries one of three provenance tags:
+
+| Tag | Meaning |
+|-----|---------|
+| `Prov::Param(mask)` | The value provably derives from one or more of this function's parameters, through operations that cannot cancel the caller's pointer. `mask` is a 64-bit bitset recording which parameters. |
+| `Prov::Const` | The value is a compile-time constant (`*.const` literal, or `add`/`sub` of two `Const`s). Caller-independent — never a valid memory address on its own, but a valid offset to add to a `Param` base. |
+| `Prov::NotParam` | Any other source: a global, a call result, a parameter-cancelling operator, or anything the analysis cannot prove parameter-derived. The fail-closed default. |
+
+The lattice join is a **must-join**: a value stays `Param` only when it is
+`Param` on *every* incoming control-flow path. The mask at a join point is the
+**union** of the per-path masks (on every path it derives from *some* parameter,
+so on the merged path it derives from one of the union). A value arriving as
+`Const` on one path and `Param` on another widens to `NotParam`.
+
+### Why `Const` Is a Separate Tag
+
+`Const` exists so a `Param + Const` expression (a struct-field or
+array-element offset: `base_ptr + 8`) can stay `Param` while a `Param + NotParam`
+expression cannot. A `NotParam` addend means *not provably parameter-derived*, not
+*constant*. It may hold `C - p` (a constant minus a parameter), and
+`(C - p) + p == C` is a caller-independent absolute address. Restricting the
+non-`Param` addend to a proven `Const` closes that cancellation attack.
+
+For the same reason `sub` propagates `Param` only from the minuend when the
+subtrahend is `Const` (`caller_base - fixed_offset` is still caller-relative), and
+`Param - Param` demotes to `NotParam` (since `b - b == 0`, a caller-independent
+constant).
+
+Every other binary operator — multiply, divide, bitwise, shift, rotate,
+comparison — and every unary operator produces `NotParam`. The analysis is
+deliberately conservative: it cannot distinguish `param << 0` (value-preserving)
+from `param & 0` (value-destroying), so it treats all such operators uniformly.
+
+### Bulk-Memory Extent Operands
+
+For `memory.fill` and `memory.copy`, the **size/extent** operand carries the same
+caller-derivation requirement as the address operand. The operation touches the
+contiguous region `[address, address + size)`, so a caller-bounded start is not
+enough — a constant or global `size` would let the operation clobber or read an
+unbounded span above a caller pointer (`memory.fill(base, v, 0x8000)` scorches
+host memory the caller never exposed). A `Param` size (a caller-supplied `len`)
+is admitted; a `Const` or `NotParam` size fails the subset check.
+
+### Interprocedural Fixpoint
+
+Each function in the closure is summarised once by seeding parameter `i` with
+`Prov::Param({i})`. The summary records, per function, the provenance mask of
+every memory access, and per call site, the argument mask of every argument in
+the calling function's own parameter terms.
+
+A greatest-fixpoint pass over the call graph then computes, for every function
+`g`, the set `trusted[g]` — the subset of `g`'s parameters that are provably
+caller-derived:
+
+- The closure root's parameters are all trusted (the host that calls the exported
+  function supplies them).
+- A parameter `j` of a non-root function `g` is trusted if and only if, at
+  **every** internal call site `f → g`, the argument in position `j` has a
+  non-empty mask that is a subset of `trusted[f]`.
+
+The iteration starts from "all parameters trusted" and removes any parameter
+contradicted at a reachable call site, converging in at most `(slot count + 1)`
+rounds. The fixpoint handles self- and mutual recursion correctly. A function
+reachable only through the table (no direct call site) starts with the empty
+trusted set — a dereference of its parameter is rejected.
+
+Finally, every recorded memory access is verified: its address mask must be
+non-empty and a subset of its function's trusted set. A failure at any point
+rejects the whole closure as Tier C, never Tier B.
+
+```text
+root_params = {ptr, len}        (trusted by the external caller)
+
+inner(addr, count):
+  addr derived from ptr → trusted
+  count derived from len → trusted
+  memory.fill(addr, 0, count) → both masks ⊆ trusted → Tier B ✓
+
+inner2(addr, count):
+  count is i32.const 0x8000 → Const, mask = {} → mask ⊄ trusted → Tier C ✗
+```
+
+## Proof-Only Stripping
+
+Inference non-deterministic blocks (`forall`, `exists`, `assume`, `unique`) and
+uzumaki rvalues (`i32.uzumaki`, `i64.uzumaki`) are **proof-only constructs**:
+they have meaning solely in the Rocq lowering and no executable runtime semantics.
+A function that is merged into the output is part of an executable binary, so a
+proof-only opcode inside such a body would yield a non-executable output.
+
+The operator allow-list (`src/safety.rs`) **rejects** every proof-only opcode from
+an external body with `LinkError::UnsupportedConstruct`:
+
+```text
+unsupported WASM construct for static merge: non-deterministic block `forall`
+    has no executable semantics and cannot be merged into an executable binary
+```
+
+The main module's own proof scaffolding (its `spec` blocks and non-det opcodes)
+is **preserved and passed through** verbatim — the re-encoder recognises those
+opcodes and copies them intact onto the main-module bodies, which are not subject
+to the allow-list. Those bodies flow through `wasm-to-v` as the proof obligations
+the user wrote.
+
+## Floating-Point Exclusion
+
+The Inference language has no `f32`/`f64` types. The Rocq translator models no
+float instruction. The linker enforces this at two gates:
+
+1. **Feature gate** (`SUPPORTED_WASM_FEATURES` in `src/lib.rs`): every external
+   module is structurally validated before any body is touched. The feature set
+   deliberately omits `FLOATS`, so a float-using external is rejected upfront with
+   `LinkError::UnsupportedWasmFeature` naming the exact feature.
+
+2. **Operator allow-list** (`src/safety.rs`): the main-module re-encode path does
+   not pass through the feature gate, so the allow-list is the backstop. Every
+   float instruction — comparisons, arithmetic, conversions, reinterprets,
+   loads/stores, and constants — is rejected with `LinkError::UnsupportedConstruct`
+   naming the exact mnemonic (e.g. `floating-point instruction 'f32.add' is not
+   supported`).
+
+Sign-extension (`i32.extend8_s`, `i64.extend32_s`, etc.) and saturating
+float-to-int (`i32.trunc_sat_f32_s`, etc.) are also excluded: the Rocq
+translator has no lowering for either, and Inference codegen emits neither.
+
+## Name Preservation
+
+The linker preserves the WASM `name` custom section so the Rocq translator emits
+named `Definition`s rather than opaque `func_<idx>` placeholders:
+
+- Main module local functions keep their source debug names, re-indexed onto the
+  import-free output space.
+- Every merged external function is named under its source's logical module using
+  a `module.field` form:
+  - A closure **root** satisfying import `sum` bound under logical module `mathlib`
+    becomes `mathlib.sum`.
+  - An internal callee the source module named keeps that name, prefixed:
+    `mathlib.helper`.
+  - A **nameless** inner callee (an external with no name section) receives a
+    deterministic fallback derived from its output index: `mathlib.func_<idx>`.
+
+The `.` separator prevents collision between two libraries that export
+same-named fields under different logical modules. The Rocq translator
+(`core/wasm-to-v/src/rocq_names.rs`) sanitizes every non-alphanumeric character
+to `_`, so `mathlib.sum` becomes `Definition mathlib_sum` in the `.v` file.
+A residual collision after sanitization (e.g. two modules that sanitize to the
+same identifier) is still disambiguated by the translator's index suffix;
+the module prefix removes the common case rather than every possible one.
+
+## Error Reference
+
+| Error | Trigger |
+|-------|---------|
+| `LinkError::Parse(msg)` | A module's bytes could not be parsed as valid WASM, or a module that passed structural validation contains a malformed section (over-declared locals count, invalid LEB128, etc.) |
+| `LinkError::UnsatisfiedImport { field }` | No external module tagged with the right logical module name exports a function named `field` |
+| `LinkError::TransitiveHostImport { module, field }` | A body inside the merged closure calls one of the external module's own imports; there is no body to copy for it |
+| `LinkError::RequiresRelocatableBuild { field, reasons }` | The closure for `field` is Tier C; `reasons` lists each signal (e.g. "defines or initializes its own static data segments") |
+| `LinkError::UnsupportedConstruct(msg)` | A body contains an unmergeable construct: any floating-point instruction (with the exact mnemonic), a proof-only non-det or uzumaki opcode in an external body, a tail call (`return_call` / `return_call_indirect`), a sign-extension op, a segment-indexed table op (`table.init` / `elem.drop` / `table.copy`), a float or `v128` value type in a merged signature or local, multi-memory access, or a main module section the merge cannot preserve (start function, table section, non-function imports, data/element segments) |
+| `LinkError::UnsupportedWasmFeature { module, details }` | The external module is well-formed WASM but uses a feature beyond the supported subset (floats, sign-extension, saturating float-to-int, reference types, SIMD, atomics, exceptions, `memory64`, multi-memory, multi-value, GC, or tail calls); `details` carries the validator's feature-named diagnostic |
+| `LinkError::AmbiguousImport { module, field }` | More than one supplied external exports a function of the same field name the import requests under the same logical module; the body to merge is ambiguous |
+| `LinkError::IncompatibleMemory { field, reason }` | The linear memory requirements of the main module and the Tier-B external cannot be reconciled into one shared output memory |
+| `LinkError::InvalidMergedModule(msg)` | The post-merge structural validator rejected the merged output; this is a guard against allow-list gaps — it converts a potential silent miscompile into a clean diagnostic |
+
+## Supported WASM Subset
+
+The linker accepts only the following feature set (`SUPPORTED_WASM_FEATURES`
+in `src/lib.rs`):
+
+- Integer core: `i32`/`i64` value types, all integer arithmetic, comparisons,
+  loads/stores, and the three integer width conversions (`i32.wrap_i64`,
+  `i64.extend_i32_s/u`).
+- Mutable globals and bulk memory (`memory.copy`/`memory.fill`).
+
+Everything else is rejected at the feature gate or the operator allow-list before
+any body is copied.
+
+## Formal Implications
+
+Once merged, every external function becomes an ordinary local function in the
+output module. The Rocq translator processes that module without knowing which
+functions originated externally: each merged body becomes a Rocq `Definition` in
+the `.v` file, exactly as a locally-defined function does.
+
+Verification therefore covers the actual deployed merged artifact, not a
+stand-in. A proof that `sort_demo` returns the expected value reasons about
+the real `mathlib_sort` and `memlib_store_at` bodies — not their declared
+signatures.
+
+The `inference.spec_funcs` custom section (`src/spec_funcs.rs`) carries the WASM
+function indices the Rocq translator must turn into proof obligations. The merge
+removes imports and shifts indices, so the linker decodes this section,
+remaps every index through the unified index space, and re-emits it. The
+round-trip is byte-stable: proof obligations are never lost across the link step.
+
+## Comparison with Traditional Linkers
+
+Traditional `wasm-ld` (LLVM's WebAssembly linker) supports relocatable object
+files: each compiled translation unit emits relocation metadata (symbol tables,
+reloc sections), and `wasm-ld` patches absolute addresses and index references at
+link time. That model handles Tier-C inputs (static data, globals, indirect-call
+tables) without a provenance proof, because the relocation metadata describes
+exactly what needs patching.
+
+Inference cannot use `wasm-ld` for two reasons:
+
+1. **Verification needs a relocation-free module.** `wasm-ld` produces a module
+   that is self-contained at runtime but which was assembled from relocatable
+   pieces. The Rocq translator expects to reason about the final module; it has no
+   model for relocation metadata or the toolchain decisions it encodes.
+
+2. **External libraries are not necessarily compiled with Inference.** They may
+   come from any WASM toolchain and need not carry `wasm-ld`-compatible relocation
+   sections. The static merge works on any conforming WASM binary — no toolchain
+   cooperation is required for Tier-A and Tier-B inputs.
+
+The provenance analysis fills the gap: instead of relocation metadata, the linker
+*proves* that the merged function cannot produce an address the host program did
+not supply. A function passing that proof needs no relocation, because its memory
+accesses are bounded to whatever region the caller chose to expose.
+
+| Concern | `wasm-ld` | Inference static merge |
+|---------|-----------|------------------------|
+| Tier-A/B inputs | Requires reloc sections | Any conforming WASM binary |
+| Tier-C inputs | Supported via relocation | Rejected (`RequiresRelocatableBuild`) |
+| Address safety | Relocation metadata | Interprocedural provenance proof |
+| Verification | Reloc artifact not translatable | Merged module translates directly |
+| Runtime loader | Not required (static) | Not required (static) |
+
+Tier-C support via relocation metadata is a stated future direction. The current
+linker explicitly gates on Tier A and B rather than risk a silent miscompile from
+an unproven address.
+
+## Related Resources
+
+- [External Functions and WASM Linking](external-functions-and-wasm-linking.md) —
+  the language-level feature: `external fn`, `use … from`, resolution priority,
+  and the Tier A/B/C overview
+- [Projects and the infs Toolchain](projects-and-the-infs-toolchain.md) —
+  configuring `[wasm-dependencies]` and building with the project-aware CLI
+- [Compilation Targets](compilation_targets.md) — compile vs. proof modes;
+  the merged module flows through the same `-v` proof path as a locally-compiled module
+- `core/wasm-linker/README.md` — merge algorithm, tier classification,
+  index space, name section, testing, and fuzzing
+- `core/wasm-linker/src/provenance.rs` — full source of the abstract interpreter
+  (module-level doc comment is a complete specification)
+- [WebAssembly binary format](https://webassembly.github.io/spec/core/binary/index.html) —
+  section ordering, index spaces, and the name custom section


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Documentation-only change adding three new chapters; no executable code is modified.

All changes are Markdown prose and table-of-contents updates. Every cross-reference link resolves to a file present in this PR. The single notation inaccuracy (using ⊄ where the rejection actually comes from a non-empty check) has no effect on any executable artifact.

No files require special attention; the notation clarification in the-wasm-linker.md is the only change worth a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| book/src/SUMMARY.md | Adds a new 'Projects & Tooling' section grouping the four chapters (module hierarchy, infs toolchain, external functions, WASM linker); all four file references are valid. |
| book/src/module-hierarchy-and-multi-file-compilation.md | New 446-line chapter covering file-as-module model, two forms of `use`, visibility, re-exports, cross-file type identity, import-closure BFS walk, WASM codegen naming, spec name folding, and formal implications; content is internally consistent and all cross-references resolve. |
| book/src/projects-and-the-infs-toolchain.md | New 389-line chapter covering Inference.toml manifest, project discovery, infs build/run modes, ABI versioning, scaffolding commands, and Cargo comparison; content is accurate and well-structured. |
| book/src/the-wasm-linker.md | New 454-line deep-dive chapter on the WASM static merge algorithm, feasibility tiers, Tier-B provenance analysis, and error reference; one notation inaccuracy in the provenance example where ⊄ is used but the rejection actually stems from the non-empty requirement, not the subset check. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".inf source files"] --> B["infc (compiler)"]
    B --> C["parse"]
    C --> D["type-check"]
    D --> E["analyze"]
    E --> F["codegen"]
    F --> G["main.wasm\n(import-bearing)"]

    H["[wasm-dependencies]\n*.wasm libraries"] --> I["inference-wasm-linker"]
    G --> I

    I -->|"Tier A/B: merge bodies\nrewrite index space"| J["unified.wasm\n(no imports)"]
    I -->|"Tier C: own globals/data/tables"| K["LinkError::\nRequiresRelocatableBuild"]

    J --> L["out/ (.wasm)"]
    J --> M["wasm-to-v\n(Rocq translator)"]
    M --> N["proofs/ (.v file)"]

    subgraph infs ["infs orchestrator"]
        O["Inference.toml\ndiscovery"] --> P["infs build / run"]
        P --> B
        P --> I
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[".inf source files"] --> B["infc (compiler)"]
    B --> C["parse"]
    C --> D["type-check"]
    D --> E["analyze"]
    E --> F["codegen"]
    F --> G["main.wasm\n(import-bearing)"]

    H["[wasm-dependencies]\n*.wasm libraries"] --> I["inference-wasm-linker"]
    G --> I

    I -->|"Tier A/B: merge bodies\nrewrite index space"| J["unified.wasm\n(no imports)"]
    I -->|"Tier C: own globals/data/tables"| K["LinkError::\nRequiresRelocatableBuild"]

    J --> L["out/ (.wasm)"]
    J --> M["wasm-to-v\n(Rocq translator)"]
    M --> N["proofs/ (.v file)"]

    subgraph infs ["infs orchestrator"]
        O["Inference.toml\ndiscovery"] --> P["infs build / run"]
        P --> B
        P --> I
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Update book/src/projects-and-the-infs-to..."](https://github.com/inferara/inference/commit/02d975a38b9d42aafd09e93ec4a2c5acf5611b28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38869093)</sub>

<!-- /greptile_comment -->