### PR TITLE
refactoring: extract project front end into leaf inference-project-model crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WASM custom section name for the per-spec function index map is now `inference.spec_funcs` (vendor-prefixed namespace). External tools previously looking for `metadata.code.inference.spec_funcs` must update. The latter was a misuse of the WebAssembly tool-conventions reserved namespace ([CodeMetadata.md](https://github.com/WebAssembly/tool-conventions/blob/main/CodeMetadata.md)) ([issue#16])
 - `inference.spec_funcs` custom section payload now starts with a `varuint32` version byte (`1` for current format). Consumers should reject unsupported versions. This is a wire-format change — anyone parsing the section directly must update; the in-tree parser handles it transparently. ([issue#16])
 
+### Changed
+
+- Extract the shared project front end into a new leaf crate `inference-project-model` (`core/project-model`) so the IDE/LSP stack no longer transitively links the WASM/Rocq backend ([#256])
+  - The crate owns the import-closure walk and `FileLoader` seam (`parse_project`, `load_project_resilient`, `DiskLoader`, `ProjectParse`, `ResilientProjectParse`, …), `read_source_file`/`strip_utf8_bom`, the `InferenceError` project errors, and manifest source-root discovery (`manifest_source_root`). Its dependencies are leaf-safe (`inference-parser`, `inference-ast`, `toml`, `rustc-hash`) — no type-checker, codegen, or wasm crates.
+  - `core/inference` re-exports every one of these items unchanged, so `infc`, `infs`, tools, and tests keep reaching them as `inference::…` with no call-site churn; compiler behavior is byte-identical.
+  - `ide-db` now depends on `inference-project-model` instead of the full `inference` orchestration crate. `cargo tree -p inference-ide-db` (and `-p inference-ide`, `-p inference-lsp`) links none of `inference-wasm-codegen`, `inference-wasm-to-v-translator`, `inference-wasm-linker`, `inf-wasmparser`, or `wasm-encoder`.
+- Drop the always-empty `ResilientProjectParse::warnings` field (the resilient IDE walk never scans for unreachable files); the fail-fast `parse_project` keeps reporting `ProjectParse::warnings` ([#256])
+- Document `RootDatabase`'s single-threaded, read-through-`&mut self` query model on `RootDatabase` and `ide/ide`'s `Analysis`: memoizing on read forecloses cancellation and parallel reads until a Salsa-style rewrite ([#157]) ([#256])
+- Declare `serde_json` in `[workspace.dependencies]` and inherit it in `apps/lsp`, `apps/infs`, and `tests` ([#256])
+
 ### Language
 
 - File-based module hierarchy (Zig-style, no `mod` keyword) ([#63])
@@ -1023,3 +1033,5 @@ Initial tagged release.
 [#241]: https://github.com/Inferara/inference/issues/241
 [#240]: https://github.com/Inferara/inference/issues/240
 [#249]: https://github.com/Inferara/inference/issues/249
+[#157]: https://github.com/Inferara/inference/issues/157
+[#256]: https://github.com/Inferara/inference/issues/256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ repository = "https://github.com/Inferara/inference"
 [workspace.dependencies]
 # Core Inference crates
 inference = { path = "./core/inference", version = "0.0.1" }
+inference-project-model = { path = "./core/project-model", version = "0.0.1" }
 inference-ast = { path = "./core/ast", version = "0.0.1" }
 inference-parser = { path = "./core/parser", version = "0.0.1" }
 inference-type-checker = { path = "./core/type-checker", version = "0.0.1" }
@@ -61,6 +62,7 @@ inf-wasmparser = { path = "./tools/inf-wasmparser", version = "0.0.9" }
 anyhow = "1.0.101"
 thiserror = "2.0.18"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
+serde_json = "1.0.99"
 toml = "1.1.2"
 cov-mark = { version = "2.2.0", default-features = false }
 leb128 = "0.2.6"

--- a/apps/infs/Cargo.toml
+++ b/apps/infs/Cargo.toml
@@ -23,7 +23,7 @@ tar = "0.4"
 semver = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json.workspace = true
 toml = "1.1.2"
 hex = "0.4"
 futures-util = "0.3"

--- a/apps/lsp/Cargo.toml
+++ b/apps/lsp/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 lsp-server = "=0.8.0"
 lsp-types = "=0.97.0"
-serde_json = "1.0"
+serde_json.workspace = true
 anyhow.workspace = true
 rustc-hash.workspace = true
 inference-ide.workspace = true

--- a/core/inference/Cargo.toml
+++ b/core/inference/Cargo.toml
@@ -11,10 +11,9 @@ categories = ["compilers", "wasm"]
 
 [dependencies]
 anyhow.workspace = true
-thiserror.workspace = true
 rustc-hash.workspace = true
-toml.workspace = true
 inf-wasmparser.workspace = true
+inference-project-model.workspace = true
 inference-ast.workspace = true
 inference-parser.workspace = true
 inference-wasm-codegen.workspace = true

--- a/core/inference/README.md
+++ b/core/inference/README.md
@@ -247,6 +247,7 @@ The generated Rocq code can be used with the Rocq proof assistant to verify prog
 
 This crate is a thin orchestration layer delegating to specialized crates:
 
+- **[`inference_project_model`]** - Shared project front end (import-closure walk, `FileLoader` seam, manifest discovery); its items — `parse_project`, `load_project_resilient`, `InferenceError`, `manifest_source_root`, … — are re-exported here so consumers reach them as `inference::…`. It is a leaf crate the IDE stack also depends on directly, which is what keeps that stack from linking this backend.
 - **[`inference_ast`]** - Arena-based AST data model
 - **[`inference_parser`]** - Lexer + recursive-descent parser
 - **[`inference_type_checker`]** - Bidirectional type checking with error recovery

--- a/core/inference/src/lib.rs
+++ b/core/inference/src/lib.rs
@@ -282,19 +282,19 @@ pub use inference_type_checker::{TypeCheckDiagnostic, TypeCheckOutcome};
 /// [`TypeCheckError::location`]: inference_type_checker::errors::TypeCheckError::location
 pub use inference_type_checker::errors::TypeCheckError;
 
-pub mod errors;
 pub mod extern_prelude;
-pub mod manifest;
-mod project;
 pub mod wasm_link;
 
-pub use errors::InferenceError;
-pub use manifest::manifest_source_root;
-pub use project::{
-    load_project_resilient, parse_project, read_source_file, strip_utf8_bom, DiskLoader,
-    load_project_resilient_with_root,
-    FileLoader, FileParseErrors, ImportProblem, LoadedFile, ProjectParse, ProjectWarning,
-    ResilientProjectParse,
+/// Re-export of the shared project front end so compiler-side consumers reach the
+/// import-closure walk, file loaders, and manifest discovery as `inference::…`
+/// without a direct dependency on `inference-project-model`. This is the same leaf
+/// crate `ide-db` depends on directly, which is what keeps the compiler and the
+/// IDE from ever disagreeing about which files a program is made of — there is one
+/// closure-walk implementation, parameterized over a [`FileLoader`].
+pub use inference_project_model::{
+    load_project_resilient, load_project_resilient_with_root, manifest_source_root, parse_project,
+    read_source_file, strip_utf8_bom, DiskLoader, FileLoader, FileParseErrors, ImportProblem,
+    InferenceError, LoadedFile, ProjectParse, ProjectWarning, ResilientProjectParse,
 };
 
 /// Re-export of `rustc_hash::FxHashMap` so library consumers of `inference`

--- a/core/project-model/Cargo.toml
+++ b/core/project-model/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "inference-project-model"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+description = "Shared project front end for the Inference compiler and IDE: import-closure walk, file loaders, and manifest discovery"
+keywords = ["compiler", "ide", "project-model"]
+categories = ["compilers"]
+
+[dependencies]
+anyhow.workspace = true
+thiserror.workspace = true
+rustc-hash.workspace = true
+toml.workspace = true
+inference-ast.workspace = true
+inference-parser.workspace = true

--- a/core/project-model/README.md
+++ b/core/project-model/README.md
@@ -1,0 +1,118 @@
+# inference-project-model
+
+The shared project front end for the Inference toolchain: the one place that
+turns an entry `.inf` file into the set of files a program is made of. It walks
+the import-reachable closure from an entry point, reads and parses each file
+exactly once, and lowers them all into a single `AstArena`.
+
+## Where It Sits
+
+```
+core/inference (compiler)        ide/ide-db (IDE)
+        \                          /
+         \                        /
+          core/project-model  <--+
+                 |
+       inference-parser, inference-ast, toml, rustc-hash
+```
+
+`project-model` is a **leaf** crate. It depends only on the parser, the AST data
+model, `toml`, and `rustc-hash` — never on the type checker, code generator, or
+any WASM/Rocq crate. That is deliberate: both the compiler and the IDE stack
+depend on it, and keeping it a leaf is what lets `ide-db` reach the project walk
+without transitively linking the backend it never uses.
+
+## Why the Compiler and the IDE Share It
+
+A diagnostic the IDE shows about a missing import, and the set of files the
+compiler decides a program is made of, must never disagree. This crate makes
+that guarantee *structural* rather than a matter of two implementations staying
+in sync: there is exactly one closure-walk algorithm, parameterized over where
+bytes come from through the [`FileLoader`] seam — a trait with two methods,
+`exists` and `read`.
+
+- The **compiler** drives the walk with a [`DiskLoader`] (straight to
+  `std::fs`) via [`parse_project`], which fails fast on the first problem,
+  preserving the exact errors and ordering it has always produced.
+- The **IDE** drives the same walk with an overlay-then-disk loader via
+  [`load_project_resilient`], which never fails fast: every file is parsed
+  resiliently and every problem — a syntax error, an unresolved import, an
+  unreadable file — is collected as data so an editor can serve features on the
+  healthy parts of a broken program.
+
+`core/inference` re-exports every public item here, so compiler-side consumers
+(`infc`, `infs`, tools, tests) keep reaching them as `inference::…` unchanged.
+
+## What It Owns
+
+- **The closure walk** — breadth-first discovery of the import-reachable set
+  from an entry file, keyed by canonical module path so cycles terminate, with
+  files lowered into one arena in canonical order (entry first, then imports
+  sorted by module path).
+- **The [`FileLoader`] seam** and its [`DiskLoader`] implementation.
+- **Reading a source file** — [`read_source_file`] / [`strip_utf8_bom`], the one
+  reader that both the disk and overlay loaders build on so a leading UTF-8 BOM
+  is stripped identically everywhere.
+- **Project errors** — [`InferenceError`], the structured errors the fail-fast
+  walk raises.
+- **Manifest source-root discovery** — [`manifest_source_root`], which derives
+  the `<manifest_dir>/src` root an opened file's imports resolve against so the
+  IDE resolves exactly as `infs` would.
+
+## Two Outcomes
+
+| Type | Produced by | Shape |
+|---|---|---|
+| `ProjectParse` | `parse_project` | The merged `arena` plus `ProjectWarning`s for unreachable files |
+| `ResilientProjectParse` | `load_project_resilient[_with_root]` | The merged `arena`, per-file parse errors, unresolved-import problems, the loaded-file list, and read failures |
+
+## Key Types
+
+| Type | Role |
+|---|---|
+| `FileLoader` | The `exists`/`read` seam the walk resolves bytes through |
+| `DiskLoader` | The `FileLoader` the compiler uses, reading straight from disk |
+| `LoadedFile` | One reachable file: its canonical module path and the path it was read from |
+| `FileParseErrors` | A file's own syntax errors, labeled with its module path |
+| `ImportProblem` | A `use` that resolved to no file, anchored at its directive for in-place IDE diagnostics |
+| `ProjectWarning` | A non-fatal finding (currently only `UnreachableFile`) |
+| `InferenceError` | The structured error the fail-fast walk raises |
+
+## Usage
+
+```rust
+use std::path::Path;
+use inference_project_model::parse_project;
+
+// Compiler front end: fail fast, one arena for the whole program.
+let entry = Path::new("/project/src/main.inf");
+let project = parse_project(entry)?;
+for warning in &project.warnings {
+    eprintln!("{warning}");
+}
+let arena = project.arena; // All reachable files, in canonical order.
+# Ok::<(), anyhow::Error>(())
+```
+
+The IDE drives the resilient entry points through its own `FileLoader` (see
+`ide/ide-db`), so an open, unsaved buffer shadows on-disk contents while both
+the compiler and the editor resolve imports the same way.
+
+## Testing
+
+Unit tests live alongside each module (`project.rs`, `manifest.rs`). They cover
+the closure walk end to end — cycle termination, canonical ordering, missing
+imports with nearest-match suggestions, resilient-vs-fail-fast arena parity,
+UTF-8 BOM handling, filesystem-root safety, and manifest source-root derivation.
+
+```
+cargo test -p inference-project-model
+```
+
+## Related Resources
+
+- [`core/inference`](../inference/README.md) — the orchestration crate that
+  re-exports this front end and adds type-checking, codegen, and Rocq translation
+- [`core/parser`](../parser/README.md) — the resilient parser the walk drives
+- [`ide/ide-db`](../../ide/ide-db/README.md) — the IDE consumer that drives the
+  resilient walk through an overlay-then-disk `FileLoader`

--- a/core/project-model/src/errors.rs
+++ b/core/project-model/src/errors.rs
@@ -1,9 +1,10 @@
-//! Consolidated error types for the `inference` orchestration crate.
+//! Error types for the project front end.
 //!
-//! Per the project's error-handling convention, every fallible operation in this
-//! crate surfaces a variant of [`InferenceError`] wrapped in `anyhow::Result`,
-//! so downstream consumers can downcast to a structured error instead of parsing
-//! free-form strings.
+//! Per the project's error-handling convention, every fallible operation in the
+//! fail-fast project walk surfaces a variant of [`InferenceError`] wrapped in
+//! `anyhow::Result`, so downstream consumers can downcast to a structured error
+//! instead of parsing free-form strings. The name is kept for source
+//! compatibility: the orchestration crate re-exports it as `inference::InferenceError`.
 
 use std::path::PathBuf;
 

--- a/core/project-model/src/lib.rs
+++ b/core/project-model/src/lib.rs
@@ -1,0 +1,54 @@
+#![warn(clippy::pedantic)]
+//! The shared project front end for the Inference toolchain: the one place that
+//! turns an entry `.inf` file into the set of files a program is made of.
+//!
+//! A program is more than a single source file — a `use a::b;` directive pulls
+//! `<src_root>/a/b.inf` into the compilation unit, transitively. This crate owns
+//! that walk: given an entry file and a [`FileLoader`], it discovers the
+//! import-reachable closure, reads and parses each file exactly once, and lowers
+//! them all into one [`AstArena`]. It also owns the small pieces of project
+//! structure the walk needs — reading a source file (stripping a UTF-8 BOM) and
+//! deriving a project's source root from its `Inference.toml` manifest.
+//!
+//! # Why a leaf crate
+//!
+//! The compiler and the IDE must never disagree about which files a program
+//! imports or how they are lowered — a diagnostic the IDE shows has to match what
+//! the compiler would produce. The guarantee that they agree is *structural*:
+//! there is exactly one closure-walk implementation, parameterized over where
+//! bytes come from through the [`FileLoader`] seam. The compiler drives it with a
+//! [`DiskLoader`] (straight to `std::fs`) via [`parse_project`]; the IDE drives it
+//! with an overlay-then-disk loader via [`load_project_resilient`], so an open,
+//! unsaved buffer shadows on-disk contents while both resolve imports the same
+//! way.
+//!
+//! Keeping this front end a leaf — depending only on `inference-parser`,
+//! `inference-ast`, `toml`, and `rustc-hash` — is what lets `ide-db` reach it
+//! without transitively linking the WASM/Rocq backend (codegen, the translator,
+//! the linker). The `inference` orchestration crate re-exports every item here, so
+//! compiler-side consumers keep reaching them as `inference::…` unchanged.
+//!
+//! # Two entry points, one walk
+//!
+//! - [`parse_project`] — the compiler front end. Fails fast on the first problem,
+//!   preserving the exact errors and ordering the compiler has always produced,
+//!   and additionally reports [`ProjectWarning`]s for unreachable files.
+//! - [`load_project_resilient`] / [`load_project_resilient_with_root`] — the IDE
+//!   front end. Never fails fast: every file is parsed resiliently and every
+//!   problem (a syntax error, an unresolved import, an unreadable file) is
+//!   collected as data in a [`ResilientProjectParse`] so an editor can serve
+//!   features on the healthy parts of a broken program.
+//!
+//! [`AstArena`]: inference_ast::arena::AstArena
+
+pub mod errors;
+pub mod manifest;
+mod project;
+
+pub use errors::InferenceError;
+pub use manifest::manifest_source_root;
+pub use project::{
+    DiskLoader, FileLoader, FileParseErrors, ImportProblem, LoadedFile, ProjectParse,
+    ProjectWarning, ResilientProjectParse, load_project_resilient,
+    load_project_resilient_with_root, parse_project, read_source_file, strip_utf8_bom,
+};

--- a/core/project-model/src/manifest.rs
+++ b/core/project-model/src/manifest.rs
@@ -11,10 +11,10 @@
 //! This module gives ide-db just enough to derive that root: walk up to the
 //! nearest manifest, confirm it is a well-formed Inference manifest, and return
 //! `<manifest_dir>/src` when the opened file lives under it. It deliberately does
-//! not model the whole manifest — issue #256 will extract a shared project-model
-//! crate, at which point `infs` and this helper can converge on one
-//! implementation. Until then this small piece keeps the IDE and CLI agreeing on
-//! what a manifest means without ide-db depending on `apps/infs`.
+//! not model the whole manifest — `infs` owns the full `InferenceToml`, and a
+//! future change can let `infs` and this helper converge on one implementation.
+//! Until then this small piece keeps the IDE and CLI agreeing on what a manifest
+//! means without ide-db depending on `apps/infs`.
 //!
 //! # v1 limitation
 //!

--- a/core/project-model/src/project.rs
+++ b/core/project-model/src/project.rs
@@ -203,13 +203,6 @@ pub struct ResilientProjectParse {
     pub parse_errors: Vec<FileParseErrors>,
     /// `use` imports that did not resolve to a file.
     pub import_problems: Vec<ImportProblem>,
-    /// Always empty. The resilient walk does not scan the source tree for
-    /// unreachable files: that scan enumerates and canonicalizes every `.inf`
-    /// under the source root — work an editor would repeat on every keystroke,
-    /// growing with the tree — and no IDE consumer reads the result. The field is
-    /// retained so the resilient outcome mirrors [`ProjectParse`]'s shape; the
-    /// fail-fast [`parse_project`] still populates its own warnings.
-    pub warnings: Vec<ProjectWarning>,
     /// Every file actually read, in discovery order: its module path and the
     /// path it was read from. Serves as both the closure file set and the
     /// module-path → path mapping.
@@ -371,21 +364,14 @@ pub fn load_project_resilient_with_root(
         }
     }
 
-    // The resilient walk never scans the source tree for unreachable files. The
-    // scan enumerates and canonicalizes every `.inf` file under the source root,
-    // which for an editor runs on every keystroke and grows with the tree — yet no
-    // IDE consumer reads these warnings. They are always empty here; the fail-fast
-    // compiler keeps the scan (see [`ResilientProjectParse::warnings`]).
-    // The resilient walk never scans the source tree for unreachable files. The
-    // scan enumerates and canonicalizes every `.inf` file under the source root,
-    // which for an editor runs on every keystroke and grows with the tree — yet no
-    // IDE consumer reads these warnings. They are always empty here; the fail-fast
-    // compiler keeps the scan (see [`ResilientProjectParse::warnings`]).
+    // The resilient walk never scans the source tree for unreachable files: that
+    // scan enumerates and canonicalizes every `.inf` under the source root — work
+    // an editor would repeat on every keystroke, growing with the tree — and no IDE
+    // consumer needs the result. The fail-fast `parse_project` keeps the scan.
     ResilientProjectParse {
         arena,
         parse_errors,
         import_problems,
-        warnings: Vec::new(),
         files,
         read_failures,
     }
@@ -2244,7 +2230,10 @@ mod tests {
             fail_fast.arena, resilient.arena,
             "clean-project arenas must be byte-identical across both walks"
         );
-        assert_eq!(fail_fast.warnings, resilient.warnings);
+        assert!(
+            fail_fast.warnings.is_empty(),
+            "a clean project has no unreachable-file warnings"
+        );
     }
 
     #[test]
@@ -2297,18 +2286,18 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let parse = load_project_resilient(&entry, &loader);
-            let _ = tx.send(parse.warnings.len());
+            let _ = tx.send(parse.files.len());
         });
 
-        let warning_count = rx
+        let file_count = rx
             .recv_timeout(std::time::Duration::from_secs(20))
             .expect(
                 "the resilient walk at a filesystem root did not return: \
                  the whole-disk unreachable scan was not skipped",
             );
         assert_eq!(
-            warning_count, 0,
-            "a lone file at a filesystem root has no unreachable-file warnings"
+            file_count, 1,
+            "a lone file at a filesystem root loads only itself, with no disk scan"
         );
     }
 
@@ -2581,17 +2570,17 @@ mod tests {
     }
 
     #[test]
-    fn resilient_walk_never_reports_unreachable_warnings() {
+    fn resilient_walk_never_scans_for_unreachable_files() {
         // Regression: the resilient/IDE walk must not scan the source tree for
         // unreachable files. That scan enumerates and canonicalizes every `.inf`
         // under the source root — work an editor repeats on every keystroke — yet
-        // no IDE consumer reads the warnings. An orphan the fail-fast walk warns
-        // about must yield no resilient warning at all.
+        // no IDE consumer needs the result. An orphan the fail-fast walk warns
+        // about must not be scanned in or reported by the resilient walk at all.
         let project = TempProject::new("resilient-no-warn");
         let entry = project.write("main.inf", "pub fn main() -> i32 { return 0; }");
         project.write("orphan.inf", "pub fn orphan() {}");
 
-        // The fail-fast compiler still warns about the orphan...
+        // The fail-fast compiler still scans for and warns about the orphan...
         let fail_fast = parse_project(&entry).expect("project parses");
         assert_eq!(
             fail_fast.warnings.len(),
@@ -2599,13 +2588,17 @@ mod tests {
             "the compiler still scans for and warns about orphans"
         );
 
-        // ...but the resilient walk skips the scan entirely.
+        // ...but the resilient walk skips the scan entirely: it loads only the
+        // import-reachable closure (here just the entry) and manufactures no
+        // problems for the unreachable orphan.
         let resilient = load_project_resilient(&entry, &DiskLoader);
-        assert!(
-            resilient.warnings.is_empty(),
-            "the resilient walk must not compute unreachable-file warnings, got {:?}",
-            resilient.warnings,
+        assert_eq!(
+            resilient_module_paths(&resilient),
+            vec![Vec::<String>::new()],
+            "the resilient walk loads only the reachable entry, not the orphan",
         );
+        assert!(resilient.parse_errors.is_empty());
+        assert!(resilient.import_problems.is_empty());
     }
 
     #[test]

--- a/ide/ide-db/Cargo.toml
+++ b/ide/ide-db/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 description = "IDE Database for Inference IDE support"
 
 [dependencies]
-inference.workspace = true
+inference-project-model.workspace = true
 inference-analysis.workspace = true
 inference-ast.workspace = true
 inference-base-db.workspace = true

--- a/ide/ide-db/README.md
+++ b/ide/ide-db/README.md
@@ -13,7 +13,7 @@ apps/lsp
     |
 ide/ide
     |
-ide/ide-db  -----consumes-----> core/inference, core/analysis,
+ide/ide-db  -----consumes-----> core/project-model, core/analysis,
     |                            core/type-checker, core/ast, core/parser
 ide/base-db
     |
@@ -23,7 +23,9 @@ ide/vfs
 `ide-db` is the first layer in the IDE stack that depends on the compiler. It
 is also the *only* IDE layer that does: `ide/ide` above it never names a
 compiler type in its public API, and everything below it (`vfs`, `base-db`) is
-compiler-independent plumbing.
+compiler-independent plumbing. It reaches the compiler's front end through the
+leaf `core/project-model` crate rather than the `inference` orchestration crate,
+so the IDE stack never links the WASM/Rocq backend.
 
 ## What It Owns
 
@@ -46,7 +48,7 @@ or a compiler type re-exported verbatim (`TypeCheckError`, `AnalysisDiagnostic`,
 `NodeId`, `Location`, …). The feature layer above (`ide/ide`) translates these
 into editor-terminology PODs; the protocol layer above that (`apps/lsp`)
 translates *those* into LSP JSON. Import resolution is **not** reimplemented
-here — the closure walk lives in `core/inference` behind a `FileLoader` seam,
+here — the closure walk lives in `core/project-model` behind a `FileLoader` seam,
 and `ide-db` drives it with an overlay-then-disk loader, so the compiler and
 the IDE resolve imports identically by construction.
 
@@ -90,23 +92,23 @@ same file always arrives under one path (the LSP layer does this once, per
 
 ### The overlay-then-disk `FileLoader`
 
-`core/inference` exposes import resolution behind a `FileLoader` trait — a seam
-with exactly two methods, `exists` and `read` — so the same closure-walk logic
-drives both the compiler (`DiskLoader`, straight to `std::fs`) and the IDE. This
-crate's `VfsLoader` implements that trait by consulting the editor's `Vfs`
+`core/project-model` exposes import resolution behind a `FileLoader` trait — a
+seam with exactly two methods, `exists` and `read` — so the same closure-walk
+logic drives both the compiler (`DiskLoader`, straight to `std::fs`) and the IDE.
+This crate's `VfsLoader` implements that trait by consulting the editor's `Vfs`
 overlay first and falling back to disk, so an open, unsaved buffer shadows its
 on-disk contents while an import the editor has never opened is still read
-from disk. Driving `inference::load_project_resilient` through this loader is
-what guarantees the compiler and the IDE can never disagree about which files a
-program imports — there is exactly one resolution algorithm, parameterized
+from disk. Driving `inference_project_model::load_project_resilient` through this
+loader is what guarantees the compiler and the IDE can never disagree about which
+files a program imports — there is exactly one resolution algorithm, parameterized
 over where bytes come from.
 
 `FileAnalysis::compute` builds the loader, calls `load_project_resilient_with_root`
 (which never fails fast — every file is parsed resiliently and every problem,
 from a broken import to a syntax error, is collected as data rather than
 aborting), then type-checks the merged arena losslessly with
-`inference::type_check_with_diagnostics` and runs every registered analysis
-rule (`inference_analysis::rules::all_rules()`) over the resulting
+`inference_type_checker::check_with_diagnostics` and runs every registered
+analysis rule (`inference_analysis::rules::all_rules()`) over the resulting
 `TypedContext`.
 
 ## Per-File-Local Offsets
@@ -172,5 +174,6 @@ cargo test -p inference-ide-db
 - [`ide/vfs`](../vfs/README.md) — the path/overlay store `RootDatabase` wraps
 - [`ide/base-db`](../base-db/README.md) — `LineIndex` and the position PODs re-exported here
 - [`ide/ide`](../ide/README.md) — the feature layer built on `FileAnalysis`
-- [`core/inference`](../../core/inference/README.md) — `load_project_resilient`, `FileLoader`, `type_check_with_diagnostics`
+- [`core/project-model`](../../core/project-model/README.md) — `load_project_resilient`, `FileLoader`, and manifest source-root discovery, the leaf front end this crate drives
+- [`core/type-checker`](../../core/type-checker/README.md) — `check_with_diagnostics`, the lossless type-check `FileAnalysis` runs
 - [`core/analysis`](../../core/analysis/README.md) — the rules run over every `FileAnalysis`

--- a/ide/ide-db/src/analysis.rs
+++ b/ide/ide-db/src/analysis.rs
@@ -4,7 +4,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use inference::{FileParseErrors, ImportProblem, LoadedFile, load_project_resilient_with_root};
+use inference_project_model::{
+    FileParseErrors, ImportProblem, LoadedFile, load_project_resilient_with_root,
+};
 use inference_analysis::errors::{LabeledDiagnostic, Severity};
 use inference_analysis::rules::all_rules;
 use inference_ast::arena::AstArena;

--- a/ide/ide-db/src/database.rs
+++ b/ide/ide-db/src/database.rs
@@ -14,6 +14,19 @@ use crate::analysis::FileAnalysis;
 /// Each open file is analyzed as its own project entry. Analyses are computed
 /// lazily on first request and memoized until a document change invalidates them.
 ///
+/// # Query model: read-through-`&mut self`, single-threaded
+///
+/// Because a query computes and memoizes its analysis in place,
+/// [`analysis`](Self::analysis) — a *read* — takes `&mut self`, and so does every
+/// feature query layered on it. This is correct and sufficient for the LSP main
+/// loop, which drives the database from a single thread. It is also a deliberate
+/// constraint: reading through `&mut self` forecloses request cancellation and
+/// parallel reads, which would require memoizing behind shared interior
+/// mutability (a per-query cell, dependency tracking, and cancellation) rather
+/// than a plain `&mut`-guarded map. Adopting Salsa (issue #157) is the planned
+/// path to that model; until then callers must serialize access, and no query may
+/// assume it can run concurrently with another.
+///
 /// # Per-entry source root
 ///
 /// Path-form imports resolve relative to a project's single **source root**, not
@@ -50,7 +63,7 @@ use crate::analysis::FileAnalysis;
 ///
 /// A manifest created or edited *after* a file's root was cached is therefore not
 /// observed until the document is closed and reopened: there is no filesystem
-/// watch in v1 (see the `inference::manifest` module).
+/// watch in v1 (see the `inference_project_model::manifest` module).
 ///
 /// # Closure-aware invalidation
 ///
@@ -175,7 +188,7 @@ impl RootDatabase {
         if let Some(root) = self.source_roots.get(entry) {
             return root.clone();
         }
-        if let Some(root) = inference::manifest_source_root(entry) {
+        if let Some(root) = inference_project_model::manifest_source_root(entry) {
             self.source_roots.insert(entry.to_path_buf(), root.clone());
             return root;
         }

--- a/ide/ide-db/src/lib.rs
+++ b/ide/ide-db/src/lib.rs
@@ -45,7 +45,7 @@ pub use inference_vfs::{FileId, Vfs};
 // Re-export the compiler types that appear in `FileAnalysis`'s public results so
 // a consumer names them through ide-db alone. `ide-db` is the single façade the
 // feature layer above depends on.
-pub use inference::{FileParseErrors, ImportProblem};
+pub use inference_project_model::{FileParseErrors, ImportProblem};
 pub use inference_analysis::errors::{AnalysisDiagnostic, LabeledDiagnostic, Severity};
 pub use inference_ast::ids::{DefId, NodeId, SourceFileId};
 pub use inference_ast::nodes::Location;

--- a/ide/ide-db/src/loader.rs
+++ b/ide/ide-db/src/loader.rs
@@ -2,13 +2,13 @@
 
 use std::path::{Path, PathBuf};
 
-use inference::{read_source_file, FileLoader};
+use inference_project_model::{read_source_file, FileLoader};
 use inference_vfs::Vfs;
 
 /// A [`FileLoader`] that consults the editor's in-memory overlay first and falls
 /// back to disk.
 ///
-/// This is the reader ide-db hands to `inference::load_project_resilient`, so an
+/// This is the reader ide-db hands to `inference_project_model::load_project_resilient`, so an
 /// open, unsaved buffer shadows its on-disk contents while imports the editor
 /// has never opened are still read from disk. It is the IDE half of the single
 /// import-resolution seam the compiler and the IDE share (the compiler passes a
@@ -87,7 +87,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use inference::FileLoader;
+    use inference_project_model::FileLoader;
     use inference_vfs::Vfs;
 
     use super::{overlay_text, VfsLoader};

--- a/ide/ide/src/lib.rs
+++ b/ide/ide/src/lib.rs
@@ -96,7 +96,13 @@ impl AnalysisHost {
 /// A borrowed view over the host that answers feature queries for a document.
 ///
 /// Each method names its document by path and takes `&mut self` because the
-/// document's analysis is computed lazily and cached on first use.
+/// document's analysis is computed lazily and cached on first use — a read
+/// mutates the [`RootDatabase`] to memoize its result. That is why the borrow is
+/// `&'a mut RootDatabase` rather than shared: it is correct for the
+/// single-threaded LSP main loop, but it forecloses request cancellation and
+/// parallel reads, which would need a `RootDatabase` that memoizes behind shared
+/// interior mutability. Adopting Salsa (issue #157) is the planned path to that;
+/// until then this constraint is deliberate and load-bearing.
 pub struct Analysis<'a> {
     db: &'a mut RootDatabase,
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow.workspace = true
-serde_json = "1.0.99"
+serde_json.workspace = true
 wasmtime="43.0.0"
 
 inference-analysis.workspace = true


### PR DESCRIPTION
Closes #256.

The IDE/LSP stack transitively linked the WASM/Rocq backend: `ide-db` depended on the full `inference` orchestration crate only to reach the shared project front end. This moves that front end (import-closure walk, `FileLoader` seam, manifest source-root discovery, project errors) into a new leaf crate `core/project-model` (`inference-project-model`).

- `core/inference` re-exports every moved item unchanged — `infc`, `infs`, tools, and tests keep using `inference::…` with no call-site churn and byte-identical compiler behavior.
- `ide-db` now depends on `inference-project-model`; `cargo tree` for `ide-db`, `ide`, and `lsp` links none of the backend crates (verified: zero wasm/rocq crates in the tree).
- Drops the always-empty `ResilientProjectParse::warnings` field; documents `RootDatabase`'s single-threaded `&mut self` query model (#157).
- The `children_of` duplication (issue #256 item 5) is deferred — those files are touched by the stacked follow-up branches.

Rebased onto current main; the sticky `source_roots` cache from #243's review-repair is preserved (only the `manifest_source_root` call is re-routed to the new crate). Full `cargo test` suite green (4400+ tests, 0 failures).

Merge order note: PRs for #247 and #254 are stacked on this branch (247 on 256, 254 on 247). Merge this first, then retarget/rebase 247, then 254 — merging a stacked PR into its parent branch instead of main will not auto-close its issue (that is what happened to #240/#249/#251/#252).

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; the refactoring is mechanically correct, all re-exports are accounted for, and the removed warnings field had no in-tree callers.

The extraction is clean and the test updates are strictly stronger than what they replace. The formerly-public module paths inference::errors and inference::manifest are gone without a compatibility alias — in-tree there are zero callers, but any out-of-repo consumer using those qualified paths would get a compile error on next update.

core/inference/src/lib.rs — the previously public inference::errors and inference::manifest module paths are dropped with no alias; worth confirming no downstream users rely on those paths before the next tagged release.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/project-model/Cargo.toml | New leaf crate manifest; dependencies are correctly leaf-safe (parser, ast, toml, rustc-hash, thiserror, anyhow only) |
| core/project-model/src/lib.rs | New crate root; re-exports all public items from errors, manifest, and project modules correctly |
| core/project-model/src/project.rs | Renamed from core/inference/src/project.rs; warnings field removed from ResilientProjectParse, tests updated with stronger assertions |
| core/inference/src/lib.rs | Replaces pub mod errors and pub mod manifest declarations with a flat pub use from inference_project_model; item-level compat is preserved but module-level paths (inference::errors::*, inference::manifest::*) are silently dropped |
| ide/ide-db/Cargo.toml | inference dependency replaced with inference-project-model, breaking the transitive link to WASM/Rocq backend crates |
| ide/ide-db/src/analysis.rs | Imports updated from inference to inference_project_model; logic unchanged |
| ide/ide-db/src/database.rs | manifest_source_root call updated to inference_project_model; new query-model doc comment added accurately describing single-threaded &mut self pattern |
| Cargo.toml | Adds inference-project-model and serde_json to workspace.dependencies; correct |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["apps/lsp\napps/infs"] --> B["ide/ide"]
    B --> C["ide/ide-db"]
    C --> D["core/project-model\n(inference-project-model)\nnew leaf crate"]
    C --> E["core/analysis"]
    C --> F["core/type-checker"]
    D --> G["core/parser"]
    D --> H["core/ast"]
    D --> I["toml / rustc-hash"]
    J["core/inference\n(orchestration)"] --> D
    J --> F
    J --> K["core/wasm-codegen\ncore/wasm-linker\ncore/wasm-to-v\n(WASM/Rocq backend)"]
    style K fill:#f99,stroke:#c00
    style D fill:#9f9,stroke:#090
    C -.->|"before: via core/inference"| K
    C -->|"after: only"| D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["apps/lsp\napps/infs"] --> B["ide/ide"]
    B --> C["ide/ide-db"]
    C --> D["core/project-model\n(inference-project-model)\nnew leaf crate"]
    C --> E["core/analysis"]
    C --> F["core/type-checker"]
    D --> G["core/parser"]
    D --> H["core/ast"]
    D --> I["toml / rustc-hash"]
    J["core/inference\n(orchestration)"] --> D
    J --> F
    J --> K["core/wasm-codegen\ncore/wasm-linker\ncore/wasm-to-v\n(WASM/Rocq backend)"]
    style K fill:#f99,stroke:#c00
    style D fill:#9f9,stroke:#090
    C -.->|"before: via core/inference"| K
    C -->|"after: only"| D
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `core/inference/src/lib.rs`, line 110-133 ([link](https://github.com/inferara/inference/blob/43626f24556ce5f049c3426c09e2c95e504875e5/core/inference/src/lib.rs#L110-L133)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Module-level paths silently dropped from `inference` public API**

   The old `pub mod errors` and `pub mod manifest` declarations made `inference::errors::InferenceError` and `inference::manifest::manifest_source_root` valid paths. The replacement `pub use inference_project_model::{…}` only re-exports items at the flat level (`inference::InferenceError`, `inference::manifest_source_root`). Any downstream consumer outside this repo that used the module-qualified paths would silently break at their next `cargo update`. Since `inference_project_model::errors` and `inference_project_model::manifest` remain public modules in the new crate, the module-scoped forms are still reachable there — but the `inference::errors` and `inference::manifest` module paths are gone with no deprecation path.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Extract project front end into leaf infe..."](https://github.com/inferara/inference/commit/43626f24556ce5f049c3426c09e2c95e504875e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45534510)</sub>

<!-- /greptile_comment -->