### PR TITLE
Deep syntax stack safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compiler
 
+- Every embedder now runs the compiler's recursive phases on an explicitly sized stack, so
+  deep input no longer aborts the process where it previously did. Parsing, lowering, type
+  checking, analysis and codegen each descend once per level of the input's syntactic
+  nesting, and a stack overflow aborts rather than unwinding — no thread can catch one and
+  turn it into a diagnostic — so the only mitigation is headroom that does not depend on
+  which thread happens to be running. `inference_parser::MIN_COMPILE_STACK` (128 MiB) states
+  the requirement, the new `inference::with_compiler_stack` runs a closure on a thread that
+  meets it, and `infc`'s driver now runs inside that helper. Exit codes are unchanged —
+  `process::exit` terminates the process identically from the scoped worker thread, and a
+  panic is re-raised on the calling thread with its original payload, printed exactly once —
+  and the only stderr difference is that a panic header now names the compile thread
+  (`thread 'inference-compile' panicked at …`) rather than `main`, which also makes an
+  overflow report which thread overflowed.
+  Measured on macOS aarch64 in debug, the reported repro is fixed — an operator chain that
+  aborted at 350 operands (300 was the last that compiled) now compiles at 5,262, and an
+  `else if` chain that aborted at 900 arms now compiles past 2,000. Input deeper than the new
+  ceilings still aborts; making rejection *deterministic* needs an explicit depth limit with
+  a proper diagnostic, which is separate and still pending. This change is what makes such a
+  limit reachable in every embedder rather than shadowed by whichever host stack runs out
+  first ([#322])
+- parser: `SyntaxNode`'s drop is now iterative. The derived drop glue descended once per tree
+  level, so merely *discarding* a deeply nested CST overflowed the stack — the path any
+  rejected over-deep input has to take. Detaching the children into a worklist and draining
+  it holds the depth at one: a 500,000-level tree, constructed directly, is now discarded on
+  a bare 2 MiB thread, where the recursive glue capped at roughly 8,200 levels. This makes a
+  tree safe to *discard*, not safe to *build*: CST construction still recurses with tree
+  height — through the grammar's own recursive descent, and through `Builder::leave`'s span
+  resolution for shapes whose extremal children are nodes rather than tokens — and that side
+  binds first for a parsed tree (measured on 8 MiB: construction caps at 14,994 levels, the
+  old drop glue at 32,804). Bounding the
+  construction side is separate, still-pending work; removing the drop-side consumer is what
+  lets a rejected tree be freed at all, and what makes limit-depth trees testable on small
+  stacks. The derived `Clone`, `PartialEq` and `Debug` on `SyntaxNode` and `SyntaxElement`
+  remain recursive and must not be applied to a tree of unbounded height ([#322])
 - wasm-linker: New `core/wasm-linker` crate (`inference-wasm-linker`) implementing the
   static-merge link pass. `link(main_wasm, &[external_wasm])` folds satisfied imports'
   transitive closures into the main module, rewrites all index-bearing operators into a
@@ -628,6 +662,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- Add `tests/src/robustness/deep_syntax.rs`, a generated-source module covering deep and
+  deeply chained input across seven shapes — flat operator chain, right-nested parentheses,
+  prefix-unary nest, `else if` chain, block nest, nested array type, and a deep spec-function
+  body. Its pipeline helpers all route through `inference::with_compiler_stack`, because
+  cargo's test harness gives each test thread roughly 2 MiB and every one of these tests would
+  otherwise overflow long before reaching the code under test. The two regressions pinned at
+  issue scale are a 350-operand chain (the reported repro, asserted through analysis rather
+  than merely parsing, since the type checker is the phase that aborted) and a 900-arm
+  `else if` chain (the lowest known abort threshold), driven through code generation.
+  Alongside them: `core/inference/tests/compiler_stack.rs` covers the helper's contract —
+  return value, a closure borrowing its environment (the scoped-thread requirement the CLI
+  call site depends on), a stack far larger than the caller's, and panic propagation with the
+  original payload; `core/cli/tests/cli_integration.rs` proves both shapes exit 0 through the
+  real binary, which distinguishes the fix from both the old abort and any diagnostic, since a
+  stack-overflow abort is a signal kill rather than exit 1; and a parser unit test discards a
+  500,000-level tree on a bare 2 MiB thread, deliberately not routed through the helper because
+  the claim is that it needs no headroom ([#322])
 - Fix a hot-spin in the LSP e2e test client's message waits ([#296])
   - `wait_for_response`/`wait_for_notification` looped over `recv_message`, which returns buffered messages before reading the wire. Once any non-matching message existed — most often a `publishDiagnostics` landing ahead of the awaited response — each iteration popped it from the buffer and pushed it straight back, so the loop never reached the wire again. The client burned 100% of a core indefinitely with no timeout, because `recv_timeout` was never called. This was misdiagnosed once as a server-side hang and forced a wire-direct `collect_responses` workaround in the cancellation tests
   - Both waits now scan the buffer once up front and then read straight off the wire, appending each non-matching message to the back of the buffer so arrival order survives for later waits. Each wait is bounded by a single deadline covering the whole wait rather than per read, and expiry panics naming what was awaited and how many messages it stepped over. A new `recv_from_wire` is the one place a wait turns a reader-thread item into a failure; the two drains keep interpreting the same items quietly, as collectors rather than waits. `recv_message`'s own semantics (buffer first, then the wire, one timeout per call) are unchanged — the `#294` shutdown-silence test depends on them
@@ -996,6 +1047,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### IDE / LSP
 
+- The language server's `SERVER_STACK_SIZE` is now the larger of its historical 64 MiB
+  (the rust-analyzer main-loop figure it mirrored) and `inference_parser::MIN_COMPILE_STACK`,
+  with a compile-time assertion pinning the two together. All three spawn sites — router,
+  read pool and analysis worker — reserve the larger amount. The deviation from the
+  rust-analyzer number is deliberate: the server runs the same recursive phases the compiler
+  does and owes them the same stack, and the reservation is address space with lazy commit,
+  so the editor's resident memory still tracks the depth actually reached. Taking the larger
+  of the two is what keeps them in step: were the server's figure allowed to sit below the
+  front end's, a file at that limit would compile under the CLI while killing the editor
+  process — a worse failure than the one the requirement exists to prevent. The compile-time
+  assertion is a machine-checked restatement of that invariant rather than a gate; the `max`
+  already makes it unfalsifiable ([#322])
 - Add `inference-lsp`, a Language Server Protocol server for Inference (`apps/lsp`) ([#33])
   - A synchronous, single-threaded `lsp-server` 0.8 stdio binary; single-threaded by design because `TypedContext` is `!Send`
   - Diagnostics: merged syntax, import, type-check, and analysis-rule findings (rule codes `A001`–`A041`), published on `didOpen`/`didChange`/`didClose`
@@ -1175,3 +1238,4 @@ Initial tagged release.
 [#306]: https://github.com/Inferara/inference/pull/306
 [#296]: https://github.com/Inferara/inference/issues/296
 [#219]: https://github.com/Inferara/inference/issues/219
+[#322]: https://github.com/Inferara/inference/issues/322

--- a/apps/lsp/Cargo.toml
+++ b/apps/lsp/Cargo.toml
@@ -21,3 +21,8 @@ serde_json.workspace = true
 anyhow.workspace = true
 rustc-hash.workspace = true
 inference-ide.workspace = true
+# Named directly for the front end's stack requirement only: the assertion beside
+# SERVER_STACK_SIZE has to read as "the editor satisfies the *front end's* demand",
+# which laundering the constant through `inference-ide` would obscure. Everything
+# else this server needs still comes through `inference-ide` alone.
+inference-parser.workspace = true

--- a/apps/lsp/src/server.rs
+++ b/apps/lsp/src/server.rs
@@ -54,17 +54,49 @@ const SERVER_NAME: &str = env!("CARGO_PKG_NAME");
 /// version).
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// The stack rust-analyzer gives its main loop, and this crate's historical
+/// figure. Kept as the floor [`SERVER_STACK_SIZE`] never drops below.
+const RUST_ANALYZER_MAIN_LOOP_STACK: usize = 64 * 1024 * 1024;
+
 /// The stack each of the server's threads runs on. The analysis pipeline
 /// (type-checker, analysis passes) recurses with the input's nesting depth, so a
 /// pathological or generated document can overflow the default stack and abort the
 /// whole process — taking every open document's state with it. A stack overflow
 /// aborts rather than unwinds, so a thread cannot *catch* it; the mitigation is
-/// headroom. 64 MiB (mirroring rust-analyzer's main-loop stack) clears realistic
-/// deep nesting by a wide margin. A thread must set this explicitly: a spawned
-/// thread's default stack is far smaller than the main thread's. `main` runs the
-/// router on a thread of this size and the analysis worker — where the deep
-/// recursion now happens — is spawned with the same headroom.
-pub(crate) const SERVER_STACK_SIZE: usize = 64 * 1024 * 1024;
+/// headroom. A thread must set this explicitly: a spawned thread's default stack
+/// is far smaller than the main thread's. `main` runs the router on a thread of
+/// this size and the analysis worker — where the deep recursion now happens — is
+/// spawned with the same headroom.
+///
+/// The size is the larger of that historical figure and the compiler front end's
+/// own [`inference_parser::MIN_COMPILE_STACK`]. That is a deliberate deviation
+/// from the rust-analyzer number this crate used to mirror: the server runs the
+/// same recursive phases the compiler does, so it owes them the same stack. All
+/// three spawn sites reserve the larger amount, which is four threads in a running
+/// server — the router, the two read-pool workers ([`READ_POOL_SIZE`]) and the
+/// analysis worker — so the reservation the editor's process carries doubles from
+/// 256 MiB to 512 MiB. It is affordable because the reservation is address space
+/// with lazy commit; the editor's resident memory still tracks the depth actually
+/// reached. The total, not the per-thread figure, is what to weigh if the front
+/// end's requirement is ever raised again.
+///
+/// Taking the larger of the two is what keeps them in step, and it is the half
+/// that matters: were this figure allowed to sit below the front end's, a file at
+/// the front end's limit would compile under the CLI while killing the editor
+/// process — a worse failure than the one the requirement exists to prevent. The
+/// assertion below is a machine-checked restatement of that invariant for a reader,
+/// not a gate; the `max` already makes it unfalsifiable. What the `max` does *not*
+/// do is ask anyone's permission: a raise to the front end's requirement silently
+/// quadruples into this process's total, which is why that total is the thing to
+/// weigh, above.
+pub(crate) const SERVER_STACK_SIZE: usize =
+    if inference_parser::MIN_COMPILE_STACK > RUST_ANALYZER_MAIN_LOOP_STACK {
+        inference_parser::MIN_COMPILE_STACK
+    } else {
+        RUST_ANALYZER_MAIN_LOOP_STACK
+    };
+
+const _: () = assert!(SERVER_STACK_SIZE >= inference_parser::MIN_COMPILE_STACK);
 
 /// A document the editor has opened, with the path the analysis host knows it by
 /// and the last version the editor reported (echoed back in published

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -426,7 +426,20 @@ fn clear_stale_outputs(output_dir: &std::path::Path, source_fname: &str) {
     let _ = fs::remove_file(output_dir.join(format!("{source_fname}.v")));
 }
 
-/// Entry point for the Inference compiler CLI.
+/// Runs the compiler driver on an explicitly sized stack.
+///
+/// The compiler's phases recurse with the input's syntactic nesting depth, and the
+/// platform's default main-thread stack is too small to survive input the front end
+/// is expected to accept. Exit codes are what they were: `process::exit` terminates
+/// the process identically from the scoped worker thread, and a panic inside the
+/// driver is re-raised on the main thread with its original payload, printed once.
+/// The only stderr difference is that a panic header now names the compile thread
+/// rather than `main`.
+fn main() {
+    inference::with_compiler_stack(run);
+}
+
+/// The Inference compiler CLI driver, run by [`main`] on a compiler-sized stack.
 ///
 /// ## Execution Flow
 ///
@@ -477,7 +490,7 @@ fn clear_stale_outputs(output_dir: &std::path::Path, source_fname: &str) {
 /// - Reads entire source file into memory (limitation: no streaming)
 /// - Phase execution is sequential (no parallelization)
 #[allow(clippy::too_many_lines)]
-fn main() {
+fn run() {
     let mut args = Cli::parse();
 
     if args.commit_hash {

--- a/core/cli/tests/cli_integration.rs
+++ b/core/cli/tests/cli_integration.rs
@@ -1879,3 +1879,129 @@ fn dash_v_success_still_writes_both_artifacts() {
     assert!(temp.child("out").child("main.wasm").path().exists());
     assert!(temp.child("out").child("main.v").path().exists());
 }
+
+// Deeply nested and deeply chained input (issue #322).
+//
+// The compiler's phases recurse once per level of the input's syntactic nesting,
+// and the platform's default main-thread stack is smaller than they need, so
+// these programs used to end the process with `fatal runtime error: stack
+// overflow`. That is a signal kill, not an exit status, so the assertion that
+// separates the fixed behaviour from both the old abort and any diagnostic is
+// `.success()` — a mere "not exit 1" would pass on an abort.
+//
+// The binary is the level that matters here: `fn main` is what reserves the
+// stack, so only a real process proves the reservation is in place for a user's
+// build rather than only for a test that opts into it.
+
+/// `pub fn f(a: i64) -> i64 { return a + a + … + a; }` with `n` operands.
+fn operand_chain_source(n: usize) -> String {
+    let chain = std::iter::repeat_n("a", n).collect::<Vec<_>>().join(" + ");
+    format!("pub fn f(a: i64) -> i64 {{ return {chain}; }}")
+}
+
+/// An `if` / `else if` chain of `k` arms closed by a final `else`.
+fn else_if_chain_source(k: usize) -> String {
+    let arms: String = (0..k)
+        .map(|i| format!("if a == {i} {{ return {i}; }} else "))
+        .collect();
+    format!("pub fn f(a: i64) -> i64 {{ {arms}{{ return 0; }} }}")
+}
+
+/// The input reported in issue #322 — a 350-operand operator chain — compiles
+/// through the binary. On the platform default stack the type checker aborted
+/// here, while 300 operands survived.
+#[test]
+fn deep_operand_chain_compiles_through_the_binary() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let entry = write_source(temp.path(), "chain.inf", &operand_chain_source(350));
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infc"));
+    cmd.current_dir(temp.path()).arg(&entry);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("WASM generated"));
+
+    assert!(temp.child("out").child("chain.wasm").path().exists());
+}
+
+/// A 900-arm `else if` chain compiles through the binary. This was the lowest
+/// known abort threshold: 800 arms survived, 900 did not.
+#[test]
+fn deep_else_if_chain_compiles_through_the_binary() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let entry = write_source(temp.path(), "arms.inf", &else_if_chain_source(900));
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infc"));
+    cmd.current_dir(temp.path()).arg(&entry);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("WASM generated"));
+
+    assert!(temp.child("out").child("arms.wasm").path().exists());
+}
+
+/// The acceptance bar for this work, driven end to end through the binary rather
+/// than stopping at the type checker: 2,000 operands and 2,000 `else if` arms
+/// compile. Both are an order of magnitude past the depths that used to abort, and
+/// running them here is what makes the claim hold on every CI platform rather than
+/// only on the machine the numbers were measured on.
+#[test]
+fn deep_input_at_the_acceptance_bar_compiles_through_the_binary() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let chain = write_source(temp.path(), "chain2k.inf", &operand_chain_source(2_000));
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infc"));
+    cmd.current_dir(temp.path()).arg(&chain);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("WASM generated"));
+    assert!(temp.child("out").child("chain2k.wasm").path().exists());
+
+    let arms = write_source(temp.path(), "arms2k.inf", &else_if_chain_source(2_000));
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infc"));
+    cmd.current_dir(temp.path()).arg(&arms);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("WASM generated"));
+    assert!(temp.child("out").child("arms2k.wasm").path().exists());
+}
+
+// Exit statuses on the argument-handling paths.
+//
+// These are the paths most perturbed by running the driver on a worker thread:
+// argument parsing now happens off the main thread, so clap's own `process::exit`
+// and the missing-argument path both terminate the process from a thread that is
+// not `main`. They are pinned by exact code rather than by `.failure()`, because
+// `.failure()` cannot tell 1 from 2 — nor either of them from the signal kill a
+// stack overflow produces.
+
+/// No arguments: the driver reports the missing source file and exits 1.
+#[test]
+fn no_arguments_exits_one() {
+    Command::new(assert_cmd::cargo::cargo_bin!("infc"))
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("source file argument required"));
+}
+
+/// An unknown flag is rejected by clap, which exits 2 — a distinct status from the
+/// driver's own exit 1, and one that survives the move onto the worker thread.
+#[test]
+fn unknown_flag_exits_two() {
+    Command::new(assert_cmd::cargo::cargo_bin!("infc"))
+        .arg("--no-such-flag")
+        .assert()
+        .code(2);
+}
+
+/// A path that does not exist: exit 1, before any phase runs.
+#[test]
+fn missing_source_file_exits_one() {
+    Command::new(assert_cmd::cargo::cargo_bin!("infc"))
+        .arg("definitely-not-here.inf")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path not found"));
+}

--- a/core/inference/src/lib.rs
+++ b/core/inference/src/lib.rs
@@ -323,6 +323,60 @@ pub use inference_wasm_codegen::{SPEC_FUNCS_SECTION_NAME, SPEC_FUNCS_SECTION_VER
 /// pre-link cross-check) without depending on `inference-hassert` directly.
 pub use inference_wasm_codegen::HSpecMap;
 
+/// Runs `f` on a thread reserving [`inference_parser::MIN_COMPILE_STACK`].
+///
+/// The compiler's phases recurse once per level of the input's syntactic nesting,
+/// and a stack overflow aborts the process rather than unwinding — so the stack
+/// each phase gets cannot be left to whatever the host thread happens to have. That
+/// default varies with the platform and with how the thread was created — a test
+/// harness thread gets a fraction of what a process main thread gets — and none of
+/// them reach the front end's requirement. Every embedder that drives the pipeline
+/// in-process runs it through this helper, so the stack available to the recursive
+/// phases is the same everywhere the compiler runs.
+///
+/// This generalizes a mitigation that already shipped once in this repository for
+/// this exact failure: the language server hit it first — a pathological document
+/// aborting the whole process and taking every open file's state with it — and gave
+/// each of its threads an explicit big stack (`SERVER_STACK_SIZE`, `apps/lsp`). That
+/// server keeps its own long-lived threads rather than calling this helper, and now
+/// sizes them from the same constant.
+///
+/// `f` runs on a scoped thread and may borrow from its environment. Panics
+/// propagate unchanged: the payload is re-raised on the calling thread with
+/// [`std::panic::resume_unwind`], which does not run the panic hook a second time,
+/// so the message still prints exactly once and a wrapped driver keeps the exit
+/// code it had before. The one observable difference is the panic header, which
+/// now names this thread rather than `main` — which is also why the thread is
+/// named, since it makes an overflow say which thread overflowed.
+///
+/// The helper lives in the orchestration crate rather than beside the CLI driver
+/// because `core/cli` is binary-only — it has no library target, so the
+/// integration-test crates could not import a helper defined there — and because
+/// every in-process consumer of the pipeline already links this crate. The `infs`
+/// toolchain driver is deliberately not wrapped: it has no in-process compile path
+/// and always spawns `infc` as a subprocess, so wrapping that binary covers
+/// `infs build` and `infs run` as well, and `infs` need not grow a dependency on
+/// the compiler back end.
+///
+/// # Panics
+///
+/// Panics if the operating system refuses the stack reservation, which leaves no
+/// way to run the phases at all. Also re-raises any panic from `f` itself, so the
+/// caller observes it exactly as if `f` had run inline.
+pub fn with_compiler_stack<T: Send>(f: impl FnOnce() -> T + Send) -> T {
+    std::thread::scope(|scope| {
+        let worker = std::thread::Builder::new()
+            .name("inference-compile".to_owned())
+            .stack_size(inference_parser::MIN_COMPILE_STACK)
+            .spawn_scoped(scope, f)
+            .expect("failed to spawn the compiler thread");
+        match worker.join() {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    })
+}
+
 /// Parses source code and builds an arena-based Abstract Syntax Tree.
 ///
 /// This function delegates to the [`inference_parser`] front end,

--- a/core/inference/tests/compiler_stack.rs
+++ b/core/inference/tests/compiler_stack.rs
@@ -1,0 +1,115 @@
+//! Integration tests for [`inference::with_compiler_stack`], the seam every
+//! in-process driver of the pipeline goes through (issue #322).
+//!
+//! The compiler's phases recurse once per level of the input's syntactic
+//! nesting, and a stack overflow aborts the process rather than unwinding, so
+//! the stack the phases get cannot be left to whatever the host thread happens
+//! to have. The helper answers that by running the work on a thread reserving
+//! [`inference_parser::MIN_COMPILE_STACK`].
+//!
+//! Four properties are pinned, each of which a call site depends on:
+//!
+//! 1. the value the closure computes comes back to the caller;
+//! 2. the closure really does run with the reserved stack, not the caller's;
+//! 3. the closure may borrow from its environment — the CLI driver's `run`
+//!    takes no arguments today, but a `'static` bound would rule out every
+//!    embedder that needs to hand the pipeline a borrowed source or arena;
+//! 4. a panic reaches the caller carrying its original payload, which is what
+//!    keeps a wrapped driver's exit code and stderr identical to what they were
+//!    before the wrapping.
+
+/// Bytes of stack each [`burn`] frame is forced to occupy.
+const FRAME_BYTES: usize = 4 * 1024;
+
+/// Number of [`burn`] frames, chosen so the recursion needs far more stack than
+/// any default-sized thread has and far less than the helper reserves.
+const DEPTH: usize = 4 * 1024;
+
+/// Total stack the recursion consumes: 16 MiB.
+const BURN_BYTES: usize = FRAME_BYTES * DEPTH;
+
+// A default thread — including the one Cargo's harness runs each test on — gets
+// single-digit megabytes, so this recursion could not complete on the calling
+// thread; and it stays an order of magnitude inside the reservation, so the test
+// asserts that the helper switched stacks rather than probing where the
+// reservation itself ends.
+const _: () = assert!(BURN_BYTES >= 16 * 1024 * 1024);
+const _: () = assert!(BURN_BYTES * 8 <= inference_parser::MIN_COMPILE_STACK);
+
+/// Recurses `depth + 1` times, holding a [`FRAME_BYTES`] buffer live across each
+/// call so the frame cannot be elided, and returns the number of frames entered.
+///
+/// The buffer is written before the recursive call and read after it, and passed
+/// through [`std::hint::black_box`], so the frame survives optimization and the
+/// test measures the same stack in a release build as in a debug one.
+#[inline(never)]
+fn burn(depth: usize) -> u64 {
+    let mut frame = [0u8; FRAME_BYTES];
+    let slot = depth % FRAME_BYTES;
+    frame[slot] = 1;
+    let deeper = if depth == 0 { 0 } else { burn(depth - 1) };
+    u64::from(std::hint::black_box(&frame)[slot]) + deeper
+}
+
+/// The helper is transparent to its closure's result.
+#[test]
+fn returns_the_value_the_closure_produces() {
+    let value = inference::with_compiler_stack(|| "computed on the compiler stack".to_owned());
+    assert_eq!(value, "computed on the compiler stack");
+}
+
+/// The closure runs with the reserved stack, not the caller's.
+///
+/// A 16 MiB recursion is several times more than a default thread — the test
+/// harness's included — provides, so its completing at all is the observation:
+/// were the closure run inline the process would have aborted, since a stack
+/// overflow cannot be caught and reported.
+#[test]
+fn runs_on_a_stack_far_larger_than_the_calling_thread_has() {
+    let frames = inference::with_compiler_stack(|| burn(DEPTH - 1));
+    assert_eq!(frames, DEPTH as u64);
+}
+
+/// The closure may borrow from its environment, read and write.
+///
+/// This is the scoped-thread half of the contract. A plain `spawn` would force
+/// a `'static` bound, which no driver that hands the pipeline borrowed inputs
+/// could satisfy; the borrows below would not compile against one.
+#[test]
+fn accepts_a_closure_borrowing_its_environment() {
+    let source = String::from("fn main() { return 0; }");
+    let mut observed = Vec::new();
+
+    let length = inference::with_compiler_stack(|| {
+        observed.push(source.len());
+        source.len()
+    });
+
+    assert_eq!(length, source.len());
+    assert_eq!(observed, vec![source.len()]);
+    assert!(source.starts_with("fn main"), "the borrow must not move");
+}
+
+/// A panic inside the closure reaches the caller carrying its original payload.
+///
+/// The panic hook is silenced for the duration so the expected message does not
+/// read as a failure in the test log; it runs once on the worker thread, and
+/// `resume_unwind` deliberately does not run it again on the caller's.
+#[test]
+fn propagates_a_panic_with_its_original_payload() {
+    const MESSAGE: &str = "deep-syntax stack probe";
+
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(|| {
+        inference::with_compiler_stack(|| -> usize { panic!("{MESSAGE}") })
+    });
+    std::panic::set_hook(previous_hook);
+
+    let payload = outcome.expect_err("a panic inside the closure must reach the caller");
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied());
+    assert_eq!(message, Some(MESSAGE));
+}

--- a/core/inference/tests/compiler_stack.rs
+++ b/core/inference/tests/compiler_stack.rs
@@ -90,21 +90,45 @@ fn accepts_a_closure_borrowing_its_environment() {
     assert!(source.starts_with("fn main"), "the borrow must not move");
 }
 
+/// Serializes replacement of the process-global panic hook.
+///
+/// The hook is process state shared with every concurrently running test in
+/// this binary, so a test that swaps it must hold this lock for the whole
+/// swap-restore window; two unserialized swappers could otherwise interleave
+/// take/set and leave the wrong hook installed at the end.
+static PANIC_HOOK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// A panic inside the closure reaches the caller carrying its original payload.
 ///
-/// The panic hook is silenced for the duration so the expected message does not
-/// read as a failure in the test log; it runs once on the worker thread, and
-/// `resume_unwind` deliberately does not run it again on the caller's.
+/// The expected panic fires on the helper's worker thread, whose output the
+/// test harness does not capture, so left alone it would spray a spurious
+/// "thread 'inference-compile' panicked" over the log of a passing run. The
+/// hook installed here silences exactly that thread and hands every other
+/// panic to the hook that was already installed, so a concurrently failing
+/// test keeps its diagnostic; the swap-restore window is serialized by
+/// [`PANIC_HOOK_LOCK`]. `resume_unwind` deliberately does not run the hook a
+/// second time on the caller's thread.
 #[test]
 fn propagates_a_panic_with_its_original_payload() {
     const MESSAGE: &str = "deep-syntax stack probe";
 
-    let previous_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
+    let hook_guard = PANIC_HOOK_LOCK.lock().expect("panic-hook lock poisoned");
+    let previous_hook = std::sync::Arc::new(std::panic::take_hook());
+    let delegate = std::sync::Arc::clone(&previous_hook);
+    std::panic::set_hook(Box::new(move |info| {
+        if std::thread::current().name() != Some("inference-compile") {
+            delegate(info);
+        }
+    }));
     let outcome = std::panic::catch_unwind(|| {
         inference::with_compiler_stack(|| -> usize { panic!("{MESSAGE}") })
     });
-    std::panic::set_hook(previous_hook);
+    drop(std::panic::take_hook());
+    std::panic::set_hook(
+        std::sync::Arc::try_unwrap(previous_hook)
+            .unwrap_or_else(|_| unreachable!("the filtering hook held the only other reference")),
+    );
+    drop(hook_guard);
 
     let payload = outcome.expect_err("a panic inside the closure must reach the caller");
     let message = payload

--- a/core/parser/src/lib.rs
+++ b/core/parser/src/lib.rs
@@ -47,6 +47,39 @@ pub use token_set::TokenSet;
 
 use inference_ast::arena::AstArena;
 
+/// The minimum stack a thread must have before it runs the compiler's recursive
+/// phases — parse, lowering, type check, analysis and code generation all descend
+/// once per level of the input's syntactic nesting.
+///
+/// Whether a program is accepted must be a property of its source, decided by an
+/// explicit limit, and never by the incidental point at which the host stack runs
+/// out. That point moves with the build profile, the platform and the thread: a
+/// debug frame is an order of magnitude larger than the same frame in release, so
+/// without a fixed floor the same file compiles from one binary and aborts from
+/// another. Fixing acceptance with an explicit limit only works if the process
+/// survives long enough to *reach and report* that limit, which means sizing the
+/// stack for the worst profile — debug — with substantial headroom, not for the
+/// one that happens to be shipped.
+///
+/// Headroom is the only available mitigation. A stack overflow aborts the process
+/// rather than unwinding, so no thread can catch it and turn it into a
+/// diagnostic; the stack has to be large enough that the explicit check is what
+/// the input meets first.
+///
+/// The requirement lives beside the grammar because the explicit bound on
+/// syntactic depth belongs here too, and the two are halves of one invariant: the
+/// depth a program is allowed to reach, multiplied by the worst-case frame any
+/// phase spends per level, must fit within this stack. Moving either half without
+/// the other reopens the abort. Only this half exists so far — no depth bound is
+/// enforced yet, so headroom currently decides where deep input stops, which is
+/// exactly the profile-dependence the other half has to remove.
+///
+/// This is a host-thread stack, unrelated to the linear-memory stack laid out for
+/// the generated WebAssembly. The cost is reserved address space, lazily committed
+/// on every 64-bit target the compiler builds for, so resident memory tracks the
+/// depth actually reached rather than the reservation.
+pub const MIN_COMPILE_STACK: usize = 128 * 1024 * 1024;
+
 /// The result of parsing a source string.
 ///
 /// Holds the produced AST arena together with any structured syntax errors

--- a/core/parser/src/syntax_tree.rs
+++ b/core/parser/src/syntax_tree.rs
@@ -41,6 +41,44 @@ pub struct SyntaxNode {
     pub children: Vec<SyntaxElement>,
 }
 
+/// Discards the subtree iteratively, so dropping a tree costs one frame however
+/// tall the tree is.
+///
+/// The implicit drop glue would descend once per level, which turns merely
+/// *discarding* a deeply nested tree into a stack overflow — and an overflow aborts
+/// the process rather than unwinding, so no caller can contain it. A deep tree is
+/// most often exactly the one a caller wants to throw away. Detaching the children
+/// into a worklist and draining it holds the depth at one: each node reached this
+/// way has already had its children moved out, so its own drop finds nothing to
+/// descend into. That makes any tree safe to discard on any thread, including a
+/// bare test thread with the platform's default stack.
+///
+/// This makes a tree safe to *discard*, not safe to *build*. Two independent
+/// height-recursions remain on the construction path, and together they bind sooner
+/// than the drop glue did for a parsed tree. The grammar's own recursive descent is
+/// one. The other is `Builder::leave`, which resolves every closed node's span
+/// through `first_non_trivia` and `last_non_trivia`; those stop at the first
+/// non-trivia *token*, so they cost nothing for a shape whose extremal children are
+/// tokens — a parenthesized nest, whose parentheses bound both ends — but descend
+/// the subtree's full height for one whose extremal children are nodes, such as a
+/// left-leaning operator spine. Bounding either side takes a limit on the depth the
+/// grammar will descend to, which does not exist yet; until it does, a tree deep
+/// enough to need this drop can only be built directly rather than parsed.
+///
+/// The remaining height-recursive operations, none of which may be applied to a tree
+/// of unbounded height, are `first_descendant_loc`, `debug_into`, and the derived
+/// `Clone`, `PartialEq` and `Debug` on both this type and [`SyntaxElement`].
+impl Drop for SyntaxNode {
+    fn drop(&mut self) {
+        let mut worklist = std::mem::take(&mut self.children);
+        while let Some(element) = worklist.pop() {
+            if let SyntaxElement::Node(mut node) = element {
+                worklist.append(&mut node.children);
+            }
+        }
+    }
+}
+
 /// Builds the owned CST from processed parser steps and the full token stream.
 ///
 /// `tokens` is the complete lossless lexer output (trivia included, terminated by
@@ -478,5 +516,70 @@ SourceFile@0..2
         assert_eq!(tree.loc.offset_end, 0);
         // No statement child for empty input.
         assert!(tree.child(SyntaxKind::ExpressionStatement).is_none());
+    }
+
+    /// A tower of `depth` single-child nodes under a `SourceFile` root.
+    ///
+    /// Built directly rather than through [`build`], whose throwaway rule cannot
+    /// produce nesting, and rather than through the real grammar, which would
+    /// make the test measure parsing rather than dropping. Every level is a real
+    /// [`SyntaxNode`], which is all the drop glue under test sees.
+    fn nest(depth: usize) -> SyntaxNode {
+        let mut node = SyntaxNode {
+            kind: SyntaxKind::SourceFile,
+            loc: Location::default(),
+            children: Vec::new(),
+        };
+        for _ in 0..depth {
+            node = SyntaxNode {
+                kind: SyntaxKind::ParenthesizedExpression,
+                loc: Location::default(),
+                children: vec![SyntaxElement::Node(node)],
+            };
+        }
+        node
+    }
+
+    /// The height of a single-child tower, counted without recursing.
+    fn tower_height(root: &SyntaxNode) -> usize {
+        let mut height = 0;
+        let mut cursor = root;
+        while let Some(SyntaxElement::Node(child)) = cursor.children.first() {
+            height += 1;
+            cursor = child;
+        }
+        height
+    }
+
+    /// Dropping a tree costs one frame regardless of its height.
+    ///
+    /// The derived drop glue descended once per level, so merely discarding a
+    /// tree a few thousand levels tall aborted the process — and an abort cannot
+    /// be caught, so the only way to assert the iterative drop is to perform it
+    /// on a thread whose stack is too small for the recursive one and require
+    /// the thread to finish. The stack here is the platform default a bare
+    /// thread gets; the height is two orders of magnitude past the roughly 8,200
+    /// levels the recursive drop managed on it.
+    ///
+    /// `Clone`, `PartialEq` and `Debug` are still recursive, so the tree is only
+    /// walked iteratively and never compared or printed.
+    #[test]
+    fn deep_tree_drops_on_a_default_sized_stack() {
+        const DEPTH: usize = 500_000;
+        const STACK_BYTES: usize = 2 * 1024 * 1024;
+
+        let worker = std::thread::Builder::new()
+            .stack_size(STACK_BYTES)
+            .spawn(|| {
+                let tree = nest(DEPTH);
+                tower_height(&tree)
+            })
+            .expect("failed to spawn the drop-test thread");
+
+        assert_eq!(
+            worker.join().ok(),
+            Some(DEPTH),
+            "the tree must be built to full height and dropped without the thread dying"
+        );
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,6 +8,7 @@ mod codegen;
 mod diagnostics_file_context;
 mod hassert_translation;
 mod parser_literal_diagnostics;
+mod robustness;
 mod rocq_typecheck;
 mod spec_propagation;
 mod spec_propagation_inf;

--- a/tests/src/robustness/deep_syntax.rs
+++ b/tests/src/robustness/deep_syntax.rs
@@ -1,0 +1,239 @@
+//! Deeply nested and deeply chained input survives the recursive phases (#322).
+//!
+//! Every phase of the front end — grammar, AST lowering, type check, analysis
+//! and code generation — descends once per level of the input's syntactic
+//! nesting, so the stack a phase runs on decides how deep an input it survives.
+//! The phases used to run on whatever stack the host thread happened to have,
+//! which is how a 350-operand operator chain and a 900-arm `else if` chain both
+//! ended a compile with `fatal runtime error: stack overflow` — a signal kill,
+//! not a diagnostic, because an overflow aborts the process instead of
+//! unwinding. Both now compile: every in-process driver runs the pipeline
+//! through [`inference::with_compiler_stack`], which reserves
+//! [`inference_parser::MIN_COMPILE_STACK`].
+//!
+//! The tests below must route through that helper themselves. Cargo's test
+//! harness gives each test thread a stack an order of magnitude smaller than the
+//! phases need, so a test that called a phase directly would overflow long
+//! before it reached the behaviour under test — it would be measuring the
+//! harness, not the compiler.
+//!
+//! What is pinned here is *survival*, not rejection. There is no explicit
+//! syntactic depth limit yet, so input deeper than the reserved stack allows
+//! still aborts; asserting a diagnostic for over-deep input would assert
+//! something the compiler does not do. Every depth below is therefore a depth
+//! the compiler is claimed to accept, kept several times under the measured
+//! ceiling so that platforms whose stack frames are larger than the ones these
+//! were measured on still clear it.
+
+use crate::utils::try_build_ast;
+
+// Source-shape generators. Each emits one compact line, per the contributing
+// guide: whitespace is irrelevant to the parser and the interesting parameter is
+// the depth, not the layout.
+
+/// `pub fn f(a: i64) -> i64 { return a + a + … + a; }` with `n` operands, so the
+/// parsed expression is a left-leaning `Binary` spine `n - 1` deep.
+fn operand_chain(n: usize) -> String {
+    let chain = std::iter::repeat_n("a", n).collect::<Vec<_>>().join(" + ");
+    format!("pub fn f(a: i64) -> i64 {{ return {chain}; }}")
+}
+
+/// `pub fn f(a: i64) -> i64 { return ((…a…)); }` with `n` nested parentheses.
+fn paren_nest(n: usize) -> String {
+    let open = "(".repeat(n);
+    let close = ")".repeat(n);
+    format!("pub fn f(a: i64) -> i64 {{ return {open}a{close}; }}")
+}
+
+/// `pub fn f(a: i64) -> i64 { return ----a; }` with `n` prefix `-` operators.
+///
+/// `n` is kept even so the value is unchanged; the point of the shape is the
+/// `PrefixUnary` spine, not the arithmetic.
+fn prefix_unary_nest(n: usize) -> String {
+    let ops = "-".repeat(n);
+    format!("pub fn f(a: i64) -> i64 {{ return {ops}a; }}")
+}
+
+/// An `if` / `else if` chain of `k` arms closed by a final `else`.
+///
+/// The source is flat but the walked tree is not, and the amplification is the
+/// reason this shape is worth a generator of its own: the grammar parses the chain
+/// into a single node, and lowering then desugars it into nested `if` statements at
+/// **two** levels per arm — an `if` plus the `else` block wrapping its successor.
+/// So `k` arms cost `2k` levels to every phase that walks the lowered tree, which is
+/// why a flat 900-arm chain used to abort while 900 lines of straight-line code do
+/// not. Measured: an arm costs exactly what one level of true `if` nesting costs
+/// (identical ceilings in the type checker, analysis and codegen).
+fn else_if_chain(k: usize) -> String {
+    let arms: String = (0..k)
+        .map(|i| format!("if a == {i} {{ return {i}; }} else "))
+        .collect();
+    format!("pub fn f(a: i64) -> i64 {{ {arms}{{ return 0; }} }}")
+}
+
+/// `pub fn f() { { { … } } }` with `n` nested bare block statements.
+fn block_nest(n: usize) -> String {
+    let open = "{".repeat(n);
+    let close = "}".repeat(n);
+    format!("pub fn f() {{ {open} {close} }}")
+}
+
+/// A function taking an `n`-deep nested array type, e.g. `[[[i64; 1]; 1]; 1]`,
+/// so the recursion under test is the type grammar rather than the expression
+/// grammar.
+fn nested_array_type(n: usize) -> String {
+    let ty = format!("{}i64{}", "[".repeat(n), "; 1]".repeat(n));
+    format!("pub fn f(a: {ty}) -> i64 {{ return 0; }}")
+}
+
+/// `spec Deep { fn g() -> i32 { return ((…1…)); } }` — the same expression nest
+/// as [`paren_nest`], but inside a `spec`, which the phases walk through a
+/// different set of entry points than a plain top-level function.
+fn spec_expression_nest(n: usize) -> String {
+    let open = "(".repeat(n);
+    let close = ")".repeat(n);
+    format!("spec Deep {{ fn g() -> i32 {{ return {open}1{close}; }} }}")
+}
+
+// Pipeline helpers. Each runs one prefix of the pipeline on a compiler-sized
+// thread and returns a `Result` carrying the rendered failure, so a phase that
+// rejects the input fails the assertion with its own diagnostics rather than
+// with a bare `false`. Everything the phase allocates is also dropped inside the
+// closure, so no deep structure is carried back to the harness thread.
+
+/// Parses `source`, reporting every syntax error.
+fn parses(source: &str) -> Result<(), String> {
+    inference::with_compiler_stack(|| {
+        try_build_ast(source.to_string())
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Parses and type-checks `source`.
+fn type_checks(source: &str) -> Result<(), String> {
+    inference::with_compiler_stack(|| {
+        let arena = try_build_ast(source.to_string()).map_err(|e| e.to_string())?;
+        inference::type_check(arena)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Parses, type-checks and analyses `source`.
+fn passes_front_end(source: &str) -> Result<(), String> {
+    inference::with_compiler_stack(|| {
+        let arena = try_build_ast(source.to_string()).map_err(|e| e.to_string())?;
+        let typed_context = inference::type_check(arena).map_err(|e| e.to_string())?;
+        inference::analyze(&typed_context)
+            .map(|_| ())
+            .map_err(|e| format!("{e:?}"))
+    })
+}
+
+/// Runs the whole pipeline and returns the size of the emitted module, so a
+/// caller can assert something was actually generated.
+fn compiles(source: &str) -> Result<usize, String> {
+    inference::with_compiler_stack(|| {
+        let arena = try_build_ast(source.to_string()).map_err(|e| e.to_string())?;
+        let typed_context = inference::type_check(arena).map_err(|e| e.to_string())?;
+        inference::analyze(&typed_context).map_err(|e| format!("{e:?}"))?;
+        inference::codegen(&typed_context, "deep")
+            .map(|output| output.wasm().len())
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// The exact input reported in issue #322: a 350-operand operator chain, which
+/// used to abort the type checker on the platform default stack while 300
+/// survived. It is asserted through analysis, not merely parsing, because the
+/// type checker is the phase that aborted.
+#[test]
+fn reported_350_operand_chain_passes_front_end() {
+    let source = operand_chain(350);
+    assert_eq!(passes_front_end(&source), Ok(()));
+}
+
+/// A 900-arm `else if` chain compiles end to end. This was the lowest known
+/// abort threshold — 800 arms survived, 900 did not — so it is driven all the
+/// way through code generation rather than stopping at the type checker.
+#[test]
+fn reported_900_arm_else_if_chain_compiles() {
+    let source = else_if_chain(900);
+    let wasm_len = compiles(&source).expect("a 900-arm else-if chain must compile");
+    assert!(wasm_len > 0, "codegen produced an empty module");
+}
+
+/// The phase's acceptance bar for chained operands. The type-check ceiling on
+/// the reserved stack measures at roughly 5,200 operands, so 2,000 leaves well
+/// over a factor of two for platforms with larger frames.
+#[test]
+fn operand_chain_of_2000_type_checks() {
+    let source = operand_chain(2_000);
+    assert_eq!(type_checks(&source), Ok(()));
+}
+
+/// The phase's acceptance bar for `else if` arms. Statement frames are lighter than
+/// expression frames, so this shape's own measured type-check ceiling is 14,069 arms
+/// — 2,000 sits seven times under it, a wider margin than the operand chain's.
+#[test]
+fn else_if_chain_of_2000_arms_type_checks() {
+    let source = else_if_chain(2_000);
+    assert_eq!(type_checks(&source), Ok(()));
+}
+
+/// Parenthesis nesting is the cheapest deep shape to build and the most direct
+/// probe of the grammar's own recursion. 1,000 levels is a fifth of the measured
+/// type-check ceiling and orders of magnitude past anything a program contains.
+#[test]
+fn paren_nest_of_1000_passes_front_end() {
+    let source = paren_nest(1_000);
+    assert_eq!(passes_front_end(&source), Ok(()));
+}
+
+/// A 1,000-deep prefix-unary spine survives the grammar, lowering and the type
+/// checker. It stops at the type checker because analysis rejects adjacent
+/// prefix unary operators outright (A033), which is a decision about the
+/// program's meaning and independent of how deep the spine is.
+#[test]
+fn prefix_unary_nest_of_1000_type_checks() {
+    let source = prefix_unary_nest(1_000);
+    assert_eq!(type_checks(&source), Ok(()));
+}
+
+/// 1,000 nested bare blocks — statement-level rather than expression-level
+/// nesting, which the phases descend through separate recursions.
+#[test]
+fn block_nest_of_1000_passes_front_end() {
+    let source = block_nest(1_000);
+    assert_eq!(passes_front_end(&source), Ok(()));
+}
+
+/// A 500-deep nested array type exercises the type grammar and the type
+/// checker's type resolution, neither of which is reached by the expression
+/// shapes. The depth is lower than the expression cases because a level here
+/// costs a level in the parser, in lowering, and in the resolved type it builds;
+/// 500 is still far past any type a program declares.
+#[test]
+fn nested_array_type_of_500_type_checks() {
+    let source = nested_array_type(500);
+    assert_eq!(type_checks(&source), Ok(()));
+}
+
+/// The same 1,000-level expression nest inside a `spec`, which the phases enter
+/// through their spec-handling paths rather than the top-level function paths.
+#[test]
+fn spec_expression_nest_of_1000_passes_front_end() {
+    let source = spec_expression_nest(1_000);
+    assert_eq!(passes_front_end(&source), Ok(()));
+}
+
+/// The grammar and lowering reach considerably further than the phases behind
+/// them, which is what makes one shared floor for all of them worth having:
+/// 10,000 nested parentheses parse, twice the depth the type checker accepts and
+/// twice what the parse phase managed on the platform default stack.
+#[test]
+fn paren_nest_of_10000_parses() {
+    let source = paren_nest(10_000);
+    assert_eq!(parses(&source), Ok(()));
+}

--- a/tests/src/robustness/mod.rs
+++ b/tests/src/robustness/mod.rs
@@ -1,0 +1,5 @@
+//! Tests for the compiler's behaviour on inputs that stress it physically
+//! rather than semantically — very deep nesting, very long chains, and anything
+//! else whose cost scales with the shape of the source rather than its meaning.
+
+mod deep_syntax;


### PR DESCRIPTION
Closes #322

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/inference/src/lib.rs | Adds the scoped compiler-stack helper with transparent return and panic propagation. |
| core/cli/src/main.rs | Moves the existing CLI driver onto the explicitly sized compiler thread. |
| core/parser/src/syntax_tree.rs | Makes deep syntax-tree destruction iterative and adds a small-stack regression test. |
| core/parser/src/lib.rs | Defines the shared minimum stack requirement for recursive compiler phases. |
| apps/lsp/src/server.rs | Raises all server worker stacks to at least the shared compiler minimum. |
| core/inference/tests/compiler_stack.rs | Tests stack sizing, borrowed closures, return values, and panic propagation; the previous panic-hook concern is addressed by delegating unrelated panics and restoring the original hook. |
| tests/src/robustness/deep_syntax.rs | Adds broad regression coverage across deeply nested expression, statement, type, and specification shapes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input["Deep .inf source"] --> Embedder{"Compiler embedder"}
  Embedder -->|infc| Helper["with_compiler_stack"]
  Embedder -->|LSP| Server["SERVER_STACK_SIZE ≥ MIN_COMPILE_STACK"]
  Helper --> Stack["128 MiB compile thread"]
  Server --> Stack
  Stack --> Parse["Parse and lower"]
  Parse --> Check["Type-check and analyze"]
  Check --> Codegen["WASM code generation"]
  Parse --> CST["Owned syntax tree"]
  CST --> Drop["Iterative SyntaxNode drop"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update compiler\_stack.rs"](https://github.com/inferara/inference/commit/2c4255cadb47d6bc4f49d15e7ae30bd07b670133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48237738)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Compiler Orchestration: infc End-to-End](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/compiler-orchestration.md)
- Knowledge Base — [Parser and AST](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/parser-ast.md)
- Knowledge Base — [LSP Server Request Flow](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/lsp-server.md)
- Knowledge Base — [Test Suite: Integration Fixtures and Fuzzing](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/test-suite.md)
</details>

<!-- /greptile_comment -->