### PR TITLE
lsp: contain analysis panics in the message loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -730,6 +730,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `wasm_to_v` public API signature — parameter changed from `&Vec<u8>` to idiomatic `&[u8]`
 - ide: the resilient project walk (`inference::load_project_resilient`) no longer runs the unreachable-file warning scan at all — `ResilientProjectParse::warnings` is documented always-empty. The scan recursively walked and canonicalized every `.inf` under the source root on every keystroke (and, for a document at a volume root like `/main.inf`, the entire disk) to compute warnings the IDE discards. The fail-fast compiler path (`parse_project`) keeps the scan — it runs once per build, not once per keystroke — so compiler behavior is unchanged ([#33])
 - Extern-import diagnostics (`use { … } from <module>;` binding errors such as an undeclared extern import or an ambiguous extern module) reported from an *imported* file now carry that file's module-path label instead of rendering as if they were in the entry file. Locations are per-file-local, so the missing label made these errors point at wrong positions in the entry file — visible in both the aggregated compiler message and the structured diagnostics the LSP consumes ([#33])
+- lsp: an unwinding panic in the analysis stack (a `todo!`/`unwrap` in the type-checker or analysis passes, e.g. a named constant used as an array size) no longer kills the whole server session. The message loop now wraps each request and notification in a panic boundary (`std::panic::catch_unwind`): a panicking request is answered with a JSON-RPC `InternalError` carrying its original id, and a panicking notification publishes nothing and rebuilds the analysis host from the tracked open documents so later queries start from consistent state. Every other open document keeps working, and one bad file can no longer crash-loop the server into a permanent outage. Genuinely unrecoverable failures (stack overflow) still abort as before, and the panic message still goes only to stderr, never the stdout protocol channel ([#241])
 
 ### Project Manifest
 
@@ -924,3 +925,4 @@ Initial tagged release.
 [#227]: https://github.com/Inferara/inference/issues/227
 [#217]: https://github.com/Inferara/inference/issues/217
 [#33]: https://github.com/Inferara/inference/issues/33
+[#241]: https://github.com/Inferara/inference/issues/241

--- a/apps/lsp/README.md
+++ b/apps/lsp/README.md
@@ -131,6 +131,18 @@ protocol stream — and is asserted directly by an end-to-end test (below).
   enough to exhaust even 64 MiB would still abort — bounding the recursion in
   the shared pipeline (out of scope for this crate) would be the complete fix.
 
+- **An unwinding analysis panic is contained, not fatal.** An ordinary panic in
+  the analysis stack (a `todo!` or `unwrap` in the type-checker or analysis
+  passes) *unwinds* — unlike a stack overflow — so the message loop catches it:
+  each request and notification is dispatched inside `std::panic::catch_unwind`.
+  A panicking request is answered with a JSON-RPC `InternalError` carrying its
+  original id; a panicking notification publishes nothing and rebuilds the
+  analysis host from the tracked open documents, so the session continues from
+  consistent state instead of aborting and letting the client crash-loop the
+  server into a permanent outage. The panic still reaches stderr through the
+  default hook (never stdout, the protocol channel). This is the recoverable
+  counterpart to the stack-overflow case above.
+
 - **A malformed transport frame is fatal.** `lsp-server`'s stdio reader treats
   any framing or body parse failure — an empty body (`Content-Length: 0`), a
   non-JSON body, or an unparsable `Content-Length` — as fatal to the connection.

--- a/apps/lsp/src/handlers.rs
+++ b/apps/lsp/src/handlers.rs
@@ -6,6 +6,8 @@
 //! (a non-`file` scheme, an untitled buffer) yields a null result and no
 //! diagnostics, never a panic.
 
+use std::sync::Arc;
+
 use inference_ide as ide;
 use lsp_types::{
     CompletionParams, CompletionResponse, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
@@ -149,12 +151,14 @@ pub(crate) fn did_open(
 ) -> Option<PublishDiagnosticsParams> {
     let document = params.text_document;
     let path = uri::to_path(&document.uri)?;
-    state.host.open_document(&path, document.text);
+    let text: Arc<str> = document.text.into();
+    state.host.open_document(&path, Arc::clone(&text));
     state.documents.insert(
         document.uri.clone(),
         Document {
             path,
             version: document.version,
+            text,
         },
     );
     Some(publish_diagnostics_params(state, &document.uri))
@@ -168,11 +172,16 @@ pub(crate) fn did_change(
     let version = params.text_document.version;
     let path = uri::to_path(&uri)?;
     // Full-text sync: the last content change carries the whole new document.
-    let text = params.content_changes.into_iter().next_back()?.text;
-    state.host.change_document(&path, text);
-    state
-        .documents
-        .insert(uri.clone(), Document { path, version });
+    let text: Arc<str> = params.content_changes.into_iter().next_back()?.text.into();
+    state.host.change_document(&path, Arc::clone(&text));
+    state.documents.insert(
+        uri.clone(),
+        Document {
+            path,
+            version,
+            text,
+        },
+    );
     Some(publish_diagnostics_params(state, &uri))
 }
 

--- a/apps/lsp/src/server.rs
+++ b/apps/lsp/src/server.rs
@@ -8,10 +8,14 @@
 //! results back. Nothing here prints to stdout; that stream is the protocol
 //! channel.
 
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use inference_ide::AnalysisHost;
-use lsp_server::{Connection, ErrorCode, ExtractError, Message, Notification, Request, Response};
+use lsp_server::{
+    Connection, ErrorCode, ExtractError, Message, Notification, Request, RequestId, Response,
+};
 use lsp_types::notification::{
     DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Exit, Notification as _,
     PublishDiagnostics,
@@ -31,6 +35,11 @@ use crate::handlers;
 pub(crate) struct Document {
     pub(crate) path: PathBuf,
     pub(crate) version: i32,
+    /// The document's last-seen text. Retained so [`ServerState`] can rebuild the
+    /// analysis host from the tracked documents after a contained panic, without
+    /// re-reading anything from disk (the editor's overlay may never have been
+    /// saved).
+    pub(crate) text: Arc<str>,
 }
 
 /// The analysis host plus per-document bookkeeping. Feature queries and
@@ -50,6 +59,21 @@ impl ServerState {
             documents: FxHashMap::default(),
             hierarchical_symbols,
         }
+    }
+
+    /// Routes a request through [`handle_request`](Self::handle_request),
+    /// containing any panic in the analysis stack.
+    ///
+    /// A `todo!`/`unwrap` deep in the type-checker or analysis passes (the class
+    /// tracked in #240) unwinds; left unguarded it would tear down the whole
+    /// session. Caught here, the offending request is answered with an
+    /// `InternalError` carrying its original id — so the client can correlate the
+    /// failure — and every other document keeps working. A stack overflow aborts
+    /// the process on its own and cannot be caught; that is intentionally left to
+    /// abort.
+    pub(crate) fn handle_request_resilient(&mut self, request: Request) -> Response {
+        let id = request.id.clone();
+        catch(|| self.handle_request(request)).unwrap_or_else(|| panic_response(id))
     }
 
     /// Routes a request to its handler, producing the response to send back. An
@@ -100,6 +124,30 @@ impl ServerState {
                     request.method
                 ),
             ),
+        }
+    }
+
+    /// Applies a document notification through
+    /// [`on_notification`](Self::on_notification), containing any panic in the
+    /// analysis stack.
+    ///
+    /// Diagnostics are computed on the message loop thread, so a panic while
+    /// analyzing a just-opened or just-changed document would otherwise abort the
+    /// session — and, because the client re-sends the same `didOpen` on restart,
+    /// crash-loop until it gives up (#241). Caught here, the failed notification
+    /// publishes nothing, and the analysis host — which the unwinding computation
+    /// may have left with half-updated state — is rebuilt from the tracked open
+    /// documents so later queries start from a clean, consistent host.
+    pub(crate) fn on_notification_resilient(
+        &mut self,
+        notification: Notification,
+    ) -> Vec<PublishDiagnosticsParams> {
+        match catch(|| self.on_notification(notification)) {
+            Some(publishes) => publishes,
+            None => {
+                self.rebuild_host();
+                Vec::new()
+            }
         }
     }
 
@@ -162,6 +210,23 @@ impl ServerState {
         }
         publishes
     }
+
+    /// Replaces the analysis host with a fresh one carrying only the tracked open
+    /// documents' last-seen text.
+    ///
+    /// Called after a contained analysis panic: rather than reason about which
+    /// cached state the unwinding computation may have corrupted, the host is
+    /// discarded and rebuilt from the [`documents`](Self::documents) the server
+    /// still considers open. The first query after this recomputes every analysis
+    /// from scratch. Documents are the sole source of truth here, so anything the
+    /// editor had not opened is simply gone — which is correct.
+    fn rebuild_host(&mut self) {
+        let mut host = AnalysisHost::default();
+        for document in self.documents.values() {
+            host.open_document(&document.path, Arc::clone(&document.text));
+        }
+        self.host = host;
+    }
 }
 
 /// Runs the message loop until the client exits or the connection closes.
@@ -175,6 +240,12 @@ impl ServerState {
 /// notification but `exit` is ignored. The `exit` notification ends the loop.
 /// Every other request is routed through [`ServerState`], and document
 /// notifications may publish diagnostics.
+///
+/// Requests and notifications are dispatched through the resilient wrappers
+/// ([`handle_request_resilient`](ServerState::handle_request_resilient),
+/// [`on_notification_resilient`](ServerState::on_notification_resilient)), so an
+/// unwinding panic in the analysis stack fails a single request or publish
+/// instead of the whole session.
 ///
 /// # Errors
 ///
@@ -203,7 +274,7 @@ pub fn run(connection: Connection, init_params: &InitializeParams) -> anyhow::Re
                 )?;
             }
             Message::Request(request) => {
-                let response = state.handle_request(request);
+                let response = state.handle_request_resilient(request);
                 send(&connection, Message::Response(response))?;
             }
             Message::Notification(notification) if notification.method == Exit::METHOD => {
@@ -212,7 +283,7 @@ pub fn run(connection: Connection, init_params: &InitializeParams) -> anyhow::Re
             // A stray notification after `shutdown` (other than `exit`) is dropped.
             Message::Notification(_) if shutting_down => {}
             Message::Notification(notification) => {
-                for params in state.on_notification(notification) {
+                for params in state.on_notification_resilient(notification) {
                     let published =
                         Notification::new(PublishDiagnostics::METHOD.to_owned(), params);
                     send(&connection, Message::Notification(published))?;
@@ -243,23 +314,94 @@ fn send(connection: &Connection, message: Message) -> anyhow::Result<()> {
         .map_err(|error| anyhow::anyhow!("failed to send message: {error}"))
 }
 
+/// Runs `f`, containing an unwinding panic and returning `None` in its place.
+///
+/// The process-wide panic hook still runs first, so the panic's message and
+/// backtrace are written to stderr as usual — only the unwind is swallowed, and
+/// only stderr (never stdout, the protocol channel) is touched. `f` borrows the
+/// server state mutably, which is not `UnwindSafe`; asserting it is safe is sound
+/// here because the sole recovery — [`ServerState::rebuild_host`] — discards the
+/// state a panic could have left inconsistent rather than reading it back.
+fn catch<R>(f: impl FnOnce() -> R) -> Option<R> {
+    std::panic::catch_unwind(AssertUnwindSafe(f)).ok()
+}
+
+/// The response to a request whose handler panicked: the analysis stack unwound
+/// and was contained, so this request fails but the session lives on. The
+/// original request id is echoed so the client can match the failure to its call.
+fn panic_response(id: RequestId) -> Response {
+    Response::new_err(
+        id,
+        ErrorCode::InternalError as i32,
+        "the request handler panicked and was contained; the server is still running".to_owned(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
     use lsp_server::{Request, RequestId, Response};
     use lsp_types::notification::{
         DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, Notification as _,
     };
     use lsp_types::request::{HoverRequest, Request as _};
+    use lsp_types::Uri;
 
-    use super::ServerState;
+    use super::{Document, ServerState};
+
+    /// A document that panics the analysis stack: a named constant used as an
+    /// array size hits an unimplemented `todo!` deep in the type-checker (#240).
+    /// It is the most direct in-tree trigger for the message-loop panic boundary;
+    /// if #240 is fixed so this no longer panics, replace it with another
+    /// deterministic panic trigger.
+    const PANIC_SOURCE: &str = "const N: i32 = 3;\n\
+fn main() -> i32 { let arr: [i32; N] = [1, 2, 3]; let i: i32 = 0; return arr[i]; }";
 
     fn open(state: &mut ServerState, uri: &str, text: &str) {
+        state.on_notification(did_open_notification(uri, text));
+    }
+
+    fn did_open_notification(uri: &str, text: &str) -> lsp_server::Notification {
         let params = serde_json::json!({
             "textDocument": { "uri": uri, "languageId": "inference", "version": 1, "text": text }
         });
-        let notification =
-            lsp_server::Notification::new(DidOpenTextDocument::METHOD.to_owned(), params);
-        state.on_notification(notification);
+        lsp_server::Notification::new(DidOpenTextDocument::METHOD.to_owned(), params)
+    }
+
+    /// Installs `text` as the overlay for `uri` and tracks the document, without
+    /// computing diagnostics — so a document whose *analysis* panics can be staged
+    /// for a later query without the staging itself unwinding.
+    fn track(state: &mut ServerState, uri: &str, text: &str) {
+        let uri = Uri::from_str(uri).expect("a valid uri");
+        let path = crate::uri::to_path(&uri).expect("a file uri");
+        let text: Arc<str> = text.into();
+        state.host.open_document(&path, Arc::clone(&text));
+        state.documents.insert(
+            uri,
+            Document {
+                path,
+                version: 1,
+                text,
+            },
+        );
+    }
+
+    fn diagnostics_for(state: &mut ServerState, uri: &str) -> Vec<lsp_types::Diagnostic> {
+        let uri = Uri::from_str(uri).expect("a valid uri");
+        crate::handlers::publish_diagnostics_params(state, &uri).diagnostics
+    }
+
+    fn hover_request(id: i32, uri: &str, line: u32, character: u32) -> Request {
+        Request::new(
+            RequestId::from(id),
+            HoverRequest::METHOD.to_owned(),
+            serde_json::json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }),
+        )
     }
 
     fn error_code(response: &Response) -> i32 {
@@ -416,6 +558,100 @@ mod tests {
         assert!(
             state.on_notification(notification).is_empty(),
             "an untitled buffer is not analyzed and publishes nothing"
+        );
+    }
+
+    #[test]
+    fn rebuild_host_reconstructs_tracked_documents() {
+        let mut state = ServerState::new(true);
+        open(
+            &mut state,
+            "file:///inf-test/clean.inf",
+            "fn f() -> i32 { return 1; }",
+        );
+        open(
+            &mut state,
+            "file:///inf-test/broken.inf",
+            "fn g() -> i32 { return x; }",
+        );
+
+        state.rebuild_host();
+
+        // The rebuilt host carries each tracked document's last-seen text, so the
+        // clean file is still clean and the broken one still reports its undeclared
+        // variable — proving the text, not just the path, survives the rebuild.
+        assert!(
+            diagnostics_for(&mut state, "file:///inf-test/clean.inf").is_empty(),
+            "the clean document stays clean after a rebuild"
+        );
+        assert!(
+            !diagnostics_for(&mut state, "file:///inf-test/broken.inf").is_empty(),
+            "the broken document still reports after a rebuild"
+        );
+    }
+
+    #[test]
+    fn handle_request_resilient_contains_a_handler_panic() {
+        let mut state = ServerState::new(true);
+        // Stage both documents without analyzing them (analyzing the panic file
+        // would unwind on its own); the requests below are what must be contained.
+        // Requests never republish, so staging a healthy sibling this way is safe.
+        track(&mut state, "file:///inf-test/panic.inf", PANIC_SOURCE);
+        track(
+            &mut state,
+            "file:///inf-test/ok.inf",
+            "fn f() -> i32 { return 1; }",
+        );
+
+        let response =
+            state.handle_request_resilient(hover_request(1, "file:///inf-test/panic.inf", 1, 25));
+        assert_eq!(
+            error_code(&response),
+            lsp_server::ErrorCode::InternalError as i32,
+            "a panicking handler answers InternalError"
+        );
+        assert_eq!(
+            response.id,
+            RequestId::from(1),
+            "the failed request's own id is echoed back"
+        );
+
+        // A healthy request against another document still succeeds afterward.
+        let good =
+            state.handle_request_resilient(hover_request(2, "file:///inf-test/ok.inf", 0, 3));
+        assert!(
+            good.error.is_none(),
+            "the server still answers after containing a panic"
+        );
+    }
+
+    #[test]
+    fn on_notification_resilient_contains_a_diagnostics_panic_and_recovers() {
+        let mut state = ServerState::new(true);
+        // A healthy document opened before the bad one; the bad open's panic must
+        // not disturb it. (An undeclared variable keeps its diagnostics non-empty.)
+        open(
+            &mut state,
+            "file:///inf-test/ok.inf",
+            "fn g() -> i32 { return x; }",
+        );
+
+        // Opening a document whose diagnostics computation panics publishes nothing
+        // and rebuilds the host rather than tearing down the session.
+        let publishes = state.on_notification_resilient(did_open_notification(
+            "file:///inf-test/panic.inf",
+            PANIC_SOURCE,
+        ));
+        assert!(
+            publishes.is_empty(),
+            "a panic during diagnostics publishes nothing"
+        );
+
+        // The host was rebuilt from the tracked documents, so the healthy document
+        // is still analyzable and still reports its undeclared variable.
+        assert!(
+            !diagnostics_for(&mut state, "file:///inf-test/ok.inf").is_empty(),
+            "the healthy document survives the recovery and is still analyzed"
         );
     }
 }

--- a/apps/lsp/src/server.rs
+++ b/apps/lsp/src/server.rs
@@ -66,14 +66,28 @@ impl ServerState {
     ///
     /// A `todo!`/`unwrap` deep in the type-checker or analysis passes (the class
     /// tracked in #240) unwinds; left unguarded it would tear down the whole
-    /// session. Caught here, the offending request is answered with an
-    /// `InternalError` carrying its original id — so the client can correlate the
-    /// failure — and every other document keeps working. A stack overflow aborts
-    /// the process on its own and cannot be caught; that is intentionally left to
-    /// abort.
+    /// session. Caught here, the analysis host is rebuilt from the tracked open
+    /// documents — the same recovery the notification path takes — the offending
+    /// request is answered with an `InternalError` carrying its original id (so
+    /// the client can correlate the failure), and every other document keeps
+    /// working. A stack overflow aborts the process on its own and cannot be
+    /// caught; that is intentionally left to abort.
+    ///
+    /// A memoizing query does mutate the host: it bumps the analysis generation
+    /// stamp before computing an analysis and stores the finished analysis only
+    /// afterward, so a panic partway through leaves at most a bumped stamp and
+    /// never a half-built cache entry. The unconditional rebuild does not lean on
+    /// that invariant — it keeps the recovery identical to the notification path
+    /// and robust to future changes in what a query mutates.
     pub(crate) fn handle_request_resilient(&mut self, request: Request) -> Response {
         let id = request.id.clone();
-        catch(|| self.handle_request(request)).unwrap_or_else(|| panic_response(id))
+        match catch(|| self.handle_request(request)) {
+            Some(response) => response,
+            None => {
+                self.rebuild_host();
+                panic_response(id)
+            }
+        }
     }
 
     /// Routes a request to its handler, producing the response to send back. An
@@ -320,8 +334,9 @@ fn send(connection: &Connection, message: Message) -> anyhow::Result<()> {
 /// backtrace are written to stderr as usual — only the unwind is swallowed, and
 /// only stderr (never stdout, the protocol channel) is touched. `f` borrows the
 /// server state mutably, which is not `UnwindSafe`; asserting it is safe is sound
-/// here because the sole recovery — [`ServerState::rebuild_host`] — discards the
-/// state a panic could have left inconsistent rather than reading it back.
+/// because both callers treat a caught panic the same way: they discard the host
+/// with [`ServerState::rebuild_host`] and never read the possibly-inconsistent
+/// cached state back. Any future `catch` site must recover the same way.
 fn catch<R>(f: impl FnOnce() -> R) -> Option<R> {
     std::panic::catch_unwind(AssertUnwindSafe(f)).ok()
 }
@@ -591,10 +606,10 @@ fn main() -> i32 { let arr: [i32; N] = [1, 2, 3]; let i: i32 = 0; return arr[i];
     }
 
     #[test]
-    fn handle_request_resilient_contains_a_handler_panic() {
+    fn handle_request_resilient_contains_a_handler_panic_and_rebuilds_the_host() {
         let mut state = ServerState::new(true);
         // Stage both documents without analyzing them (analyzing the panic file
-        // would unwind on its own); the requests below are what must be contained.
+        // would unwind on its own); the request below is what must be contained.
         // Requests never republish, so staging a healthy sibling this way is safe.
         track(&mut state, "file:///inf-test/panic.inf", PANIC_SOURCE);
         track(
@@ -602,6 +617,18 @@ fn main() -> i32 { let arr: [i32; N] = [1, 2, 3]; let i: i32 = 0; return arr[i];
             "file:///inf-test/ok.inf",
             "fn f() -> i32 { return 1; }",
         );
+
+        // The recovery rebuilds the host from the tracked documents, so make the
+        // sibling's *tracked* text (a rebuild's only input) diverge from its stale
+        // host overlay: an undeclared variable the current host, still holding the
+        // clean overlay, would not report. A reported diagnostic afterward can then
+        // only come from a rebuild.
+        let ok_uri = Uri::from_str("file:///inf-test/ok.inf").expect("a valid uri");
+        state
+            .documents
+            .get_mut(&ok_uri)
+            .expect("the tracked document")
+            .text = "fn g() -> i32 { return x; }".into();
 
         let response =
             state.handle_request_resilient(hover_request(1, "file:///inf-test/panic.inf", 1, 25));
@@ -616,12 +643,12 @@ fn main() -> i32 { let arr: [i32; N] = [1, 2, 3]; let i: i32 = 0; return arr[i];
             "the failed request's own id is echoed back"
         );
 
-        // A healthy request against another document still succeeds afterward.
-        let good =
-            state.handle_request_resilient(hover_request(2, "file:///inf-test/ok.inf", 0, 3));
+        // The host was rebuilt from the tracked documents — proven by the sibling's
+        // last-seen text (not its stale overlay) now being analyzed and reporting
+        // its undeclared variable — so the session keeps serving from a clean host.
         assert!(
-            good.error.is_none(),
-            "the server still answers after containing a panic"
+            !diagnostics_for(&mut state, "file:///inf-test/ok.inf").is_empty(),
+            "the sibling's tracked text is analyzed after the rebuild"
         );
     }
 

--- a/apps/lsp/tests/e2e.rs
+++ b/apps/lsp/tests/e2e.rs
@@ -27,6 +27,14 @@ const INLAY_KIND_TYPE: i64 = 1;
 // JSON-RPC error codes.
 const METHOD_NOT_FOUND: i64 = -32601;
 const INVALID_PARAMS: i64 = -32602;
+const INTERNAL_ERROR: i64 = -32603;
+
+/// A document whose *analysis* panics: a named constant used as an array size
+/// hits an unimplemented `todo!` deep in the type-checker (#240). It is the most
+/// direct in-tree trigger for the message-loop panic boundary; if #240 is fixed
+/// so this no longer unwinds, replace it with another deterministic panic.
+const PANIC_SOURCE: &str = "const N: i32 = 3;\n\
+fn main() -> i32 { let arr: [i32; N] = [1, 2, 3]; let i: i32 = 0; return arr[i]; }";
 
 /// A single-file fixture: an isolated temp dir with `main.inf` written to disk,
 /// plus its `file://` URI. The returned [`TempDir`] must be kept alive for the
@@ -947,6 +955,110 @@ fn query_or_fragment_uri_is_ignored_without_crashing() {
         hover.get("error").is_none(),
         "the server survived the query-bearing open"
     );
+
+    client.shutdown_exit_ok();
+}
+
+// --- 22. an analysis panic is contained, not fatal to the session (#241) ------
+
+#[test]
+fn a_request_whose_analysis_panics_is_answered_internal_error() {
+    let mut client = LspClient::spawn();
+    client.initialize_default(true);
+
+    // The panic file lives on disk but is never opened; a request against it reads
+    // it from disk, analyzes, and unwinds. The message-loop boundary must turn that
+    // into a failed request carrying its own id, not a dead process.
+    let (_dir, panic_uri) = fixture("panic-request", PANIC_SOURCE);
+    let healthy = "fn f() -> i32 { return 1; }";
+    let (_healthy_dir, healthy_uri) = fixture("panic-request-healthy", healthy);
+    client.did_open(&healthy_uri, healthy, 1);
+
+    let response = hover_request(&mut client, &panic_uri, pos_at(PANIC_SOURCE, "arr"));
+    assert_eq!(
+        response["error"]["code"],
+        json!(INTERNAL_ERROR),
+        "a request whose analysis panics is answered InternalError, got {response}"
+    );
+
+    // The server still answers a well-formed request against a healthy document.
+    let hover = hover_request(&mut client, &healthy_uri, pos_at(healthy, "f("));
+    assert!(
+        hover.get("error").is_none(),
+        "the server stays responsive after containing the panic, got {hover}"
+    );
+
+    client.shutdown_exit_ok();
+}
+
+#[test]
+fn a_didopen_whose_diagnostics_panic_does_not_kill_the_server() {
+    let mut client = LspClient::spawn();
+    client.initialize_default(true);
+
+    let healthy = "fn f() -> i32 { return 1; }";
+    let (_healthy_dir, healthy_uri) = fixture("panic-didopen-healthy", healthy);
+    client.did_open(&healthy_uri, healthy, 1);
+
+    // Opening the panic file computes its diagnostics on the loop thread, which
+    // unwinds. The notification boundary contains it: nothing is published for the
+    // file (so we must not wait on a publish that never comes), and the session
+    // lives on. Sent raw for that reason.
+    let (_dir, panic_uri) = fixture("panic-didopen", PANIC_SOURCE);
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": panic_uri,
+                "languageId": "inference",
+                "version": 1,
+                "text": PANIC_SOURCE,
+            }
+        }),
+    );
+
+    // The healthy document is still served after the panicking open.
+    let hover = hover_request(&mut client, &healthy_uri, pos_at(healthy, "f("));
+    assert!(
+        hover.get("error").is_none(),
+        "the server survived the panicking didOpen and still answers, got {hover}"
+    );
+
+    client.shutdown_exit_ok();
+}
+
+#[test]
+fn repeated_didopen_of_a_panicking_document_never_kills_the_server() {
+    let mut client = LspClient::spawn();
+    client.initialize_default(true);
+
+    let healthy = "fn f() -> i32 { return 1; }";
+    let (_healthy_dir, healthy_uri) = fixture("panic-loop-healthy", healthy);
+    client.did_open(&healthy_uri, healthy, 1);
+
+    // The amplification the issue describes: a client that crashes and auto-restarts
+    // re-sends didOpen for the same bad file. Each didOpen unwinds during diagnostics;
+    // every one must be contained, and the healthy document stay answerable across all
+    // of them — otherwise one bad file becomes a permanent LSP outage.
+    let (_dir, panic_uri) = fixture("panic-loop", PANIC_SOURCE);
+    for version in 1..=5 {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": panic_uri,
+                    "languageId": "inference",
+                    "version": version,
+                    "text": PANIC_SOURCE,
+                }
+            }),
+        );
+        let hover = hover_request(&mut client, &healthy_uri, pos_at(healthy, "f("));
+        assert!(
+            hover.get("error").is_none(),
+            "the server is still alive after panicking didOpen #{version}, got {hover}"
+        );
+    }
 
     client.shutdown_exit_ok();
 }


### PR DESCRIPTION
Fixes #241.

A single unwinding panic anywhere in the analysis stack no longer kills the LSP server process (previously: panic → thread death → `join().expect` → process abort → client auto-restart loop → permanent LSP outage after ~5 crashes).

## Changes
- `server.rs`: requests and notifications dispatch through new `handle_request_resilient` / `on_notification_resilient` wrappers using `std::panic::catch_unwind(AssertUnwindSafe(..))`.
- A panicking request is answered with JSON-RPC `InternalError` (-32603) carrying the original request id; a panicking notification publishes nothing and rebuilds the `AnalysisHost` from the tracked open documents, so the server never serves from possibly-inconsistent state.
- `handlers.rs`: `Document` now keeps the current overlay text (`Arc<str>`) so the host rebuild does not re-read unsaved editor buffers from disk.
- Stack overflow still aborts (uncatchable; the 64 MiB loop stack remains the mitigation). The default panic hook keeps writing to stderr only — the stdout protocol channel stays clean.
- README + CHANGELOG updated.

## Testing
- Verified the #240 panic (named constant as array size) still reproduces and used it as the deterministic in-tree fixture.
- 3 new unit tests (host rebuild, request containment, notification containment + recovery) and 3 new e2e tests (InternalError answer, didOpen-panic survival, repeated didOpen of a panicking document never kills the server).
- `cargo test -p inference-lsp`: 41 unit + 30 e2e, 0 failed. `cargo clippy --all-targets -p inference-lsp -- -D warnings` clean. Full default-workspace `cargo test` green.

Note: #240 itself is intentionally not fixed here; it stays open and serves as the panic trigger in tests.

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary goal of preventing server death on panic, but a tracked panic document silently suppresses diagnostic updates for all other open files until closed.

After a didOpen for a panicking document is contained, that document ends up in state.documents. rebuild_host opens it into the fresh host. On every subsequent didChange for any other document, publishes_with_dependents calls publish_diagnostics_params for the panic document, panics again, and drops the entire result including the changed file's already-computed diagnostics. The client sees no diagnostic refreshes for healthy files as long as the panic document is open.

apps/lsp/src/server.rs — specifically publishes_with_dependents and how it interacts with documents that permanently panic on analysis

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/lsp/src/server.rs | Adds handle_request_resilient / on_notification_resilient wrappers and rebuild_host; contains panics correctly but a tracked panic document in state.documents causes every subsequent publishes_with_dependents call to panic and drop healthy-document diagnostics |
| apps/lsp/src/handlers.rs | Adds Arc<str> text field to Document struct via did_open / did_change; text is stored before analysis runs so rebuild_host always has current content; uses next_back() for content changes per project convention |
| apps/lsp/tests/e2e.rs | Three new e2e tests cover InternalError response, didOpen panic survival, and repeated-open loop; no test covers didChange on a healthy document while a panic document is concurrently open |
| CHANGELOG.md | Changelog entry added for the panic-containment feature; accurate and clearly written |
| apps/lsp/README.md | README extended with correct description of the new panic boundary, its limits (stack overflow still aborts), and its recoverable-vs-unrecoverable distinction |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/lsp/src/server.rs`, line 207-226 ([link](https://github.com/inferara/inference/blob/5f28be006d5d399034f52184ed321a42160e91af/apps/lsp/src/server.rs#L207-L226)) 

   **Panic document in `documents` causes `publishes_with_dependents` to suppress healthy-file diagnostics**

   When `on_notification_resilient` catches a panic from `did_open`, the document has already been inserted into `state.documents` (line 156-163 of `handlers.rs`), so `rebuild_host` opens the panic document into the fresh host. On every subsequent `didChange` or `didOpen` for a healthy file, `publishes_with_dependents` iterates over all tracked documents and calls `publish_diagnostics_params` for each — including the panic document, which panics again. That second panic propagates out of `publishes_with_dependents`, the entire `Vec<PublishDiagnosticsParams>` (which already had the healthy file's entry pushed at line 221) is unwound and dropped, and `on_notification_resilient` returns `Vec::new()`. The client permanently receives no diagnostic updates for any document as long as the panic file remains open, even though the changed file's diagnostics were successfully computed.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["lsp: rebuild the host after a contained ..."](https://github.com/inferara/inference/commit/5f28be006d5d399034f52184ed321a42160e91af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44779602)</sub>

<!-- /greptile_comment -->