### PR TITLE
lsp: drop didChange for a document that was never opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -819,6 +819,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Both the fail-fast (`build_typed_context`) and lossless (`check_with_diagnostics`) entry points surface it as an ordinary diagnostic; the size-`0` sentinel no longer cascades a spurious array-literal-size or variable/return type mismatch, so the reproduction reports exactly one error
   - The [#241] message-loop panic-boundary tests, which had used this exact panic as their trigger, now inject a deliberate panic through a debug-only server seam (`INFERENCE_LSP_TEST_PANIC_PATH_SUBSTR`, invisible in release builds) instead
   - Compile-time constant evaluation of array sizes remains future work (#79)
+- lsp: a `didChange` for a document the client never opened is now dropped instead of silently adopted. Per LSP 3.17 a client sends `didChange` only between a document's `didOpen` and its `didClose`; `handlers::did_change` used to intern the path, install the change text as the overlay, track the URI, and publish diagnostics for it — enrolling a never-opened document in every future dependents-republish sweep. It now drops such a change (no interning, no tracking, no publish) and logs the URI to stderr, matching the URI layer's treat-unmappable-input-as-absent philosophy; a later proper `didOpen` starts tracking the document normally. The same rule now covers a change arriving after `didClose` (VS Code's preview-tab close race): it no longer silently resurrects tracking, and a still-open dependent is left untouched ([#275])
 
 ### Project Manifest
 
@@ -1048,3 +1049,4 @@ Initial tagged release.
 [#157]: https://github.com/Inferara/inference/issues/157
 [#256]: https://github.com/Inferara/inference/issues/256
 [#254]: https://github.com/Inferara/inference/issues/254
+[#275]: https://github.com/Inferara/inference/issues/275

--- a/apps/lsp/README.md
+++ b/apps/lsp/README.md
@@ -148,6 +148,14 @@ converts the answer back with `convert.rs`. A URI this server cannot map to a
 file — a non-`file` scheme, an untitled buffer — yields a null result and no
 diagnostics, never a panic.
 
+`didChange` is honored only for a document already in the tracked set. LSP 3.17
+sends a change only between a document's `didOpen` and its `didClose`, so a
+change for a URI never opened (or closed since — VS Code's preview-tab close
+race can emit one just after `didClose`) is a protocol violation: it is dropped
+rather than adopted (no interning, no tracking, no publish), and logged to
+stderr. A stray change therefore never starts tracking a document the editor did
+not open, and a later proper `didOpen` tracks it normally.
+
 Nothing in this crate ever writes to stdout except the framed JSON-RPC
 messages themselves; all logging goes to stderr (see `main.rs`). This is
 required by the stdio transport — anything else on stdout corrupts the

--- a/apps/lsp/src/handlers.rs
+++ b/apps/lsp/src/handlers.rs
@@ -166,11 +166,31 @@ pub(crate) fn did_open(
     Some(publish_diagnostics_params(state, &document.uri))
 }
 
+/// Applies a full-text change to an already-open document and returns its fresh
+/// diagnostics.
+///
+/// A `didChange` is only valid for a document the client has already opened (LSP
+/// 3.17 sends `didChange` only between a document's `didOpen` and its
+/// `didClose`). A change for a URI not in the tracked set — one never opened, or
+/// one closed since (VS Code's preview-tab close race can emit a change just
+/// after `didClose`) — is a protocol violation and is dropped: the path is not
+/// interned, the URI is not adopted into the tracked set or any future
+/// dependents-republish sweep, and nothing is published (#275). This mirrors the
+/// URI layer's treat-unmappable-input-as-absent philosophy; a later proper
+/// `didOpen` starts tracking the document normally, unaffected by the dropped
+/// change. The drop is logged to stderr, never stdout (the protocol channel).
 pub(crate) fn did_change(
     state: &mut ServerState,
     params: DidChangeTextDocumentParams,
 ) -> Option<PublishDiagnosticsParams> {
     let uri = params.text_document.uri;
+    if !state.documents.contains_key(&uri) {
+        eprintln!(
+            "inference-lsp: ignoring didChange for a document with no prior didOpen: {}",
+            uri.as_str()
+        );
+        return None;
+    }
     let version = params.text_document.version;
     let path = uri::to_path(&uri)?;
     // Full-text sync: the last content change carries the whole new document.

--- a/apps/lsp/src/server.rs
+++ b/apps/lsp/src/server.rs
@@ -226,7 +226,8 @@ impl ServerState {
     /// document the change invalidated for a deferred republish (see
     /// [`queue_invalidated_dependents`](Self::queue_invalidated_dependents) and
     /// [`drain_pending_republishes`](Self::drain_pending_republishes)). An unknown
-    /// or unparsable notification publishes nothing and queues nothing.
+    /// or unparsable notification — or a `didChange` for a document that was never
+    /// opened (#275) — publishes nothing and queues nothing.
     pub(crate) fn on_notification(
         &mut self,
         notification: Notification,
@@ -1217,6 +1218,73 @@ mod tests {
         assert!(
             state.on_notification(notification).is_empty(),
             "closing an unmappable URI publishes nothing at all"
+        );
+    }
+
+    #[test]
+    fn a_change_for_an_unopened_document_is_dropped_then_a_later_open_adopts_it() {
+        // LSP 3.17 sends `didChange` only for an open document. A change for a URI
+        // the server never tracked is dropped — nothing is published, nothing is
+        // queued, and the document is not adopted into the tracked set (#275). A
+        // later proper `didOpen` still adopts it cleanly.
+        let mut state = ServerState::new(full_client());
+
+        let ghost = "file:///inf-test/ghost.inf";
+        let publishes = state.on_notification(did_change_notification(
+            ghost,
+            2,
+            "fn f() -> i32 { return x; }",
+        ));
+        assert!(
+            publishes.is_empty(),
+            "a change to an unopened document publishes nothing"
+        );
+        assert!(
+            state.drain_pending_republishes().is_empty(),
+            "a dropped change queues no republish"
+        );
+        let ghost_uri = Uri::from_str(ghost).expect("a valid uri");
+        assert!(
+            !state.documents.contains_key(&ghost_uri),
+            "the never-opened document was not adopted into the tracked set"
+        );
+
+        // Opening it afterwards tracks it and publishes its diagnostics normally.
+        let mut opened =
+            state.on_notification(did_open_notification(ghost, "fn f() -> i32 { return x; }"));
+        assert_eq!(opened.len(), 1, "the later open publishes once");
+        let published = opened.remove(0);
+        assert_eq!(published.uri.as_str(), ghost);
+        assert!(
+            !published.diagnostics.is_empty(),
+            "the opened document's broken text is analyzed and reported"
+        );
+    }
+
+    #[test]
+    fn a_change_after_close_is_dropped_and_does_not_resurrect_tracking() {
+        // After `didClose` the document leaves the tracked set, so a late change —
+        // the same protocol violation as a change before any open — is dropped and
+        // does not silently resurrect tracking (#275).
+        let mut state = ServerState::new(full_client());
+        let uri = "file:///inf-test/main.inf";
+        open(&mut state, uri, "fn f() -> i32 { return x; }");
+        state.on_notification(did_close_notification(uri));
+        let _ = state.drain_pending_republishes();
+
+        let publishes = state.on_notification(did_change_notification(
+            uri,
+            3,
+            "fn f() -> i32 { return y; }",
+        ));
+        assert!(
+            publishes.is_empty(),
+            "a change after close publishes nothing"
+        );
+        let main_uri = Uri::from_str(uri).expect("a valid uri");
+        assert!(
+            !state.documents.contains_key(&main_uri),
+            "the closed document is not resurrected into the tracked set by a late change"
         );
     }
 

--- a/apps/lsp/src/server.rs
+++ b/apps/lsp/src/server.rs
@@ -1281,6 +1281,10 @@ mod tests {
             publishes.is_empty(),
             "a change after close publishes nothing"
         );
+        assert!(
+            state.drain_pending_republishes().is_empty(),
+            "a dropped change queues no republish"
+        );
         let main_uri = Uri::from_str(uri).expect("a valid uri");
         assert!(
             !state.documents.contains_key(&main_uri),

--- a/apps/lsp/tests/e2e.rs
+++ b/apps/lsp/tests/e2e.rs
@@ -1611,25 +1611,24 @@ fn requests_after_did_close_of_a_never_on_disk_document_answer_null() {
     client.shutdown_exit_ok();
 }
 
-// --- 31. didChange before didOpen: pin the current handler semantics (#254) ---
+// --- 31. didChange before didOpen is dropped, not adopted (#275) -------------
 
 #[test]
-fn did_change_before_did_open_silently_starts_tracking_the_document() {
-    // PINNED CURRENT BEHAVIOR (documented, not endorsed): a `didChange` for a URI
-    // the client never sent `didOpen` for is NOT rejected. `handlers::did_change`
-    // interns the path, installs the change text as the overlay, tracks the
-    // document, and publishes diagnostics for it — enrolling a never-opened URI in
-    // future dependents republishes. A stricter server might drop a change to an
-    // unopened document; this one does not. The wire behavior is pinned here so a
-    // deliberate change to it is noticed at review time.
+fn did_change_before_did_open_is_dropped_then_a_later_did_open_is_adopted() {
+    // A `didChange` for a URI the client never sent `didOpen` for is a protocol
+    // violation (LSP 3.17 sends `didChange` only for an open document). The server
+    // drops it — no interning, no tracking, no publish — rather than silently
+    // adopting a never-opened document and enrolling it in future dependents
+    // republishes (#275), matching the URI layer's treat-unmappable-input-as-absent
+    // philosophy. A later proper `didOpen` of the same URI is then adopted normally.
     let mut client = LspClient::spawn();
     client.initialize_default(true);
 
-    // The file exists on disk with clean text, but the change carries broken text
-    // (an undeclared variable). A published diagnostic therefore proves the server
-    // analyzed the change's overlay text, not the clean disk text — i.e. it started
-    // tracking the never-opened document.
-    let (_dir, uri) = fixture("change-before-open", "fn f() -> i32 { return 1; }");
+    // The file exists on disk with clean text; the stray change carries broken
+    // text. Were the change adopted, its broken overlay would publish a diagnostic
+    // under this URI — the absence of any such publish is the assertion.
+    let disk_src = "fn f() -> i32 { return 1; }";
+    let (_dir, uri) = fixture("change-before-open", disk_src);
     client.send_notification(
         "textDocument/didChange",
         json!({
@@ -1637,17 +1636,155 @@ fn did_change_before_did_open_silently_starts_tracking_the_document() {
             "contentChanges": [ { "text": "fn f() -> i32 { return missing_x; }" } ],
         }),
     );
+    let published = client.drain_publishes(Duration::from_secs(1));
+    assert!(
+        !published
+            .iter()
+            .any(|(published_uri, _)| published_uri == &uri),
+        "a didChange for a never-opened document publishes nothing, got {published:?}"
+    );
 
-    let published = client.wait_for_publish(&uri);
+    // The server stays alive and answers a request against the untracked URI: with
+    // no overlay installed it reads the clean disk text, so hover over `f` resolves
+    // without error — the dropped change was never applied.
+    let hover = hover_request(&mut client, &uri, pos_at(disk_src, "f("));
+    assert!(
+        hover.get("error").is_none(),
+        "the server survived the dropped change and still answers, got {hover}"
+    );
+
+    // A later proper `didOpen` of the same URI is adopted normally: it publishes a
+    // fresh diagnostic set for the opened (broken) text and echoes its version,
+    // completely unaffected by the earlier dropped change.
+    let opened = client.did_open(&uri, "fn f() -> i32 { return also_missing; }", 5);
     assert_eq!(
-        published.version,
-        json!(3),
-        "the never-opened change's version is echoed back"
+        opened.version,
+        json!(5),
+        "the later open's version is echoed back"
     );
     assert!(
-        !published.diagnostics.is_empty(),
-        "the change text (not the clean disk text) was analyzed and published, got {:?}",
-        published.diagnostics
+        !opened.diagnostics.is_empty(),
+        "the later didOpen is adopted and its broken text analyzed, got {:?}",
+        opened.diagnostics
+    );
+
+    client.shutdown_exit_ok();
+}
+
+#[test]
+fn a_did_change_after_did_close_is_dropped_and_leaves_a_dependent_untouched() {
+    // The close-race half of #275: after `didClose` the document leaves the tracked
+    // set, so a late `didChange` (VS Code can emit one on a preview-tab close race)
+    // is the same protocol violation and is dropped — it does not resurrect
+    // tracking, publishes nothing, and leaves a still-open dependent untouched.
+    let mut client = LspClient::spawn();
+    client.initialize_default(true);
+
+    let dir = TempDir::new("change-after-close");
+    let main_source = "use lib;\nfn main() -> i32 { return lib::helper(); }";
+    let lib_source = "pub fn helper() -> i32 { return 7; }";
+    let main_path = dir.write("main.inf", main_source);
+    let lib_path = dir.write("lib.inf", lib_source);
+    let main_uri = path_to_uri(&main_path);
+    let lib_uri = path_to_uri(&lib_path);
+
+    // Both open clean. Opening lib invalidates the open dependent main, whose
+    // deferred republish is consumed here so a later drain sees a clean slate.
+    let opened_main = client.did_open(&main_uri, main_source, 1);
+    assert!(opened_main.diagnostics.is_empty(), "main opens clean");
+    let opened_lib = client.did_open(&lib_uri, lib_source, 1);
+    assert!(opened_lib.diagnostics.is_empty(), "lib opens clean");
+    let main_after_lib_open = client.wait_for_publish(&main_uri);
+    assert!(
+        main_after_lib_open.diagnostics.is_empty(),
+        "main stays clean after lib opens, got {:?}",
+        main_after_lib_open.diagnostics
+    );
+
+    // Close lib: its overlay drops and main is republished from the on-disk lib
+    // (still clean). Consume that republish before probing the dropped change.
+    let closed = client.did_close(&lib_uri);
+    assert!(
+        closed.diagnostics.is_empty(),
+        "closing lib clears its diagnostics"
+    );
+    let main_after_lib_close = client.wait_for_publish(&main_uri);
+    assert!(
+        main_after_lib_close.diagnostics.is_empty(),
+        "main re-reads lib from disk and stays clean after close, got {:?}",
+        main_after_lib_close.diagnostics
+    );
+
+    // A late `didChange` for the now-closed lib, carrying text that would break
+    // main's `lib::helper()` call, is dropped: nothing is published — not for lib,
+    // not for the still-open dependent main.
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": lib_uri, "version": 2 },
+            "contentChanges": [ { "text": "pub fn other() -> i32 { return 8; }" } ],
+        }),
+    );
+    let published = client.drain_publishes(Duration::from_secs(1));
+    assert!(
+        published.is_empty(),
+        "a didChange after close publishes nothing at all, got {published:?}"
+    );
+
+    // The still-open main is untouched: it answers goto and still resolves the
+    // cross-file call into the on-disk lib, proving the dropped change never
+    // installed a broken lib overlay.
+    let response = definition_request(&mut client, &main_uri, pos_at(main_source, "helper"));
+    assert_eq!(
+        response["result"]["uri"],
+        json!(lib_uri),
+        "main still resolves helper into the on-disk lib, got {response}"
+    );
+
+    client.shutdown_exit_ok();
+}
+
+#[test]
+fn a_dropped_did_change_does_not_perturb_an_unrelated_open_document() {
+    // A dropped `didChange` for a never-opened URI must be a complete no-op for
+    // every other document: it publishes nothing and leaves an unrelated open
+    // document's tracking and analysis intact (#275).
+    let mut client = LspClient::spawn();
+    client.initialize_default(true);
+
+    // An unrelated document, opened clean and tracked.
+    let bystander_src = "fn a() -> i32 { return 1; }";
+    let (_dir_a, bystander_uri) = fixture("dropped-change-bystander", bystander_src);
+    let opened = client.did_open(&bystander_uri, bystander_src, 1);
+    assert!(opened.diagnostics.is_empty(), "the bystander opens clean");
+
+    // A stray change for a different, never-opened URI is dropped.
+    let (_dir_b, ghost_uri) = fixture("dropped-change-ghost", "fn b() -> i32 { return 2; }");
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": ghost_uri, "version": 9 },
+            "contentChanges": [ { "text": "fn b() -> i32 { return missing; }" } ],
+        }),
+    );
+    let published = client.drain_publishes(Duration::from_secs(1));
+    assert!(
+        published.is_empty(),
+        "a dropped change publishes nothing for anyone, got {published:?}"
+    );
+
+    // The bystander is still tracked and analyzed against its own overlay: a real
+    // change to it publishes fresh, correct diagnostics and advances its version.
+    let changed = client.did_change(&bystander_uri, "fn a() -> i32 { return still_missing; }", 2);
+    assert_eq!(
+        changed.version,
+        json!(2),
+        "the bystander's version advances"
+    );
+    assert!(
+        !changed.diagnostics.is_empty(),
+        "the bystander still analyzes its overlay after the unrelated dropped change, got {:?}",
+        changed.diagnostics
     );
 
     client.shutdown_exit_ok();


### PR DESCRIPTION
Closes #275.

Decision implemented: **drop the change.** A `didChange` whose URI is not in the tracked-documents set (never opened, or already closed) is ignored — no interning, no tracking, no publish — with a stderr log line naming the URI. This matches the URI layer's treat-unmappable-input-as-absent philosophy; per LSP 3.17 a `didChange` outside a document's open/close window is a protocol violation, so this is defensive handling of client misbehavior. A later proper `didOpen` adopts the document normally.

The same guard covers the after-`didClose` case (VS Code's preview-tab close race): a late change no longer silently resurrects tracking.

- The #287 e2e pin of the old adopt behavior is flipped from descriptive to intended: `did_change_before_did_open_is_dropped_then_a_later_did_open_is_adopted`.
- New e2e: after-close drop leaves a still-open dependent untouched; a dropped change doesn't perturb unrelated open documents. Publish-barrier helpers, no wall-clock sleeps.
- New `ServerState` unit tests for both drop paths; README + handler docs updated.

Full `cargo test`: 4549 passed, 0 failed.

**Stacked on #287** (`254-tests-lsp-ide-coverage`) because it flips the wire-level pin that PR adds. Merge order: #285 → #286 → #287 → this, retargeting each to `main` before merge.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a targeted early-return guard with no effect on the normal open-change-close lifecycle.

The fix is a single contains_key check before any side-effecting work in did_change. The normal document lifecycle is entirely unaffected. Unit tests and e2e tests cover the two drop paths (never-opened and post-close), the bystander-isolation invariant, and verify that a subsequent proper didOpen adopts the document cleanly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/lsp/src/handlers.rs | Adds a documents.contains_key guard in did_change to drop changes for untracked URIs; uses next_back() for content changes (consistent with the custom rule); logic is correct and well-documented. |
| apps/lsp/src/server.rs | Docstring update plus two well-structured unit tests; both assert empty publishes, empty pending republishes, and absence of tracking for the dropped-change paths. |
| apps/lsp/tests/e2e.rs | Old pinned-behavior test properly flipped; three new integration tests exercise before-open drop, after-close drop with dependent integrity, and bystander isolation, all use drain_publishes rather than raw sleeps. |
| apps/lsp/README.md | New paragraph accurately documents the drop rule for out-of-window didChange. |
| CHANGELOG.md | Changelog entry and issue reference added cleanly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as handlers::did_change
    participant State as ServerState.documents
    participant Host as host

    Note over Client,Host: Case 1 - change before didOpen (dropped)
    Client->>Handler: didChange(uri, text)
    Handler->>State: contains_key(uri)?
    State-->>Handler: false
    Handler->>Handler: eprintln!(uri) to stderr
    Handler-->>Client: None (no publish, no tracking)

    Note over Client,Host: Case 2 - change after didClose (dropped)
    Client->>Handler: didClose(uri)
    Handler->>State: remove(uri)
    Client->>Handler: didChange(uri, text) [late / race]
    Handler->>State: contains_key(uri)?
    State-->>Handler: false
    Handler->>Handler: eprintln!(uri) to stderr
    Handler-->>Client: None (no publish, no tracking)

    Note over Client,Host: Case 3 - normal open to change flow
    Client->>Handler: didOpen(uri, text)
    Handler->>State: insert(uri)
    Handler->>Host: open_document
    Handler-->>Client: PublishDiagnostics
    Client->>Handler: didChange(uri, newText)
    Handler->>State: contains_key(uri)?
    State-->>Handler: true
    Handler->>Host: change_document
    Handler-->>Client: PublishDiagnostics
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as handlers::did_change
    participant State as ServerState.documents
    participant Host as host

    Note over Client,Host: Case 1 - change before didOpen (dropped)
    Client->>Handler: didChange(uri, text)
    Handler->>State: contains_key(uri)?
    State-->>Handler: false
    Handler->>Handler: eprintln!(uri) to stderr
    Handler-->>Client: None (no publish, no tracking)

    Note over Client,Host: Case 2 - change after didClose (dropped)
    Client->>Handler: didClose(uri)
    Handler->>State: remove(uri)
    Client->>Handler: didChange(uri, text) [late / race]
    Handler->>State: contains_key(uri)?
    State-->>Handler: false
    Handler->>Handler: eprintln!(uri) to stderr
    Handler-->>Client: None (no publish, no tracking)

    Note over Client,Host: Case 3 - normal open to change flow
    Client->>Handler: didOpen(uri, text)
    Handler->>State: insert(uri)
    Handler->>Host: open_document
    Handler-->>Client: PublishDiagnostics
    Client->>Handler: didChange(uri, newText)
    Handler->>State: contains_key(uri)?
    State-->>Handler: true
    Handler->>Host: change_document
    Handler-->>Client: PublishDiagnostics
```

</a>

<sub>Reviews (2): Last reviewed commit: ["lsp: assert the after-close drop queues ..."](https://github.com/inferara/inference/commit/9db6a791601b63dbd9646a1aa2bb13470e42828c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45543226)</sub>

<!-- /greptile_comment -->