### PR TITLE
Fix double file reads when parsing projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -698,6 +698,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - ast: 98% memory reduction in `Location` struct by removing unused source field ([#69])
+- compiler: the multi-file project front end parses each reachable file exactly once — the import walk now lowers files directly into the shared arena and reorders them into canonical order afterward via the new `AstArena::canonicalize_source_file_order`; previously discovery parsed every file into a throwaway arena just to read its `use` directives and lowering re-parsed it ([#227])
 
 ### Fixed
 
@@ -859,3 +860,4 @@ Initial tagged release.
 [#223]: https://github.com/Inferara/inference/pull/223
 [#224]: https://github.com/Inferara/inference/issues/224
 [#225]: https://github.com/Inferara/inference/issues/225
+[#227]: https://github.com/Inferara/inference/issues/227

--- a/core/ast/src/arena.rs
+++ b/core/ast/src/arena.rs
@@ -225,13 +225,57 @@ impl AstArena {
     ///
     /// Source files are stored entry-first, then imported files sorted
     /// lexicographically by their `module_path` (the project front end allocates
-    /// them in this order). This order is the single source of truth that later
-    /// pipeline phases consume for scope-id assignment, codegen emission, and
-    /// Rocq output, so artifacts are reproducible regardless of import-discovery
-    /// order. A single-file arena trivially satisfies the invariant.
+    /// them in import-discovery order, then reorders them into this order with
+    /// [`canonicalize_source_file_order`](Self::canonicalize_source_file_order)
+    /// before handing the arena to later phases). This order is the single
+    /// source of truth that later pipeline phases consume for scope-id
+    /// assignment, codegen emission, and Rocq output, so artifacts are
+    /// reproducible regardless of import-discovery order. A single-file arena
+    /// trivially satisfies the invariant.
     #[must_use]
     pub fn source_files(&self) -> impl ExactSizeIterator<Item = &SourceFileData> + '_ {
         self.source_files.values()
+    }
+
+    /// Reorders the stored source files into the **canonical order** documented
+    /// on [`source_files`](Self::source_files): the entry file (empty
+    /// `module_path`) first, then imported files sorted lexicographically by
+    /// `module_path`. The empty path already compares less than any non-empty
+    /// one, so a plain lexicographic sort places the entry first without any
+    /// special case. The sort is stable, so files sharing a `module_path` keep
+    /// their relative order.
+    ///
+    /// Files accumulate in allocation (import-discovery) order during
+    /// incremental construction; this call rewrites that ordering into the
+    /// canonical one that later pipeline phases rely on.
+    ///
+    /// # Id invalidation
+    ///
+    /// A [`SourceFileId`] is a positional index into `source_files`, so
+    /// reordering renumbers the files: any `SourceFileId` obtained before this
+    /// call must not be used afterwards. Every other id (`DefId`, `ExprId`,
+    /// `BlockId`, …) is unaffected, because only the file order changes and
+    /// [`SourceFileData`] stores no `SourceFileId`.
+    pub fn canonicalize_source_file_order(&mut self) {
+        let mut files: Vec<SourceFileData> = std::mem::take(&mut self.source_files)
+            .into_iter()
+            .map(|(_, file)| file)
+            .collect();
+        files.sort_by(|a, b| a.module_path.cmp(&b.module_path));
+        self.source_files = files.into_iter().collect();
+    }
+
+    /// Returns the most recently allocated source file, if any.
+    ///
+    /// Files sit in allocation order until
+    /// [`canonicalize_source_file_order`](Self::canonicalize_source_file_order)
+    /// reorders them, so during incremental construction — one `parse_into` per
+    /// file, whose lowering allocates the file's [`SourceFileData`] after all of
+    /// that file's defs and directives — this is the file just lowered. After a
+    /// reorder it is the canonically-last file instead.
+    #[must_use = "returns the most recently allocated source file"]
+    pub fn last_source_file(&self) -> Option<&SourceFileData> {
+        self.source_files.values().next_back()
     }
 
     /// Returns a source file's module path, or `None` if the id is out of range.
@@ -735,5 +779,331 @@ mod tests {
         push_function_file(&mut arena, "fn b() { 9 }", lit_loc, vec!["m".to_string()]);
 
         assert_eq!(arena.node_module_path(NodeId::Expr(lit)), None);
+    }
+
+    /// Appends a one-function file named `fn_name` to `arena` and returns the new
+    /// file's id. Distinct names let tests tell reordered files apart by the
+    /// names their `defs` resolve to, which a fixed name (as in
+    /// [`push_function_file`]) cannot.
+    fn push_named_file(
+        arena: &mut AstArena,
+        fn_name: &str,
+        module_path: Vec<String>,
+    ) -> SourceFileId {
+        let name = arena.idents.alloc(Ident {
+            location: Location::default(),
+            name: fn_name.to_string(),
+        });
+        let body = arena.blocks.alloc(BlockData {
+            location: Location::default(),
+            block_kind: BlockKind::Regular,
+            stmts: vec![],
+        });
+        let def_id = arena.defs.alloc(DefData {
+            location: Location::default(),
+            kind: Def::Function {
+                name,
+                vis: Visibility::default(),
+                type_params: vec![],
+                args: vec![],
+                returns: None,
+                body,
+            },
+        });
+        arena.source_files.alloc(SourceFileData {
+            location: Location::default(),
+            source: String::new(),
+            defs: vec![def_id],
+            directives: vec![],
+            module_path,
+        })
+    }
+
+    /// Collects the stored files' module paths in their current order.
+    fn module_paths(arena: &AstArena) -> Vec<Vec<String>> {
+        arena
+            .source_files()
+            .map(|f| f.module_path.clone())
+            .collect()
+    }
+
+    /// Collects each stored file's def names in the files' current order, so a
+    /// reorder that cross-wired files to the wrong defs would be visible.
+    fn def_names_by_file(arena: &AstArena) -> Vec<Vec<&str>> {
+        arena
+            .source_files()
+            .map(|f| f.defs.iter().map(|&d| arena.def_name(d)).collect())
+            .collect()
+    }
+
+    #[test]
+    fn canonicalize_empty_arena_is_a_no_op() {
+        let mut arena = AstArena::default();
+        arena.canonicalize_source_file_order();
+        assert_eq!(arena.source_files().count(), 0);
+    }
+
+    #[test]
+    fn canonicalize_single_entry_file_is_unchanged() {
+        let mut arena = AstArena::default();
+        push_function_file(
+            &mut arena,
+            "fn a() { return 0; }",
+            Location::default(),
+            vec![],
+        );
+
+        arena.canonicalize_source_file_order();
+
+        let expected: Vec<Vec<String>> = vec![vec![]];
+        assert_eq!(module_paths(&arena), expected);
+    }
+
+    #[test]
+    fn canonicalize_preserves_already_canonical_order_and_is_idempotent() {
+        let mut arena = AstArena::default();
+        push_function_file(
+            &mut arena,
+            "fn a() { return 0; }",
+            Location::default(),
+            vec![],
+        );
+        push_function_file(
+            &mut arena,
+            "fn b() { return 1; }",
+            Location::default(),
+            vec!["lib".to_string(), "a".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn c() { return 2; }",
+            Location::default(),
+            vec!["lib".to_string(), "b".to_string()],
+        );
+
+        let expected: Vec<Vec<String>> = vec![
+            vec![],
+            vec!["lib".to_string(), "a".to_string()],
+            vec!["lib".to_string(), "b".to_string()],
+        ];
+
+        arena.canonicalize_source_file_order();
+        assert_eq!(module_paths(&arena), expected);
+
+        // A second call over already-canonical files is a no-op.
+        arena.canonicalize_source_file_order();
+        assert_eq!(module_paths(&arena), expected);
+    }
+
+    #[test]
+    fn canonicalize_sorts_reverse_lexicographic_insertion_ascending() {
+        let mut arena = AstArena::default();
+        push_function_file(
+            &mut arena,
+            "fn z() { return 0; }",
+            Location::default(),
+            vec!["zed".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn m() { return 1; }",
+            Location::default(),
+            vec!["mid".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn a() { return 2; }",
+            Location::default(),
+            vec!["abc".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn e() { return 3; }",
+            Location::default(),
+            vec![],
+        );
+
+        arena.canonicalize_source_file_order();
+
+        let expected: Vec<Vec<String>> = vec![
+            vec![],
+            vec!["abc".to_string()],
+            vec!["mid".to_string()],
+            vec!["zed".to_string()],
+        ];
+        assert_eq!(module_paths(&arena), expected);
+    }
+
+    #[test]
+    fn canonicalize_moves_entry_allocated_last_to_the_front() {
+        let mut arena = AstArena::default();
+        push_function_file(
+            &mut arena,
+            "fn b() { return 0; }",
+            Location::default(),
+            vec!["lib".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn c() { return 1; }",
+            Location::default(),
+            vec!["zed".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn a() { return 2; }",
+            Location::default(),
+            vec![],
+        );
+
+        arena.canonicalize_source_file_order();
+
+        let files: Vec<&SourceFileData> = arena.source_files().collect();
+        assert!(files[0].is_entry());
+        let expected: Vec<Vec<String>> =
+            vec![vec![], vec!["lib".to_string()], vec!["zed".to_string()]];
+        assert_eq!(module_paths(&arena), expected);
+    }
+
+    #[test]
+    fn canonicalize_interleaves_nested_paths_correctly() {
+        let mut arena = AstArena::default();
+        // Insert scrambled so the sort has to do real work.
+        push_function_file(
+            &mut arena,
+            "fn z() { return 0; }",
+            Location::default(),
+            vec!["zed".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn lb() { return 1; }",
+            Location::default(),
+            vec!["lib".to_string(), "b".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn a() { return 2; }",
+            Location::default(),
+            vec![],
+        );
+        push_function_file(
+            &mut arena,
+            "fn la() { return 3; }",
+            Location::default(),
+            vec!["lib".to_string(), "a".to_string()],
+        );
+
+        arena.canonicalize_source_file_order();
+
+        let expected: Vec<Vec<String>> = vec![
+            vec![],
+            vec!["lib".to_string(), "a".to_string()],
+            vec!["lib".to_string(), "b".to_string()],
+            vec!["zed".to_string()],
+        ];
+        assert_eq!(module_paths(&arena), expected);
+    }
+
+    #[test]
+    fn defs_stay_attached_to_their_files_across_a_reorder() {
+        let mut arena = AstArena::default();
+        // Insert non-canonically so the reorder actually moves both files.
+        push_named_file(&mut arena, "lib_fn", vec!["lib".to_string()]);
+        push_named_file(&mut arena, "entry_fn", vec![]);
+
+        arena.canonicalize_source_file_order();
+
+        assert_eq!(
+            def_names_by_file(&arena),
+            vec![vec!["entry_fn"], vec!["lib_fn"]]
+        );
+    }
+
+    #[test]
+    fn find_source_file_for_def_returns_the_new_id_after_reorder() {
+        let mut arena = AstArena::default();
+        let (lib_file, _) = push_function_file(
+            &mut arena,
+            "fn b() { return 0; }",
+            Location::default(),
+            vec!["lib".to_string()],
+        );
+        push_function_file(
+            &mut arena,
+            "fn a() { return 1; }",
+            Location::default(),
+            vec![],
+        );
+        let lib_def = arena[lib_file].defs[0];
+
+        arena.canonicalize_source_file_order();
+
+        let new_id = arena
+            .find_source_file_for_def(lib_def)
+            .expect("def is still owned by some file");
+        assert_eq!(
+            arena.source_file_module_path(new_id),
+            Some(&["lib".to_string()][..])
+        );
+        // The pre-reorder id is now a stale index: it names the entry file that
+        // took slot 0, not the lib file it named before.
+        assert_eq!(arena.source_file_module_path(lib_file), Some(&[][..]));
+    }
+
+    #[test]
+    fn canonicalize_keeps_duplicate_module_paths_in_stable_order() {
+        let mut arena = AstArena::default();
+        push_named_file(&mut arena, "entry_fn", vec![]);
+        // Two files share a module path; a stable sort must preserve their
+        // insertion order, which their distinct def names make observable.
+        push_named_file(&mut arena, "dup_first", vec!["dup".to_string()]);
+        push_named_file(&mut arena, "dup_second", vec!["dup".to_string()]);
+
+        arena.canonicalize_source_file_order();
+
+        assert_eq!(
+            def_names_by_file(&arena),
+            vec![vec!["entry_fn"], vec!["dup_first"], vec!["dup_second"]]
+        );
+    }
+
+    #[test]
+    fn last_source_file_is_none_for_empty_arena() {
+        let arena = AstArena::default();
+        assert!(arena.last_source_file().is_none());
+    }
+
+    #[test]
+    fn last_source_file_tracks_the_newest_allocation() {
+        let mut arena = AstArena::default();
+        push_named_file(&mut arena, "first_fn", vec![]);
+        let last = arena.last_source_file().expect("one file allocated");
+        assert_eq!(arena.def_name(last.defs[0]), "first_fn");
+
+        push_named_file(&mut arena, "second_fn", vec!["lib".to_string()]);
+        let last = arena.last_source_file().expect("two files allocated");
+        assert_eq!(arena.def_name(last.defs[0]), "second_fn");
+    }
+
+    #[test]
+    fn last_source_file_returns_the_canonically_last_after_reorder() {
+        let mut arena = AstArena::default();
+        // Allocate so that the newest file is NOT the canonically last one.
+        push_named_file(&mut arena, "zed_fn", vec!["zed".to_string()]);
+        push_named_file(&mut arena, "entry_fn", vec![]);
+        push_named_file(&mut arena, "lib_fn", vec!["lib".to_string()]);
+
+        // Before canonicalization the newest allocation ("lib") is last.
+        let last = arena.last_source_file().expect("files allocated");
+        assert_eq!(arena.def_name(last.defs[0]), "lib_fn");
+
+        arena.canonicalize_source_file_order();
+
+        // After canonicalization the greatest module path ("zed") is last, even
+        // though it was allocated first.
+        let last = arena.last_source_file().expect("files allocated");
+        assert_eq!(arena.def_name(last.defs[0]), "zed_fn");
+        assert_eq!(last.module_path.as_slice(), &["zed".to_string()][..]);
     }
 }

--- a/core/inference/src/project.rs
+++ b/core/inference/src/project.rs
@@ -142,6 +142,10 @@ fn parse_reachable_files(entry: &Path, src_root: &Path) -> anyhow::Result<AstAre
         let file = arena
             .last_source_file()
             .expect("parse_into stores the file it just lowered");
+        debug_assert_eq!(
+            file.module_path, module_path,
+            "parse_into must store the just-lowered file last"
+        );
 
         for segments in path_form_imports(&arena, file)? {
             if visited.contains(&segments) {

--- a/core/inference/src/project.rs
+++ b/core/inference/src/project.rs
@@ -11,10 +11,11 @@
 //! and is ignored here.
 //!
 //! Discovery is breadth-first with a visited set keyed by canonical module path,
-//! so import cycles terminate. The files are then stored in the arena in
-//! **canonical order** — entry first, then imported files sorted lexicographically
-//! by module path — which downstream phases consume as their single source of
-//! truth for ordering.
+//! so import cycles terminate. Each file is read and parsed exactly once — into
+//! the shared arena as it is discovered. After the walk the files are reordered
+//! into **canonical order** — entry first, then imported files sorted
+//! lexicographically by module path — which downstream phases consume as their
+//! single source of truth for ordering.
 //!
 //! All filesystem access lives here; `core/parser` stays I/O-free and is driven
 //! through [`inference_parser::parse_into`].
@@ -24,7 +25,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use inference_ast::arena::AstArena;
-use inference_ast::nodes::{Directive, UseDirective};
+use inference_ast::nodes::{Directive, SourceFileData, UseDirective};
 use rustc_hash::FxHashSet;
 
 use crate::errors::InferenceError;
@@ -69,20 +70,14 @@ impl std::fmt::Display for ProjectWarning {
     }
 }
 
-/// A discovered file: its canonical module path (empty for the entry) and source.
-struct DiscoveredFile {
-    module_path: Vec<String>,
-    source: String,
-}
-
 /// Parses a project starting from `entry`, returning one arena holding every
 /// import-reachable file plus any unreachable-file warnings.
 ///
 /// The source root is `entry`'s parent directory. The entry is parsed first;
 /// its path-form `use` directives are followed breadth-first, each mapped to a
-/// file under the root, until the reachable closure is exhausted. A file
-/// referenced more than once is parsed once. Import cycles are permitted and
-/// terminate via a visited set.
+/// file under the root, until the reachable closure is exhausted. Each reachable
+/// file is read and parsed exactly once, into the shared arena as it is
+/// discovered. Import cycles are permitted and terminate via a visited set.
 ///
 /// # Errors
 ///
@@ -98,18 +93,21 @@ pub fn parse_project(entry: &Path) -> anyhow::Result<ProjectParse> {
         .ok_or_else(|| InferenceError::NoSourceRoot(entry.to_path_buf()))?
         .to_path_buf();
 
-    let discovered = discover_files(entry, &src_root)?;
-    let arena = lower_in_canonical_order(discovered, entry)?;
+    let arena = parse_reachable_files(entry, &src_root)?;
     let warnings = collect_unreachable_warnings(&arena, &src_root, entry);
 
     Ok(ProjectParse { arena, warnings })
 }
 
-/// Breadth-first walk of the import closure, returning the entry first and every
-/// reachable imported file. Each file is keyed by its canonical module path so a
-/// file reached twice (including through a cycle) is visited once.
-fn discover_files(entry: &Path, src_root: &Path) -> anyhow::Result<Vec<DiscoveredFile>> {
-    let mut files = Vec::new();
+/// Breadth-first walk of the import closure, parsing every reachable file exactly
+/// once into a shared arena. Each file is keyed by its canonical module path so a
+/// file reached twice (including through a cycle) is parsed once.
+///
+/// Files accumulate in discovery (BFS) order; the walk ends by reordering them
+/// into canonical order (see [`AstArena::canonicalize_source_file_order`]), the
+/// single source of truth downstream phases consume for ordering.
+fn parse_reachable_files(entry: &Path, src_root: &Path) -> anyhow::Result<AstArena> {
+    let mut arena = AstArena::default();
     let mut visited: FxHashSet<Vec<String>> = FxHashSet::default();
     let mut queue: VecDeque<(Vec<String>, PathBuf)> = VecDeque::new();
 
@@ -123,7 +121,10 @@ fn discover_files(entry: &Path, src_root: &Path) -> anyhow::Result<Vec<Discovere
 
     while let Some((module_path, file_path)) = queue.pop_front() {
         let source = read_source(&file_path)?;
-        let parsed = inference_parser::parse(&source);
+        // `module_path` is moved into the arena by `parse_into` but still needed by
+        // the parse-error arm below, so clone it for the move.
+        let parsed = inference_parser::parse_into(arena, &source, module_path.clone());
+        arena = parsed.arena;
 
         // Surface a file's own syntax errors before resolving its imports. A
         // rejected `use a::b::*;` still lowers to the segments `a::b`, so without
@@ -135,7 +136,14 @@ fn discover_files(entry: &Path, src_root: &Path) -> anyhow::Result<Vec<Discovere
             return Err(parse_error(&module_path, entry, &parsed.errors));
         }
 
-        for segments in path_form_imports(&parsed.arena)? {
+        // `parse_into` lowers the file's `SourceFileData` after all of its defs and
+        // directives, so the file just parsed is the last one stored (pinned by
+        // `parse_into_allocates_the_new_file_last` in `core/parser`).
+        let file = arena
+            .last_source_file()
+            .expect("parse_into stores the file it just lowered");
+
+        for segments in path_form_imports(&arena, file)? {
             if visited.contains(&segments) {
                 continue;
             }
@@ -161,21 +169,33 @@ fn discover_files(entry: &Path, src_root: &Path) -> anyhow::Result<Vec<Discovere
             visited.insert(segments.clone());
             queue.push_back((segments, dep_path));
         }
-
-        files.push(DiscoveredFile {
-            module_path,
-            source,
-        });
     }
 
-    Ok(files)
+    // Files were parsed in discovery (BFS) order; downstream phases consume
+    // canonical order as their single source of truth, so reorder now — before any
+    // `SourceFileId` is handed out.
+    arena.canonicalize_source_file_order();
+
+    // Discovery deduplicates files by module path (and self-imports of the entry),
+    // so each file appears exactly once. A duplicate would lower the same
+    // definitions twice and emit them twice in codegen; assert the invariant so a
+    // future discovery regression is caught here rather than in the output.
+    debug_assert!(
+        arena
+            .source_files()
+            .collect::<Vec<_>>()
+            .windows(2)
+            .all(|w| w[0].module_path != w[1].module_path),
+        "discovered files must have unique module paths after deduplication"
+    );
+
+    Ok(arena)
 }
 
 /// Builds a parse-failure error for `errors`. An imported (non-entry) file is
 /// named by its canonical `module_path`; the entry file is named by its real
 /// `entry` path with non-"imported" wording, because it is the file the user
-/// compiled. Shared by discovery and lowering so both report syntax errors
-/// identically.
+/// compiled.
 fn parse_error(
     module_path: &[String],
     entry: &Path,
@@ -206,55 +226,19 @@ fn parse_error(
     }
 }
 
-/// Lowers every discovered file into one arena in canonical order: entry first,
-/// then imported files sorted lexicographically by module path. The stored order
-/// is what later phases consume, so it is independent of discovery order.
-fn lower_in_canonical_order(
-    mut files: Vec<DiscoveredFile>,
-    entry: &Path,
-) -> anyhow::Result<AstArena> {
-    files.sort_by(|a, b| {
-        // The entry (empty path) sorts first; the empty Vec already compares
-        // less than any non-empty one, so a plain lexicographic order suffices.
-        a.module_path.cmp(&b.module_path)
-    });
-
-    // Discovery deduplicates files by module path (and self-imports of the entry),
-    // so each file appears exactly once. A duplicate would lower the same
-    // definitions twice and emit them twice in codegen; assert the invariant so a
-    // future discovery regression is caught here rather than in the output.
-    debug_assert!(
-        files.windows(2).all(|w| w[0].module_path != w[1].module_path),
-        "discovered files must have unique module paths after deduplication"
-    );
-
-    let mut arena = AstArena::default();
-    for file in files {
-        // Keep the path for the error arm before it is moved into `parse_into`.
-        // Discovery already rejects any file with syntax errors, so this arm is a
-        // defensive backstop that surfaces them identically should lowering ever
-        // observe an error discovery did not.
-        let module_path = file.module_path.clone();
-        let parse = inference_parser::parse_into(arena, &file.source, file.module_path);
-        arena = parse.arena;
-        if !parse.errors.is_empty() {
-            return Err(parse_error(&module_path, entry, &parse.errors));
-        }
-    }
-    Ok(arena)
-}
-
 /// Extracts the path-form `use` imports of an already-parsed file as canonical
 /// module-path segment lists. A braced item import (`use a::b::{x};`) maps to the
 /// file `a::b` — the segments *before* the brace list. The `from`-form is skipped.
 ///
-/// The caller parses the file and surfaces any syntax errors first, so only the
-/// directive shapes of a cleanly-parsed file reach here.
-fn path_form_imports(arena: &AstArena) -> anyhow::Result<Vec<Vec<String>>> {
-    let Some(source_file) = arena.source_files().next() else {
-        return Ok(Vec::new());
-    };
-
+/// The caller passes the just-lowered file explicitly, because the shared arena
+/// holds every file walked so far; `arena` is still needed to resolve the
+/// directives' segment identifiers. The caller parses the file and surfaces any
+/// syntax errors first, so only the directive shapes of a cleanly-parsed file
+/// reach here.
+fn path_form_imports(
+    arena: &AstArena,
+    source_file: &SourceFileData,
+) -> anyhow::Result<Vec<Vec<String>>> {
     let mut imports = Vec::new();
     for directive in &source_file.directives {
         let Directive::Use(use_dir) = directive;
@@ -1140,6 +1124,42 @@ mod tests {
                 mp(&["zed"]),
             ],
         );
+    }
+
+    #[test]
+    fn defs_stay_attached_to_their_files_when_bfs_and_canonical_orders_differ() {
+        // Discovery visits entry -> zebra -> alpha (BFS), but the canonical order
+        // is entry, alpha, zebra, so the post-walk reorder genuinely moves files.
+        // After it, every file's `defs` must still resolve to that file's own
+        // function: a reorder that shuffled files without keeping their defs would
+        // cross-wire them, and this is the only test targeting that failure mode.
+        let project = TempProject::new("bfs-vs-canonical");
+        let entry = project.write("main.inf", "use zebra;\npub fn main() {}");
+        project.write("zebra.inf", "use alpha;\npub fn zebra_fn() {}");
+        project.write("alpha.inf", "pub fn alpha_fn() {}");
+
+        let parse = parse_project(&entry).expect("project parses");
+
+        assert_eq!(
+            module_paths(&parse),
+            vec![Vec::<String>::new(), mp(&["alpha"]), mp(&["zebra"])],
+        );
+
+        let def_names = |module_path: Vec<String>| -> Vec<String> {
+            let file = parse
+                .arena
+                .source_files()
+                .find(|sf| sf.module_path == module_path)
+                .expect("file present in arena");
+            file.defs
+                .iter()
+                .map(|&def_id| parse.arena.def_name(def_id).to_string())
+                .collect()
+        };
+
+        assert_eq!(def_names(Vec::new()), vec!["main".to_string()]);
+        assert_eq!(def_names(mp(&["alpha"])), vec!["alpha_fn".to_string()]);
+        assert_eq!(def_names(mp(&["zebra"])), vec!["zebra_fn".to_string()]);
     }
 
     // Axis: `pub use` in the closure walk

--- a/core/parser/src/lib.rs
+++ b/core/parser/src/lib.rs
@@ -432,4 +432,45 @@ mod parse_into_tests {
             ],
         );
     }
+
+    /// The project front end builds its arena incrementally: after each
+    /// `parse_into` it reads the file it just parsed via
+    /// `arena.last_source_file()`, relying on lowering allocating a file's
+    /// `SourceFileData` AFTER all of that file's defs and directives — so the
+    /// newest file is always the last in allocation order. This test pins that
+    /// alloc'd-last invariant at the seam that produces it, so a future lowering
+    /// reshuffle fails here, with a named test, instead of surfacing as a
+    /// mysterious mis-walk in the incremental consumer.
+    #[test]
+    fn parse_into_allocates_the_new_file_last() {
+        fn assert_newest(arena: &AstArena, module_path: &[&str], fn_name: &str) {
+            let last = arena
+                .last_source_file()
+                .expect("parse_into just lowered a file");
+            let expected: Vec<String> = module_path.iter().map(|s| s.to_string()).collect();
+            assert_eq!(last.module_path, expected);
+            let names: Vec<&str> = last
+                .defs
+                .iter()
+                .map(|&def_id| arena.def_name(def_id))
+                .collect();
+            assert!(
+                names.contains(&fn_name),
+                "newest file should carry its own def `{fn_name}`, got {names:?}",
+            );
+        }
+
+        let entry = parse_into(AstArena::default(), "pub fn main() {}", Vec::new());
+        assert_newest(&entry.arena, &[], "main");
+
+        let a = parse_into(
+            entry.arena,
+            "pub fn alpha() {}",
+            vec!["lib".to_string(), "a".to_string()],
+        );
+        assert_newest(&a.arena, &["lib", "a"], "alpha");
+
+        let b = parse_into(a.arena, "pub fn util_fn() {}", vec!["util".to_string()]);
+        assert_newest(&b.arena, &["util"], "util_fn");
+    }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-contained performance fix with no observable behaviour change for correct inputs.

Every reachable code path is exercised: the allocation-order invariant is pinned by a named cross-crate test, the sort is validated by seven arena-level tests (including the cross-wiring and idempotence cases), and an end-to-end integration test checks the BFS-vs-canonical reorder scenario. The module_path clone-before-move and the last_source_file borrow lifetime are both handled correctly. No pre-existing invariants are broken.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/ast/src/arena.rs | Adds canonicalize_source_file_order (take → sort by module_path → rebuild Arena) and last_source_file (values().next_back()); both implementations are correct against the la_arena Vec-backed Arena. Doc comments clearly flag SourceFileId invalidation post-reorder. Test coverage is thorough. |
| core/inference/src/project.rs | Merges discovery + lowering into one BFS pass with parse_into per file. module_path is correctly cloned before the move so the original remains available for parse_error. last_source_file borrow and parse_into move sequencing is safe. path_form_imports signature is updated to take the just-lowered file explicitly, fixing the previous assumption of a single-file arena. |
| core/parser/src/lib.rs | Adds parse_into_allocates_the_new_file_last test to pin the allocation-order invariant that the project front end's incremental BFS relies on. Test is clear and effective. |
| CHANGELOG.md | Adds performance entry for the single-pass parsing optimisation with correct issue link. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PF as parse_project
    participant PRF as parse_reachable_files
    participant PI as parse_into (parser)
    participant Arena as AstArena
    participant FS as Filesystem

    PF->>PRF: entry, src_root
    loop BFS queue not empty
        PRF->>FS: read_source(file_path)
        FS-->>PRF: source text
        PRF->>PI: parse_into(arena, source, module_path.clone())
        PI->>Arena: alloc defs, directives, then SourceFileData
        PI-->>PRF: "ParseIntoResult { arena, errors }"
        PRF->>Arena: "last_source_file() → &SourceFileData"
        Arena-->>PRF: just-lowered file
        PRF->>PRF: path_form_imports(arena, file) → segments
        PRF->>PRF: enqueue unvisited dependencies
    end
    PRF->>Arena: canonicalize_source_file_order()
    Note over Arena: sort source_files by module_path, invalidates SourceFileIds
    PRF-->>PF: AstArena (canonical order)
    PF->>PF: collect_unreachable_warnings
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PF as parse_project
    participant PRF as parse_reachable_files
    participant PI as parse_into (parser)
    participant Arena as AstArena
    participant FS as Filesystem

    PF->>PRF: entry, src_root
    loop BFS queue not empty
        PRF->>FS: read_source(file_path)
        FS-->>PRF: source text
        PRF->>PI: parse_into(arena, source, module_path.clone())
        PI->>Arena: alloc defs, directives, then SourceFileData
        PI-->>PRF: "ParseIntoResult { arena, errors }"
        PRF->>Arena: "last_source_file() → &SourceFileData"
        Arena-->>PRF: just-lowered file
        PRF->>PRF: path_form_imports(arena, file) → segments
        PRF->>PRF: enqueue unvisited dependencies
    end
    PRF->>Arena: canonicalize_source_file_order()
    Note over Arena: sort source_files by module_path, invalidates SourceFileIds
    PRF-->>PF: AstArena (canonical order)
    PF->>PF: collect_unreachable_warnings
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Update project.rs"](https://github.com/inferara/inference/commit/d369114bf2ebbb464014d56689f4d3366def2a25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41406659)</sub>

<!-- /greptile_comment -->