### PR TITLE
ci: quote the rocq gate's test filter so the workflow YAML parses

### DIFF
--- a/.github/workflows/rocq-typecheck.yml
+++ b/.github/workflows/rocq-typecheck.yml
@@ -48,4 +48,4 @@ jobs:
       # `find_coqc` in the test resolves `coqc` from PATH (or the COQC override),
       # so no coqc job requires the private verifier library — only this stub.
       - name: Run the coqc round-trip gate
-        run: cargo test -p inference-tests --verbose rocq_typecheck::
+        run: cargo test -p inference-tests --verbose "rocq_typecheck::"


### PR DESCRIPTION
One-line CI fix. The `run:` line of `.github/workflows/rocq-typecheck.yml` ended with the bare test filter `rocq_typecheck::` — a trailing colon at end-of-line is a YAML mapping indicator, so the workflow file has been unparseable since it merged in #276. GitHub records an unparseable workflow as a zero-job failure run on **every push** (branch/path filters can't be evaluated), which explains:

- every run of this workflow in history showing `failure` with "log not found" / no jobs,
- failure runs appearing even on branches the `paths`/`branches` filters should exclude (e.g. the LSP-only #297 branch).

**The coqc round-trip gate (#231/#276) has therefore never executed in CI.** Quoting the scalar fixes the parse; the gate itself is healthy — verified locally: `cargo test -p inference-tests "rocq_typecheck::"` → 2 passed (the corpus type-checks against the vendored stub with a real `coqc`).

This PR's own run of the workflow is the first real CI execution of the gate — its result on this PR is the proof of the fix.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The shell passes the quoted filter to Cargo with the same value.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/rocq-typecheck.yml | Quotes the Cargo test filter so YAML parses it correctly without changing the shell argument. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into 231-fix-rocq-wo..."](https://github.com/inferara/inference/commit/d5e58cd6500f56e83b357e0f23222068ef387b0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45932905)</sub>

<!-- /greptile_comment -->