### PR TITLE
lsp: fix test-harness wait livelock — waits drain the wire past interleaved traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- Fix a hot-spin in the LSP e2e test client's message waits ([#296])
+  - `wait_for_response`/`wait_for_notification` looped over `recv_message`, which returns buffered messages before reading the wire. Once any non-matching message existed — most often a `publishDiagnostics` landing ahead of the awaited response — each iteration popped it from the buffer and pushed it straight back, so the loop never reached the wire again. The client burned 100% of a core indefinitely with no timeout, because `recv_timeout` was never called. This was misdiagnosed once as a server-side hang and forced a wire-direct `collect_responses` workaround in the cancellation tests
+  - Both waits now scan the buffer once up front and then read straight off the wire, appending each non-matching message to the back of the buffer so arrival order survives for later waits. Each wait is bounded by a single deadline covering the whole wait rather than per read, and expiry panics naming what was awaited and how many messages it stepped over. A new `recv_from_wire` is the one place a wait turns a reader-thread item into a failure; the two drains keep interpreting the same items quietly, as collectors rather than waits. `recv_message`'s own semantics (buffer first, then the wire, one timeout per call) are unchanged — the `#294` shutdown-silence test depends on them
+  - Seven harness self-tests pin the contract: stepping over buffered and over wire traffic on both the response and notification paths, retention order across the buffer/wire boundary, claiming an already-buffered target without a wire read, and giving up loudly when a target never comes. One of them runs the wait on its own thread under a watchdog, so a reintroduced spin fails red instead of hanging the suite. Determinism comes from seeding the buffer directly and from the server's own arrival-order contract, never from a sleep
 - Add a `coqc` round-trip gate for proof-mode `wasm-to-v` output ([#231])
   - Every prior `wasm-to-v` test string-matched the emitted `.v` and never type-checked it, so a mis-aritied or renamed Rocq constructor (the [#230] `BI_forall`/`BI_exists` arity class) passed CI and failed only on the paid prover worker
   - New vendored signature stub `core/wasm-to-v/rocq-stub/` provides the logical library `Wasm` (`bytes`, `numerics`, `datatypes`, `verifier`) as signatures only — no semantics, no proofs — encoding each external declaration with the arity/shape the emitter writes, so a regression becomes a `coqc` type error
@@ -1096,3 +1100,4 @@ Initial tagged release.
 [#254]: https://github.com/Inferara/inference/issues/254
 [#275]: https://github.com/Inferara/inference/issues/275
 [#306]: https://github.com/Inferara/inference/pull/306
+[#296]: https://github.com/Inferara/inference/issues/296

--- a/apps/lsp/tests/e2e.rs
+++ b/apps/lsp/tests/e2e.rs
@@ -129,15 +129,14 @@ fn send_hover(client: &mut LspClient, uri: &str, position: Value) -> i64 {
     )
 }
 
-/// Collects the responses for `ids`, reading the wire directly so the result is
-/// immune to how the responses interleave with publishes.
+/// Collects the responses for `ids` in one pass, in whatever order they arrive.
 ///
-/// `wait_for_response` cannot span several outstanding async requests: it
-/// re-buffers non-matching messages and the underlying `recv_message` returns
-/// buffered items before the wire, so a publish (or a sibling response) landing
-/// ahead of the target livelocks it. This inspects each message exactly once,
-/// keeping matching responses and dropping everything else, so no arrival order can
-/// stall it. Every read stays bounded by the harness receive timeout.
+/// `wait_for_response` also spans interleaved traffic, but it awaits one id at a
+/// time and *retains* everything else for later waits. The tests here launch several
+/// requests at once and care about none of the surrounding traffic, so this inspects
+/// each message exactly once, keeps the matching responses and drops the rest —
+/// leaving nothing buffered to be accounted for afterwards. Every read stays bounded
+/// by the harness receive timeout.
 #[cfg(debug_assertions)]
 fn collect_responses(client: &mut LspClient, ids: &[i64]) -> std::collections::HashMap<i64, Value> {
     let mut found = std::collections::HashMap::new();
@@ -2389,9 +2388,9 @@ fn a_write_cancels_an_in_flight_pool_read() {
         "a write supersedes the in-flight read to -32801, got {response}"
     );
 
-    // The write applied and the session serves a repeat read. `collect_responses`
-    // is used (not the blocking hover) so an interleaved republish cannot livelock
-    // the wait.
+    // The write applied and the session serves a repeat read. `collect_responses` is
+    // used (not the blocking hover) so the republishes the write triggers are dropped
+    // rather than retained for a later wait to account for.
     let repeat_id = send_hover(&mut client, &doc_uri, json!({ "line": 1, "character": 3 }));
     let repeat = collect_responses(&mut client, &[repeat_id])
         .remove(&repeat_id)
@@ -2511,11 +2510,13 @@ fn shutdown_does_not_republish_a_stale_open_slow_dependent() {
     // The corrected mechanism (the issue's write-up said the server "loops forever";
     // it does not): salsa resets its cancellation token on every unwind, so the
     // drain's retry always completes and the server always answered `shutdown`. The
-    // apparent "hang" was client-side — a `wait_for_response` loop hot-spins when any
-    // publish (the trailing post-shutdown one) lands ahead of the response it awaits.
-    // This test therefore pins *protocol silence*, not termination: no diagnostics for
-    // the stale dependent once shutdown is in flight. It reads the wire directly
-    // (never `wait_for_response`) and brackets both drain sites with response
+    // apparent "hang" was client-side — the harness used to re-take the messages it
+    // had just buffered, so the trailing post-shutdown publish landing ahead of the
+    // awaited response spun it in place. Its waits now read past such traffic under
+    // one deadline, and this test pins *protocol silence*, not termination: no
+    // diagnostics for the stale dependent once shutdown is in flight. Because it must
+    // see every message rather than just the awaited ones, it drains in arrival order
+    // instead of awaiting one id, and brackets both drain sites with response
     // barriers, bounded by the harness receive timeout — a drained recompute fails
     // this within the seam bound rather than hanging the suite.
     let mut client = LspClient::spawn_with_env(&[(SLOW_ANALYSIS_ENV, SLOW_PATH_MARKER)]);

--- a/apps/lsp/tests/harness/mod.rs
+++ b/apps/lsp/tests/harness/mod.rs
@@ -6,6 +6,15 @@
 //! are kept as raw [`serde_json::Value`]s and asserted with JSON pointer paths,
 //! so the tests exercise the real wire format, not a typed re-encoding of it.
 //!
+//! [`LspClient::wait_for_response`] and [`LspClient::wait_for_notification`] read
+//! past whatever arrives ahead of the message they want and retain it, in arrival
+//! order, for the waits that follow — a session is free to interleave
+//! notifications with the responses a test awaits. Each of those two bounds its
+//! whole wait by a single deadline. The helpers layered on top do not inherit that
+//! bound: [`LspClient::wait_for_publish`] loops until a publish matches its URI, so
+//! it starts a fresh deadline per non-matching publish and *discards* rather than
+//! retains them.
+//!
 //! A background reader thread parses the child's stdout into framed messages. If
 //! any byte of that stream is not valid framing, the reader reports it as a
 //! [`Incoming::Framing`] error instead of a message — which is what lets a test
@@ -47,9 +56,22 @@ pub struct LspClient {
     stdin: ChildStdin,
     incoming: Receiver<Incoming>,
     reader: Option<JoinHandle<()>>,
-    /// Messages received while waiting for a different, specific one.
+    /// Messages read off the wire but not yet claimed by a wait.
+    ///
+    /// Invariant: always a subsequence of the arrival sequence, in arrival order.
+    /// Every mutation preserves it — reads remove at an index, and appends only ever
+    /// come from a wire read, which is by construction later than anything already
+    /// here. Code that adds a buffer mutation must keep it.
+    ///
+    /// Only responses and notifications are ever claimed. A server-to-client
+    /// *request* (both `id` and `method`) matches neither [`response_id`] nor
+    /// [`notification_method`], so it would accumulate here unclaimed; the server
+    /// sends none today.
     pending: Vec<Value>,
     next_id: i64,
+    /// The budget each wait gets. Defaults to [`RECV_TIMEOUT`]; the harness's own
+    /// tests shorten it so a wait that must give up does so quickly.
+    recv_timeout: Duration,
     /// Set once a framing violation is observed; asserted absent at shutdown.
     framing_error: Option<String>,
 }
@@ -91,6 +113,7 @@ impl LspClient {
             reader: Some(reader),
             pending: Vec::new(),
             next_id: 0,
+            recv_timeout: RECV_TIMEOUT,
             framing_error: None,
         }
     }
@@ -120,59 +143,100 @@ impl LspClient {
     }
 
     /// Receives the next message in arrival order, failing on timeout or a
-    /// prematurely closed / corrupt stream.
+    /// prematurely closed / corrupt stream. Already-buffered messages come first.
     pub fn recv_message(&mut self) -> Value {
         if !self.pending.is_empty() {
             return self.pending.remove(0);
         }
-        match self.incoming.recv_timeout(RECV_TIMEOUT) {
+        let deadline = Instant::now() + self.recv_timeout;
+        self.recv_from_wire(deadline, "a message")
+    }
+
+    /// Reads the next message straight off the wire, ignoring [`Self::pending`] and
+    /// giving up at `deadline`.
+    ///
+    /// The one place a wait turns a reader-thread item into a test failure, so a
+    /// clean EOF mid-session, non-protocol bytes, a silent server and a dead reader
+    /// all fail the same loud way wherever a wait observes them. `awaited` names what
+    /// the caller wanted, so an expiry says which wait gave up. The two drains
+    /// ([`Self::drain_publishes`], [`Self::drain_until_eof`]) interpret the same items
+    /// separately and end quietly by design — they are collectors, not waits.
+    fn recv_from_wire(&mut self, deadline: Instant, awaited: &str) -> Value {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match self.incoming.recv_timeout(remaining) {
             Ok(Incoming::Message(value)) => value,
-            Ok(Incoming::Eof) => panic!("server closed its stdout while a message was expected"),
+            Ok(Incoming::Eof) => {
+                panic!("server closed its stdout while waiting for {awaited}")
+            }
             Ok(Incoming::Framing(error)) => {
                 self.framing_error = Some(error.clone());
                 panic!("server wrote non-protocol bytes to stdout: {error}");
             }
             Err(RecvTimeoutError::Timeout) => {
-                panic!("timed out waiting for a message from the server")
+                let budget = self.recv_timeout;
+                panic!("timed out after {budget:?} waiting for {awaited}")
             }
             Err(RecvTimeoutError::Disconnected) => panic!("the reader thread ended unexpectedly"),
         }
     }
 
-    /// Waits for the response to `id`, buffering any notifications that arrive
-    /// first so a later `wait_for_notification` can still find them.
+    /// Waits for the response to `id`, retaining every other message in
+    /// [`Self::pending`] — in arrival order — so a later `wait_for_notification`,
+    /// `wait_for_publish` or `drain_publishes` still finds it.
+    ///
+    /// The buffer is scanned once, up front; after that every read goes straight to
+    /// the wire. Reading through [`Self::recv_message`] instead would hand back the
+    /// very messages this loop just buffered and never reach the wire again. The
+    /// whole wait — not each read within it — is bounded by [`Self::recv_timeout`],
+    /// so a response that never comes fails the test loudly instead of stalling it.
     pub fn wait_for_response(&mut self, id: i64) -> Value {
+        if let Some(index) = self
+            .pending
+            .iter()
+            .position(|message| response_id(message) == Some(id))
+        {
+            return self.pending.remove(index);
+        }
+
+        let deadline = Instant::now() + self.recv_timeout;
+        let mut stepped_over = 0usize;
         loop {
-            if let Some(index) = self
-                .pending
-                .iter()
-                .position(|message| response_id(message) == Some(id))
-            {
-                return self.pending.remove(index);
-            }
-            let message = self.recv_message();
+            let message = self.recv_from_wire(
+                deadline,
+                &format!("the response to request {id} ({stepped_over} messages stepped over)"),
+            );
             if response_id(&message) == Some(id) {
                 return message;
             }
             self.pending.push(message);
+            stepped_over += 1;
         }
     }
 
-    /// Waits for the next notification with `method`, buffering everything else.
+    /// Waits for the next notification with `method`, retaining everything else in
+    /// arrival order. Buffer-then-wire and deadline behaviour mirror
+    /// [`Self::wait_for_response`].
     pub fn wait_for_notification(&mut self, method: &str) -> Value {
+        if let Some(index) = self
+            .pending
+            .iter()
+            .position(|message| notification_method(message) == Some(method))
+        {
+            return self.pending.remove(index);
+        }
+
+        let deadline = Instant::now() + self.recv_timeout;
+        let mut stepped_over = 0usize;
         loop {
-            if let Some(index) = self
-                .pending
-                .iter()
-                .position(|message| notification_method(message) == Some(method))
-            {
-                return self.pending.remove(index);
-            }
-            let message = self.recv_message();
+            let message = self.recv_from_wire(
+                deadline,
+                &format!("a {method} notification ({stepped_over} messages stepped over)"),
+            );
             if notification_method(&message) == Some(method) {
                 return message;
             }
             self.pending.push(message);
+            stepped_over += 1;
         }
     }
 
@@ -662,4 +726,365 @@ fn percent_encode(input: &str) -> String {
         }
     }
     out
+}
+
+/// Contract tests for the waiting primitives themselves.
+///
+/// A wait for one message must read past whatever stands ahead of it — already
+/// buffered or still on the wire — retain that traffic for the waits that follow,
+/// and give up at a deadline if its target never comes. A wait that re-took the
+/// messages it had itself buffered would instead spin in place: the shape that once
+/// made a busy test client look like a hung server.
+///
+/// Determinism comes from two sources, never from a sleep. Traffic the server would
+/// not send is seeded straight into the buffer. Traffic it does send is ordered by
+/// the server's own contract — the worker handles jobs in arrival order and publishes
+/// for a document write before it dequeues the next job, so a write queued ahead of a
+/// request is always published ahead of that request's response.
+///
+/// A spinning wait never reaches a deadline to expire, so it would *hang* most of
+/// these rather than fail them. [`tests::a_wait_makes_progress_instead_of_spinning`]
+/// is the one that stays red instead of hanging: it runs the wait on its own thread
+/// and bounds it from the test thread.
+#[cfg(test)]
+mod tests {
+    use std::panic::{self, AssertUnwindSafe};
+
+    use super::*;
+
+    /// A short budget for the waits that are *meant* to expire, or that must finish
+    /// without reading the wire at all. Long enough not to fire spuriously on a loaded
+    /// machine, short enough that a regression fails in fractions of a second.
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(250);
+
+    /// How long the test thread lets an off-thread wait run before calling it a spin.
+    /// Only ever reached on failure — a healthy wait answers in milliseconds — but as
+    /// generous as [`RECV_TIMEOUT`], and for the same reason: a loaded machine must
+    /// make this slower, never red.
+    const SPIN_WATCHDOG: Duration = RECV_TIMEOUT;
+
+    /// The id of a seeded response. `next_id` starts at 0, so no real request is ever
+    /// assigned this and no wait can mistake a seeded message for its target.
+    const UNCLAIMED_ID: i64 = 9_999;
+
+    const SOURCE: &str = "fn main() -> i32 { return 0; }";
+    const SOURCE_V2: &str = "fn main() -> i32 { return 1; }";
+
+    /// A `publishDiagnostics` notification the server never sent.
+    fn seeded_publish(uri: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": { "uri": uri, "diagnostics": [] },
+        })
+    }
+
+    /// A response the server never sent, answering [`UNCLAIMED_ID`].
+    fn seeded_response() -> Value {
+        json!({ "jsonrpc": "2.0", "id": UNCLAIMED_ID, "result": Value::Null })
+    }
+
+    /// Handshake params for the tests that drive `initialize` by hand rather than
+    /// through [`LspClient::initialize_default`], because they assert on the wait
+    /// itself and so must send the request and await it in separate steps.
+    fn initialize_params() -> Value {
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": {},
+        })
+    }
+
+    /// Writes a valid single-file fixture and returns its directory and URI. The
+    /// directory must outlive the session — it removes itself on drop.
+    fn fixture(tag: &str) -> (TempDir, String) {
+        let dir = TempDir::new(tag);
+        let uri = path_to_uri(&dir.write("main.inf", SOURCE));
+        (dir, uri)
+    }
+
+    /// Opens a document without awaiting its publish, so the publish is still in
+    /// flight when the next message is sent.
+    fn open_without_waiting(client: &mut LspClient, uri: &str, version: i64) {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "inference",
+                    "version": version,
+                    "text": SOURCE,
+                }
+            }),
+        );
+    }
+
+    /// Rewrites a document without awaiting its publish.
+    fn change_without_waiting(client: &mut LspClient, uri: &str, version: i64) {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [ { "text": SOURCE_V2 } ],
+            }),
+        );
+    }
+
+    fn document_symbol(client: &mut LspClient, uri: &str) -> i64 {
+        client.send_request(
+            "textDocument/documentSymbol",
+            json!({ "textDocument": { "uri": uri } }),
+        )
+    }
+
+    /// The `params.uri` of each buffered message, for order assertions.
+    fn buffered_uris(client: &LspClient) -> Vec<String> {
+        client
+            .pending
+            .iter()
+            .map(|message| {
+                message["params"]["uri"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned()
+            })
+            .collect()
+    }
+
+    /// The message a caught panic carried, whichever payload shape it used.
+    fn panic_text(payload: &(dyn std::any::Any + Send)) -> &str {
+        payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&'static str>().copied())
+            .unwrap_or("<panic payload was not a string>")
+    }
+
+    #[test]
+    fn a_response_wait_steps_over_buffered_traffic_and_keeps_its_order() {
+        let mut client = LspClient::spawn();
+        client.pending.push(seeded_publish("file:///first.inf"));
+        client.pending.push(seeded_publish("file:///second.inf"));
+
+        let id = client.send_request("initialize", initialize_params());
+        let response = client.wait_for_response(id);
+
+        assert_eq!(
+            response["id"],
+            json!(id),
+            "the awaited response arrives, got {response}"
+        );
+        assert!(
+            response.get("result").is_some(),
+            "initialize answers a result, got {response}"
+        );
+        assert_eq!(
+            buffered_uris(&client),
+            ["file:///first.inf", "file:///second.inf"],
+            "both non-targets are retained, in their original order, got {:?}",
+            client.pending
+        );
+
+        client.send_notification("initialized", json!({}));
+        client.shutdown_exit_ok();
+    }
+
+    #[test]
+    fn a_notification_wait_steps_over_a_buffered_response() {
+        let mut client = LspClient::spawn();
+        client.initialize_default(true);
+        // Seeded after the handshake to keep this test about the notification wait; the
+        // id could not collide with a real request's in any case.
+        client.pending.push(seeded_response());
+
+        let (_dir, uri) = fixture("harness-buffered-response");
+        open_without_waiting(&mut client, &uri, 1);
+
+        let published = client.wait_for_notification("textDocument/publishDiagnostics");
+
+        assert_eq!(
+            published["params"]["uri"],
+            json!(uri),
+            "the opened document's publish arrives, got {published}"
+        );
+        assert_eq!(
+            client.pending.len(),
+            1,
+            "the non-target is retained exactly once, got {:?}",
+            client.pending
+        );
+        assert_eq!(
+            client.pending[0]["id"],
+            json!(UNCLAIMED_ID),
+            "and it is the buffered response, got {:?}",
+            client.pending
+        );
+
+        client.shutdown_exit_ok();
+    }
+
+    #[test]
+    fn a_response_wait_retains_a_publish_behind_what_was_already_buffered() {
+        let mut client = LspClient::spawn();
+        client.initialize_default(true);
+        client.pending.push(seeded_publish("file:///buffered.inf"));
+
+        let (_dir, uri) = fixture("harness-retain-publish");
+        // A write queued ahead of the request, not awaited: the server publishes for it
+        // before it dequeues the request, so the wait meets the publish first and has
+        // to step over it to reach the response.
+        open_without_waiting(&mut client, &uri, 1);
+        let id = document_symbol(&mut client, &uri);
+
+        let response = client.wait_for_response(id);
+        assert!(
+            response.get("error").is_none(),
+            "documentSymbol is answered from behind the publish, got {response}"
+        );
+        assert_eq!(
+            buffered_uris(&client),
+            ["file:///buffered.inf", uri.as_str()],
+            "the publish is retained behind the message already buffered, got {:?}",
+            client.pending
+        );
+
+        // And a later wait still finds what this one retained.
+        let published = client.wait_for_publish(&uri);
+        assert!(
+            published.diagnostics.is_empty(),
+            "a valid document publishes no diagnostics, got {:?}",
+            published.diagnostics
+        );
+
+        client.shutdown_exit_ok();
+    }
+
+    #[test]
+    fn a_notification_wait_retains_the_response_that_precedes_it() {
+        let mut client = LspClient::spawn();
+        client.initialize_default(true);
+
+        let (_dir, uri) = fixture("harness-retain-response");
+        client.did_open(&uri, SOURCE, 1);
+
+        // The request is queued ahead of the write, so its response reaches the wire
+        // first and the publish wait has to step over it.
+        let id = document_symbol(&mut client, &uri);
+        change_without_waiting(&mut client, &uri, 2);
+
+        let published = client.wait_for_publish(&uri);
+        assert_eq!(
+            published.version,
+            json!(2),
+            "the write's publish arrives, got {:?}",
+            published.version
+        );
+        assert_eq!(
+            client.pending.len(),
+            1,
+            "the response it stepped over is retained, got {:?}",
+            client.pending
+        );
+        assert_eq!(
+            client.pending[0]["id"],
+            json!(id),
+            "and it is the documentSymbol response, got {:?}",
+            client.pending
+        );
+
+        client.shutdown_exit_ok();
+    }
+
+    #[test]
+    fn an_already_buffered_target_is_taken_without_reading_the_wire() {
+        // Nothing is ever sent to this server, so it answers nothing: any read that
+        // reached the wire would burn the whole budget and expire.
+        let mut client = LspClient::spawn();
+        client.recv_timeout = SHORT_TIMEOUT;
+        client.pending.push(seeded_publish("file:///buffered.inf"));
+        client.pending.push(seeded_response());
+
+        let first = client.recv_message();
+        assert_eq!(
+            notification_method(&first),
+            Some("textDocument/publishDiagnostics"),
+            "the oldest buffered message comes back first, got {first}"
+        );
+
+        let response = client.wait_for_response(UNCLAIMED_ID);
+        assert_eq!(
+            response["id"],
+            json!(UNCLAIMED_ID),
+            "the buffered response is claimed by the up-front scan, got {response}"
+        );
+        assert!(
+            client.pending.is_empty(),
+            "and the buffer is drained, got {:?}",
+            client.pending
+        );
+    }
+
+    #[test]
+    fn a_wait_makes_progress_instead_of_spinning() {
+        let mut client = LspClient::spawn();
+        client.pending.push(seeded_publish("file:///buffered.inf"));
+        let id = client.send_request("initialize", initialize_params());
+
+        // The wait runs off-thread so the test thread can outlive it. A wait that
+        // re-took its own buffered message would never return and never expire; here
+        // that shows up as a failed test rather than a suite that never finishes.
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let response = client.wait_for_response(id);
+            let _ = tx.send((response, client));
+        });
+
+        match rx.recv_timeout(SPIN_WATCHDOG) {
+            Ok((response, mut client)) => {
+                assert_eq!(
+                    response["id"],
+                    json!(id),
+                    "the awaited response arrives, got {response}"
+                );
+                assert_eq!(
+                    buffered_uris(&client),
+                    ["file:///buffered.inf"],
+                    "and the non-target is retained, got {:?}",
+                    client.pending
+                );
+                client.send_notification("initialized", json!({}));
+                client.shutdown_exit_ok();
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("the wait ended without answering")
+            }
+            Err(RecvTimeoutError::Timeout) => panic!(
+                "the wait neither answered nor gave up within {SPIN_WATCHDOG:?} — it spun on its own buffer"
+            ),
+        }
+    }
+
+    #[test]
+    fn a_wait_that_never_gets_its_target_gives_up_loudly() {
+        // A buffered non-target is the essential ingredient: a silent server expires
+        // any implementation, but a wait that re-took its own buffer would never
+        // consult the deadline at all.
+        let mut client = LspClient::spawn();
+        client.recv_timeout = SHORT_TIMEOUT;
+        client.pending.push(seeded_publish("file:///buffered.inf"));
+
+        // No request was ever sent, so nothing can answer this id.
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| client.wait_for_response(7)));
+
+        let payload = outcome.expect_err("an unanswerable wait must give up");
+        let message = panic_text(&*payload);
+        assert!(
+            message.contains("timed out"),
+            "it gives up on the deadline, got {message:?}"
+        );
+        assert!(
+            message.contains("the response to request 7"),
+            "and names what it awaited, got {message:?}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #296.

## Mechanism

`wait_for_response`/`wait_for_notification` looped over `recv_message`, which returns buffered `pending` items before reading the wire. Each iteration popped the non-matching head of the buffer and pushed it straight back, so the moment any non-target message existed — most often a `publishDiagnostics` landing ahead of the awaited response — the loop never reached the wire again. The client hot-spun at 100% CPU indefinitely with no timeout, because `recv_timeout` is only consulted when the buffer is empty. This was misdiagnosed once as a server-side hang (#294) and forced the wire-direct `collect_responses` workaround in the cancellation tests.

## Fix

- Both waits scan `pending` once up front, then read straight off the wire via a new private `recv_from_wire`, appending each non-matching message to the back of the buffer so arrival order survives for later `wait_for_notification`/`wait_for_publish`/`drain_publishes` calls.
- One deadline bounds the whole wait (not each read); expiry panics naming the awaited id/method and how many messages were stepped over — a livelock-shaped failure is now a loud test failure.
- `recv_message`'s public semantics are unchanged (buffer first, then wire, one timeout per call); the shutdown-silence test depends on them. `drain_publishes`, `drain_until_eof`, and `wait_for_publish` are untouched.
- `collect_responses` and every call site stay as-is per the issue; its doc now states its surviving rationale (multi-id collection that *drops* surrounding traffic instead of retaining it). All e2e changes are comment-only.

## Tests

Seven harness self-tests pin the contract: stepping over buffered and wire traffic on both wait paths, retention order across the buffer/wire boundary, claiming an already-buffered target without a wire read, and loud deadline expiry. One runs the wait off-thread under a watchdog so a reintroduced spin fails red instead of hanging the suite. Determinism comes from seeding the buffer directly and from the server's arrival-order contract — no sleeps.

Reversion check: with only the two wait bodies reverted, the watchdog test fails in ~10s ("it spun on its own buffer") and the binary shows the original signature — ~400% client CPU, all spawned servers idle at 0%.

## Verification

- `cargo test -p inference-lsp`: 163 passed (99 unit + 63 e2e + 1 guard)
- `cargo test -p inference-lsp --release` (CI configuration): 145 passed, all 7 new tests included
- `cargo clippy -p inference-lsp --all-targets` clean; touched files fmt-clean (pre-existing drift in untouched files left alone)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed wait paths preserving buffered traffic and making bounded progress through interleaved wire messages.

The waits scan existing buffered traffic once, read subsequent messages directly from the channel under a shared deadline, and append skipped messages in arrival order; the added tests cover both wait variants, retention ordering, buffered targets, livelock prevention, and expiry.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/lsp/tests/harness/mod.rs | Reworks response and notification waits to drain interleaved wire traffic under one deadline and adds comprehensive harness-level regression tests. |
| apps/lsp/tests/e2e.rs | Updates comments to reflect the fixed wait semantics and the distinct traffic-dropping purpose of multi-response collectors. |
| CHANGELOG.md | Documents the original livelock, the deadline-and-buffering fix, and its regression coverage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test
  participant Pending as Pending buffer
  participant Wait as Wait helper
  participant Wire as Reader channel
  Test->>Wait: wait_for_response(id)
  Wait->>Pending: Scan once for target
  alt Target already buffered
    Pending-->>Wait: Remove matching message
    Wait-->>Test: Return target
  else Target absent
    loop Until target or deadline
      Wait->>Wire: recv_from_wire(deadline)
      Wire-->>Wait: Next message
      alt Message matches target
        Wait-->>Test: Return target
      else Non-target message
        Wait->>Pending: Append in arrival order
      end
    end
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["lsp: fix test-harness wait livelock — wa..."](https://github.com/inferara/inference/commit/12fe99cdb5c823821a0aab2d21aec756aa49c66d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47509287)</sub>

**Context used:**

- Knowledge Base — [LSP Server Request Flow](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/lsp-server.md)

<!-- /greptile_comment -->