### PR TITLE
analysis: reject reserved wasm export names (A043)

### DIFF
--- a/core/analysis/src/errors.rs
+++ b/core/analysis/src/errors.rs
@@ -216,6 +216,9 @@ pub enum AnalysisDiagnostic {
         location: Location,
         first_location: Location,
     },
+
+    #[error("entry-file `pub fn {name}` collides with the reserved export name `{name}`; the compiled module reserves `memory` for its linear memory export and `__stack_pointer` for its stack pointer global, which WebAssembly hosts rely on; rename the function, or remove `pub` if it does not need to be exported")]
+    ReservedExportName { name: String, location: Location },
 }
 
 impl AnalysisDiagnostic {
@@ -260,7 +263,8 @@ impl AnalysisDiagnostic {
             | AnalysisDiagnostic::RecursionDetected { location, .. }
             | AnalysisDiagnostic::StackDepthExceeded { location, .. }
             | AnalysisDiagnostic::ArrayIndexConstOutOfBounds { location, .. }
-            | AnalysisDiagnostic::DuplicateLocalName { location, .. } => location,
+            | AnalysisDiagnostic::DuplicateLocalName { location, .. }
+            | AnalysisDiagnostic::ReservedExportName { location, .. } => location,
         }
     }
 
@@ -309,6 +313,7 @@ impl AnalysisDiagnostic {
             AnalysisDiagnostic::StructUzumakiAsArgument { .. } => "A039",
             AnalysisDiagnostic::UzumakiOnCompoundArrayElement { .. } => "A040",
             AnalysisDiagnostic::DuplicateLocalName { .. } => "A041",
+            AnalysisDiagnostic::ReservedExportName { .. } => "A043",
         }
     }
 }
@@ -1239,6 +1244,38 @@ mod tests {
             "A041 diagnostic must not use shadowing terminology, got: {text}"
         );
         assert_eq!(err.rule_id(), "A041");
+    }
+
+    #[test]
+    fn display_reserved_export_name() {
+        let err = AnalysisDiagnostic::ReservedExportName {
+            name: "memory".to_string(),
+            location: test_location(),
+        };
+        let text = err.to_string();
+        // The leading fragment pins the OFFENDING name; the bare word "memory"
+        // also appears later in the why-clause, so match the full phrase.
+        assert!(
+            text.contains("entry-file `pub fn memory` collides"),
+            "A043 diagnostic must name the offending function, got: {text}"
+        );
+        assert!(
+            text.contains("reserved export name"),
+            "A043 diagnostic must explain the name is reserved, got: {text}"
+        );
+        assert!(
+            text.contains("`__stack_pointer`"),
+            "A043 diagnostic must explain both reserved names, got: {text}"
+        );
+        assert!(
+            text.contains("rename the function"),
+            "A043 diagnostic must suggest renaming the function, got: {text}"
+        );
+        assert!(
+            text.contains("remove `pub`"),
+            "A043 diagnostic must suggest removing `pub`, got: {text}"
+        );
+        assert_eq!(err.rule_id(), "A043");
     }
 
     #[test]

--- a/core/analysis/src/lib.rs
+++ b/core/analysis/src/lib.rs
@@ -94,6 +94,16 @@
 //!   rule — it preserves a 1:1 source-name to local to proof-index mapping per
 //!   function — not a proof-soundness requirement.
 //!
+//! ### Reserved Export Names (A043)
+//!
+//! - A043: An entry-file top-level `pub fn` may not be named `memory` or
+//!   `__stack_pointer`. Codegen exports such a function under its plain source
+//!   name and separately reserves those names for the module's synthetic linear
+//!   memory and stack-pointer exports; a user function with either name would
+//!   produce a duplicate export name (invalid wasm) or hijack the standard
+//!   `memory` export with a Function. The check is unconditional so the ABI
+//!   surface does not depend on whether the program happens to use memory.
+//!
 //! ## Pipeline Position
 //!
 //! ```text
@@ -208,6 +218,7 @@ mod tests {
             AnalysisDiagnostic::StructUzumakiAsArgument { location: dummy_location() },
             AnalysisDiagnostic::UzumakiOnCompoundArrayElement { ty: "Point".to_string(), location: dummy_location() },
             AnalysisDiagnostic::DuplicateLocalName { name: "x".to_string(), location: dummy_location(), first_location: dummy_location() },
+            AnalysisDiagnostic::ReservedExportName { name: "memory".to_string(), location: dummy_location() },
         ];
 
         let rules = rules::all_rules();

--- a/core/analysis/src/rules/mod.rs
+++ b/core/analysis/src/rules/mod.rs
@@ -21,6 +21,7 @@ pub mod method_never_accesses_self;
 pub mod missing_return;
 pub mod nested_compound_depth;
 pub mod recursion;
+pub mod reserved_export_name;
 pub mod return_inside_loop;
 pub mod return_inside_nondet_block;
 pub mod stack_depth;
@@ -60,6 +61,7 @@ use method_never_accesses_self::MethodNeverAccessesSelf;
 use missing_return::MissingReturn;
 use nested_compound_depth::NestedCompoundDepth;
 use recursion::RecursionDetected;
+use reserved_export_name::ReservedExportName;
 use return_inside_loop::ReturnInsideLoop;
 use return_inside_nondet_block::ReturnInsideNonDetBlock;
 use stack_depth::StackDepthExceeded;
@@ -123,5 +125,6 @@ pub fn all_rules() -> &'static [&'static dyn crate::rule::Rule] {
         &StructUzumakiAsArgument,
         &UzumakiOnCompoundArrayElement,
         &DuplicateLocalName,
+        &ReservedExportName,
     ]
 }

--- a/core/analysis/src/rules/reserved_export_name.rs
+++ b/core/analysis/src/rules/reserved_export_name.rs
@@ -1,0 +1,74 @@
+//! A043: An entry-file top-level `pub fn` may not use a reserved export name.
+//!
+//! Code generation exports an entry-file top-level (non-method) `pub fn` under
+//! its plain source name, and separately appends the synthetic exports `memory`
+//! (the module's linear memory) and `__stack_pointer` (its shadow-stack global)
+//! whenever the compiled module emits linear memory. Those two names are
+//! therefore reserved: a user function claiming either one collides with the
+//! compiler's own export surface.
+//!
+//! The collision has two failure modes depending on codegen-internal state that
+//! is not visible from the source alone:
+//!
+//! - If the program emits linear memory (any struct/array local anywhere is
+//!   enough), the module ends up with two exports named `memory` (or
+//!   `__stack_pointer`), which is invalid WebAssembly — export names must be
+//!   unique across kinds.
+//! - If the program uses no memory, the module is valid but exports a *Function*
+//!   named `memory`, hijacking the name WebAssembly hosts expect to resolve to
+//!   the module's linear memory. That is an ABI hazard.
+//!
+//! Whether a given program falls in the first or the second case is codegen
+//! decision, and adding an unrelated struct local later would silently flip a
+//! program from the second case into the first. The rule is therefore
+//! unconditional: it rejects the reserved names regardless of whether the
+//! program happens to use memory, so the exported ABI surface never depends on
+//! that hidden state.
+//!
+//! The reserved names mirror the synthetic exports emitted in the export-section
+//! code of core/wasm-codegen/src/compiler.rs; the two sites must stay in sync if
+//! either reserved name ever changes.
+
+use inference_ast::nodes::{Def, Visibility};
+
+use crate::errors::{AnalysisDiagnostic, LabeledDiagnostic};
+
+/// Export names the compiled module reserves for its own synthetic exports.
+const RESERVED_EXPORT_NAMES: [&str; 2] = ["memory", "__stack_pointer"];
+
+crate::rule! {
+    /// An entry-file top-level `pub fn` must not use a reserved WebAssembly
+    /// export name (`memory`, `__stack_pointer`).
+    #[id = "A043"]
+    #[name = "Reserved export name"]
+    #[severity = error]
+    pub struct ReservedExportName;
+    fn check(ctx: &TypedContext) -> Vec<LabeledDiagnostic> {
+        let mut errors = Vec::new();
+        let arena = ctx.arena();
+        for source_file in ctx.source_files() {
+            if !source_file.is_entry() {
+                continue;
+            }
+            // Direct `defs` entries that are `Def::Function` are top-level and
+            // non-method by construction: methods nest in `Def::Struct` and spec
+            // functions in `Def::Spec`. Only these top-level entry-file `pub fn`s
+            // are exported under their plain name, so the check must not recurse
+            // into struct or spec definitions.
+            for &def_id in &source_file.defs {
+                if let Def::Function { name, vis: Visibility::Public, .. } = &arena[def_id].kind {
+                    let ident = &arena[*name];
+                    if RESERVED_EXPORT_NAMES.contains(&ident.name.as_str()) {
+                        errors.push(LabeledDiagnostic::entry(
+                            AnalysisDiagnostic::ReservedExportName {
+                                name: ident.name.clone(),
+                                location: ident.location,
+                            },
+                        ));
+                    }
+                }
+            }
+        }
+        errors
+    }
+}

--- a/tests/src/analysis/mod.rs
+++ b/tests/src/analysis/mod.rs
@@ -17,4 +17,5 @@ mod rules_a038;
 mod rules_a039;
 mod rules_a040;
 mod rules_a041;
+mod rules_a043;
 mod walker_tests;

--- a/tests/src/analysis/rules_a043.rs
+++ b/tests/src/analysis/rules_a043.rs
@@ -1,0 +1,367 @@
+/// Integration tests for analysis rule A043.
+///
+/// - A043: ReservedExportName — an entry-file top-level `pub fn` may not be named
+///   `memory` or `__stack_pointer`. Codegen exports such a function under its
+///   plain source name and separately reserves those two names for the module's
+///   synthetic linear-memory and shadow-stack exports; a user function with
+///   either name collides with that surface — producing a duplicate export name
+///   (invalid wasm) when the program uses memory, or hijacking the standard
+///   `memory` export with a Function when it does not. The rule is unconditional,
+///   so the exported ABI never depends on that hidden codegen state.
+///
+/// The predicate is entry-file-only and top-level-only: methods (which nest in a
+/// struct), spec-inner functions, imported-file `pub fn`s, locals, and struct
+/// fields are all out of scope because none of them are exported under a plain
+/// module-level name. These tests are the cross-crate guard that the rule fires
+/// through a real parse -> type-check -> analyze pipeline, complementing the
+/// in-crate message/`rule_id` unit tests in `core/analysis`.
+///
+/// Bare integer literals are `i32` and do not coerce in return position, so the
+/// name-only test bodies return `i32`; the two tests that genuinely exercise an
+/// `i64` value read it from a struct field, where the type is concrete.
+#[cfg(test)]
+mod analysis_rules_tests {
+    use crate::utils::{build_ast, try_codegen, try_type_check_multi_file};
+    use inference_analysis::errors::{AnalysisDiagnostic, AnalysisErrors, AnalysisResult};
+    use inference_type_checker::typed_context::TypedContext;
+
+    fn type_check(source: &str) -> TypedContext {
+        let arena = build_ast(source.to_string());
+        inference_type_checker::TypeCheckerBuilder::build_typed_context(arena)
+            .expect("type checking should succeed for analysis test input")
+            .typed_context()
+    }
+
+    fn analyze(source: &str) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = type_check(source);
+        inference_analysis::analyze(&ctx)
+    }
+
+    /// Returns true if any analysis error is a `ReservedExportName` (A043).
+    /// Filters by variant rather than asserting a total error count, since the
+    /// surface may also trip unrelated rules (or warnings).
+    fn has_a043(source: &str) -> bool {
+        match analyze(source) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::ReservedExportName { .. })),
+        }
+    }
+
+    fn a043_diag(source: &str) -> AnalysisDiagnostic {
+        analyze(source)
+            .expect_err("expected analysis errors but got Ok")
+            .errors()
+            .iter()
+            .find(|e| matches!(e, AnalysisDiagnostic::ReservedExportName { .. }))
+            .expect("expected a ReservedExportName diagnostic")
+            .clone()
+    }
+
+    /// Counts how many `ReservedExportName` (A043) diagnostics the analysis emits
+    /// for `source`. Like the other helpers it filters by variant so unrelated
+    /// rules tripped by the same surface do not perturb the count.
+    fn count_a043(source: &str) -> usize {
+        match analyze(source) {
+            Ok(_) => 0,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .filter(|e| matches!(e, AnalysisDiagnostic::ReservedExportName { .. }))
+                .count(),
+        }
+    }
+
+    /// Type-checks a multi-file program (entry first, empty module path) and runs
+    /// the analysis pass, returning its result.
+    fn analyze_multi(files: &[(Vec<&str>, &str)]) -> Result<AnalysisResult, AnalysisErrors> {
+        let ctx = try_type_check_multi_file(files)
+            .expect("multi-file type checking should succeed for analysis test input");
+        inference_analysis::analyze(&ctx)
+    }
+
+    fn has_a043_multi(files: &[(Vec<&str>, &str)]) -> bool {
+        match analyze_multi(files) {
+            Ok(_) => false,
+            Err(errors) => errors
+                .errors()
+                .iter()
+                .any(|e| matches!(e, AnalysisDiagnostic::ReservedExportName { .. })),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Fires: entry-file top-level `pub fn` claiming a reserved name
+    // ---------------------------------------------------------------------
+
+    /// A memory-FREE `pub fn memory` still fires. This is the ABI-landmine case:
+    /// today it compiles to a valid module that exports a *Function* named
+    /// `memory`, hijacking the name hosts resolve to linear memory. The rule is
+    /// unconditional, so it rejects the name even though no memory is emitted.
+    #[test]
+    fn a043_entry_pub_fn_memory_rejected() {
+        let source = r#"
+            pub fn memory() -> i32 { return 1; }
+            pub fn main() -> i32 { return 0; }
+        "#;
+        let diag = a043_diag(source);
+        assert!(
+            matches!(&diag, AnalysisDiagnostic::ReservedExportName { name, .. } if name == "memory"),
+            "expected A043 to flag the entry-file `pub fn memory`, got: {diag}"
+        );
+    }
+
+    /// The twin case for the shadow-stack global: an entry-file `pub fn
+    /// __stack_pointer` is rejected on the same unconditional grounds.
+    #[test]
+    fn a043_entry_pub_fn_stack_pointer_rejected() {
+        let source = r#"
+            pub fn __stack_pointer() -> i32 { return 1; }
+            pub fn main() -> i32 { return 0; }
+        "#;
+        let diag = a043_diag(source);
+        assert!(
+            matches!(&diag, AnalysisDiagnostic::ReservedExportName { name, .. } if name == "__stack_pointer"),
+            "expected A043 to flag the entry-file `pub fn __stack_pointer`, got: {diag}"
+        );
+    }
+
+    /// The invalid-wasm shape: a struct local makes codegen emit linear memory,
+    /// so a `pub fn memory` would produce two exports named `memory`. A043 fires
+    /// before that invalid module can be built. The returned `t.v` is a concrete
+    /// `i64` field read, so the `i64` return type is genuine here.
+    #[test]
+    fn a043_memory_with_struct_local_rejected() {
+        let source = r#"
+            struct T { v: i64; }
+            pub fn memory() -> i64 { let t: T = T { v: 1 }; return t.v; }
+        "#;
+        let diag = a043_diag(source);
+        assert!(
+            matches!(&diag, AnalysisDiagnostic::ReservedExportName { name, .. } if name == "memory"),
+            "expected A043 to flag the memory-using `pub fn memory`, got: {diag}"
+        );
+    }
+
+    /// One file declaring both reserved names must yield exactly two A043
+    /// diagnostics — one per offending function.
+    #[test]
+    fn a043_both_reserved_names_two_diagnostics() {
+        let source = r#"
+            pub fn memory() -> i32 { return 1; }
+            pub fn __stack_pointer() -> i32 { return 2; }
+        "#;
+        assert_eq!(
+            count_a043(source),
+            2,
+            "a file declaring both reserved names must yield exactly two A043 diagnostics"
+        );
+    }
+
+    /// Diagnostic quality through the real pipeline: the finding names the
+    /// offending function, gives both suggested fixes, and reports rule id A043.
+    #[test]
+    fn a043_diagnostic_quality() {
+        let source = r#"
+            pub fn memory() -> i32 { return 1; }
+        "#;
+        let diag = a043_diag(source);
+        assert!(
+            matches!(&diag, AnalysisDiagnostic::ReservedExportName { name, .. } if name == "memory"),
+            "expected A043 to flag `memory`, got: {diag}"
+        );
+        let msg = diag.to_string();
+        assert!(
+            msg.contains("entry-file `pub fn memory` collides"),
+            "A043 message must name the offending function, got: {msg}"
+        );
+        assert!(
+            msg.contains("rename the function"),
+            "A043 message must suggest renaming the function, got: {msg}"
+        );
+        assert!(
+            msg.contains("remove `pub`"),
+            "A043 message must suggest removing `pub`, got: {msg}"
+        );
+        assert_eq!(diag.rule_id(), "A043");
+    }
+
+    /// The entry-file predicate must survive project-mode threading: an entry
+    /// file with a `pub fn memory` fires A043 even when it imports and calls into
+    /// a sibling module. The imported module carries an innocent `pub fn helper`.
+    #[test]
+    fn a043_entry_offense_fires_in_project_mode() {
+        let files: &[(Vec<&str>, &str)] = &[
+            (
+                vec![],
+                r#"
+                    use lib;
+                    pub fn memory() -> i32 { return 1; }
+                    pub fn main() -> i32 {
+                        let x: i32 = lib::helper();
+                        return x;
+                    }
+                "#,
+            ),
+            (
+                vec!["lib"],
+                r#"
+                    pub fn helper() -> i32 { return 1; }
+                "#,
+            ),
+        ];
+        assert!(
+            has_a043_multi(files),
+            "an entry-file `pub fn memory` must still fire A043 in project mode"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Does not fire
+    // ---------------------------------------------------------------------
+
+    /// A non-pub `fn memory` in the entry file is never exported (private
+    /// functions are not part of the module surface), so A043 stays silent and
+    /// the program compiles end-to-end.
+    #[test]
+    fn a043_private_fn_memory_accepted() {
+        let source = r#"
+            fn memory() -> i32 { return 1; }
+        "#;
+        assert!(
+            !has_a043(source),
+            "a private `fn memory` is never exported, so A043 must not fire"
+        );
+        assert!(
+            try_codegen(source).is_ok(),
+            "a private `fn memory` must compile end-to-end through the analysis-inclusive pipeline"
+        );
+    }
+
+    /// An imported-file `pub fn memory` is intra-project visibility, never a
+    /// module export, so A043 must not fire on it. The entry file calls
+    /// `lib::memory()` so both files type-check as one project.
+    #[test]
+    fn a043_imported_file_pub_fn_memory_accepted() {
+        let files: &[(Vec<&str>, &str)] = &[
+            (
+                vec![],
+                r#"
+                    use lib;
+                    pub fn main() -> i32 {
+                        let x: i32 = lib::memory();
+                        return x;
+                    }
+                "#,
+            ),
+            (
+                vec!["lib"],
+                r#"
+                    pub fn memory() -> i32 { return 1; }
+                "#,
+            ),
+        ];
+        assert!(
+            !has_a043_multi(files),
+            "an imported-file `pub fn memory` is never exported, so A043 must not fire"
+        );
+    }
+
+    /// A struct *method* named `memory` nests in `Def::Struct` and is never a
+    /// module export, so A043 must not fire. This also guards that the rule does
+    /// not recurse into struct definitions. `self.v` is a concrete `i64` field
+    /// read, so the `i64` return type is genuine here.
+    #[test]
+    fn a043_method_named_memory_accepted() {
+        let source = r#"
+            struct S {
+                v: i64;
+                fn memory(self) -> i64 { return self.v; }
+            }
+        "#;
+        assert!(
+            !has_a043(source),
+            "a struct method named `memory` is never exported, so A043 must not fire"
+        );
+    }
+
+    /// A spec-inner function named `memory` nests in `Def::Spec` and is never a
+    /// module export, so A043 must not fire. This is the guard that the rule
+    /// iterates direct defs only and does NOT descend through a body walker into
+    /// spec definitions.
+    #[test]
+    fn a043_spec_inner_fn_memory_accepted() {
+        let source = r#"
+            fn main() -> i32 { return 0; }
+            spec S {
+                fn memory() -> i32 { return 0; }
+            }
+        "#;
+        assert!(
+            !has_a043(source),
+            "a spec-inner `fn memory` is never exported, so A043 must not fire"
+        );
+    }
+
+    /// A function *local* named `memory` is not an export, so A043 must not fire.
+    #[test]
+    fn a043_local_named_memory_accepted() {
+        let source = r#"
+            fn f() {
+                let memory: i32 = 0;
+            }
+        "#;
+        assert!(
+            !has_a043(source),
+            "a local named `memory` is not an export, so A043 must not fire"
+        );
+    }
+
+    /// A struct *field* named `memory` is not an export, so A043 must not fire.
+    #[test]
+    fn a043_struct_field_named_memory_accepted() {
+        let source = r#"
+            struct S { memory: i64; }
+        "#;
+        assert!(
+            !has_a043(source),
+            "a struct field named `memory` is not an export, so A043 must not fire"
+        );
+    }
+
+    /// A plain `pub fn main` program is fine: `main` is not a reserved export
+    /// name, and it exports under its own name.
+    #[test]
+    fn a043_pub_fn_main_accepted() {
+        let source = r#"
+            pub fn main() -> i32 { return 0; }
+        "#;
+        assert!(
+            !has_a043(source),
+            "`pub fn main` exports as `main`, which is not reserved, so A043 must not fire"
+        );
+    }
+
+    /// The suggested fix genuinely compiles: the rejected memory-using shape,
+    /// renamed to `pub fn my_memory`, passes the full analysis-inclusive pipeline
+    /// (`try_codegen` runs parse -> type-check -> analyze -> codegen and catches
+    /// panics), so an `Ok` here pins the rename as a real fix. The `i64` return
+    /// is genuine — `t.v` is a concrete field read.
+    #[test]
+    fn a043_renamed_fn_fix_pin() {
+        let source = r#"
+            struct T { v: i64; }
+            pub fn my_memory() -> i64 { let t: T = T { v: 1 }; return t.v; }
+        "#;
+        assert!(
+            !has_a043(source),
+            "the renamed `pub fn my_memory` must not trip A043"
+        );
+        assert!(
+            try_codegen(source).is_ok(),
+            "the renamed `pub fn my_memory` must compile end-to-end"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

An entry-file top-level `pub fn memory()` (or `pub fn __stack_pointer()`) compiles with exit 0, but the emitted module is invalid WebAssembly: codegen exports the function under its plain source name and separately appends the synthetic `memory` (linear memory) and `__stack_pointer` (stack-pointer global) exports whenever the module uses memory — with no collision check. Export names must be unique across kinds, so validation fails with `duplicate export name`. In memory-free programs the module validates but exports a *Function* named `memory`, hijacking the name hosts resolve to linear memory.

## Fix

New analysis rule **A043 — Reserved export name** (`core/analysis/src/rules/reserved_export_name.rs`): an entry-file top-level `pub fn` may not be named `memory` or `__stack_pointer`. The predicate mirrors codegen's export gate exactly (public + top-level + non-method + entry file, checked by iterating direct top-level defs only), so methods, spec-inner functions, imported-file `pub fn`s, locals, and fields all stay accepted. The check is unconditional: whether the collision manifests as invalid wasm or as the ABI landmine depends on codegen-internal memory state, and the exported ABI surface should not depend on that.

The diagnostic names the offending function and offers both fixes (rename, or drop `pub`).

Zero codegen changes; the entire diff is confined to `core/analysis` and `tests/src/analysis`. Rule id A042 is intentionally skipped here — it is claimed by the in-flight nondet-outside-spec branch.

## Tests

- In-crate: message-content + `rule_id` unit test, rule/diagnostic zip-alignment test extended.
- Integration (`tests/src/analysis/rules_a043.rs`): 14-case matrix — 6 rejecting shapes (both reserved names, memory-free and memory-using bodies, double offense = two diagnostics, diagnostic quality, project-mode entry file) and 8 accepting shapes (private fn, imported-file `pub fn`, method, spec-inner fn, local, struct field, `pub fn main`, renamed fix-pin compiling end-to-end).

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is entirely additive, confined to the analysis pass, and touches no codegen or runtime paths.

The rule predicate exactly mirrors the export gate in compiler.rs (top-level, entry file, public, non-method), the reserved name list matches the two synthetic exports the codegen emits, and the tests cover every accepted and rejected shape described in the PR. The zip-alignment test in lib.rs guards the A043/diagnostic pairing. No logic errors or edge-case gaps were found.

**Files Needing Attention:** No files require special attention. A future maintainer should remember that RESERVED_EXPORT_NAMES in reserved_export_name.rs must stay in sync with the export-section block in core/wasm-codegen/src/compiler.rs if either reserved name ever changes — the module-level comment documents this obligation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/analysis/src/rules/reserved_export_name.rs | New rule A043: correctly iterates only direct top-level entry-file defs, matches public functions against the two reserved names, and does not recurse into struct or spec definitions. Reserved name list matches the codegen's export section exactly. |
| core/analysis/src/errors.rs | Adds ReservedExportName diagnostic variant with a clear format string, correct location() and rule_id() implementations, and comprehensive unit test coverage. Rule ID A043 is consistent across variant and rule_id(). |
| core/analysis/src/lib.rs | Documentation and zip-alignment test extended for A043. The new diagnostic is added at the correct tail position matching the rule registration order. |
| core/analysis/src/rules/mod.rs | Module declaration and all_rules() registration are correct; ReservedExportName is appended after DuplicateLocalName (A041), with A042 intentionally skipped. |
| tests/src/analysis/rules_a043.rs | Thorough 14-case matrix: 6 rejecting shapes cover both reserved names, memory-using bodies, double-offense two-diagnostic count, diagnostic quality, and project-mode entry detection. 8 accepting shapes cover all non-exported positions and include an end-to-end compile fix-pin. |
| tests/src/analysis/mod.rs | Trivial addition of the mod rules_a043 declaration; no issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source file] --> B{is_entry?}
    B -- No --> Z[Skip - imported file pub fn OK]
    B -- Yes --> C[Iterate top-level defs]
    C --> D{Def::Function + Visibility::Public?}
    D -- No --> E[Skip]
    D -- Yes --> F{name in RESERVED_EXPORT_NAMES?}
    F -- No --> G[Accept]
    F -- Yes --> H[Emit A043 ReservedExportName]
    H --> I{Codegen state}
    I -- has_memory=true --> J[Invalid wasm: duplicate export name]
    I -- has_memory=false --> K[ABI hazard: Function hijacks memory export]
```

<sub>Reviews (1): Last reviewed commit: ["A043: ReservedExportName"](https://github.com/inferara/inference/commit/458de90f5e7d3d732d0e1a9d58e1c3c84a68835c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47162469)</sub>

<!-- /greptile_comment -->