### PR TITLE
Apply PR #335 review feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,6 +705,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- Bump the test suite's `wasmtime` execution-harness dependency from 43.0.0 to 47.0.3, picking up the fix for [RUSTSEC-2026-0222](https://rustsec.org/advisories/RUSTSEC-2026-0222.html); wasmtime only executes compiled modules in tests, so no compiler output changes ([#335])
 - Fix three golden-regeneration helpers that were stale against A042: `regenerate_const_in_forall_wasm`, `regenerate_struct_array_field_nondet_wasm`, and `regenerate_multidim_array_uzumaki_wasm` ran the analysis pass (`wasm_codegen`) while the golden tests they serve compile with `wasm_codegen_no_analysis`, so once A042 started rejecting non-det constructs outside `spec` the helpers crashed and those goldens could not be regenerated. Each helper now mirrors its test's pipeline. Eight sibling helpers with the same staleness (`if_nondet`, five `binops_*`, two `loops` non-det fixtures) are untouched — their goldens did not change here — and remain follow-up debt
 - Add `tests/src/robustness/deep_syntax.rs`, a generated-source module covering deep and
   deeply chained input across seven shapes — flat operator chain, right-nested parentheses,
@@ -1295,3 +1296,4 @@ Initial tagged release.
 [#322]: https://github.com/Inferara/inference/issues/322
 [#329]: https://github.com/Inferara/inference/issues/329
 [#333]: https://github.com/Inferara/inference/issues/333
+[#335]: https://github.com/Inferara/inference/pull/335

--- a/core/type-checker/src/type_checker.rs
+++ b/core/type-checker/src/type_checker.rs
@@ -3795,8 +3795,14 @@ impl TypeChecker {
             // import (`use lib::arith::{add};`); `definition_scope_id` is the
             // callee's defining file either way, so codegen file-qualifies the
             // WASM name correctly even when it differs from the calling file.
-            // Externs carry no local body, so leave them to bare-name import
-            // resolution in codegen.
+            // Externs carry no local body, so an extern call resolves by bare
+            // name against codegen's import map. That bare-identifier shape is
+            // also what `Compiler::param_escapes_to_extern` keys on when it
+            // decides whether a compound parameter must keep its private entry
+            // copy because the callee may write through the pointer. Leaving
+            // externs unrecorded keeps "an extern call carries no target" a
+            // contract codegen can rely on, rather than a value it would have
+            // to know to ignore.
             if !s.is_extern() {
                 let module_path = self
                     .symbol_table

--- a/core/wasm-codegen/src/compiler.rs
+++ b/core/wasm-codegen/src/compiler.rs
@@ -1758,13 +1758,21 @@ impl Compiler {
     /// Reports whether `expr_id` itself or any of its sub-expressions satisfies
     /// `pred`, in pre-order and short-circuiting on the first `true`.
     ///
-    /// This is the compiler's single enumeration of expression children: every
-    /// variant carrying sub-expressions names them here, and every leaf is listed
-    /// explicitly rather than swept by a wildcard, so a new `Expr` variant has to
-    /// be classified instead of silently becoming a node no scan can reach. The
-    /// predicates in [`Self::body_has_expr`]'s family and the alias test in
-    /// [`Self::expr_reads_var`] all run through this one match; nothing else in
-    /// codegen recurses over expression children.
+    /// This is the compiler's single *exhaustive* enumeration of expression
+    /// children: every variant carrying sub-expressions names all of them here,
+    /// and every leaf is listed explicitly rather than swept by a wildcard, so a
+    /// new `Expr` variant has to be classified instead of silently becoming a node
+    /// no scan can reach. The predicates in [`Self::body_has_expr`]'s family and
+    /// the alias test in [`Self::expr_reads_var`] all run through this one match.
+    ///
+    /// Other descents over expression children exist, and each is partial by
+    /// design rather than a second general walk: [`Self::lower_expression`] and
+    /// its helpers follow only the shapes they emit code for,
+    /// [`Self::expr_root_is`] follows a projection to its base and deliberately
+    /// never enters an `ArrayIndexAccess`'s index, [`Self::is_syntactic_zero`]
+    /// stops at a wildcard arm, and the `hassert` translator re-walks the same
+    /// nodes into its own term language. A scan that must not miss a node belongs
+    /// here.
     fn expr_any(
         arena: &AstArena,
         expr_id: ExprId,
@@ -6911,6 +6919,8 @@ struct Pair {{
     /// dropped from a parameter the callee does write, so the negative cases
     /// carry the same weight as the positive ones.
     mod param_by_ref_scan {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
         use super::*;
 
         const PREAMBLE: &str = "\
@@ -7018,6 +7028,19 @@ fn subject(mut g: Holder, mut arr: [i32; 4], mut n: i32) -> i32 {{
             compiler
         }
 
+        /// The text of a caught panic. A formatted `assert!` message arrives as a
+        /// `String`; the other arms keep an unexpected payload from reading as an
+        /// empty message and failing an assertion for the wrong reason.
+        fn panic_text(payload: &(dyn std::any::Any + Send)) -> String {
+            if let Some(text) = payload.downcast_ref::<String>() {
+                return text.clone();
+            }
+            if let Some(text) = payload.downcast_ref::<&str>() {
+                return (*text).to_string();
+            }
+            "<non-string panic payload>".to_string()
+        }
+
         /// The tripwire fires on the divergence it exists to catch: an
         /// assignment rooted at a compound parameter that has no frame slot.
         ///
@@ -7026,13 +7049,25 @@ fn subject(mut g: Holder, mut arr: [i32; 4], mut n: i32) -> i32 {{
         /// compound parameter would silently take the scalar branch and store
         /// into the caller's memory. Excluding a field-less struct from
         /// `compound_params` removes the one case where a missing slot is not a
-        /// divergence; it must not have removed the guard.
+        /// divergence; it must not have removed the guard. The abort is caught
+        /// with `catch_unwind` and asserted on by message rather than declared as
+        /// an expected panic, and the panic hook is left alone so no
+        /// process-global state is touched.
         #[test]
-        #[should_panic(expected = "assignment targets compound parameter `g`")]
         fn assignment_to_a_slotless_compound_parameter_aborts() {
             let (arena, block_id) = subject_body("        g.tag = 1;");
             let left = first_assign_target(&arena, block_id);
-            staged_with_layout(None).assert_assign_target_has_slot(&arena, left);
+            let compiler = staged_with_layout(None);
+            let unwound = catch_unwind(AssertUnwindSafe(|| {
+                compiler.assert_assign_target_has_slot(&arena, left);
+            }));
+            let payload =
+                unwound.expect_err("a slotless compound parameter must abort compilation");
+            let text = panic_text(payload.as_ref());
+            assert!(
+                text.contains("assignment targets compound parameter `g`"),
+                "the abort must name the parameter it fired on, got: {text}"
+            );
         }
 
         /// The same assignment passes once the parameter has its slot, so the


### PR DESCRIPTION
Follow-up to #335 (merged), applying its post-merge review feedback. One commit, cherry-picked content-identical from the pre-merge branch.

## What this does

- **`core/wasm-codegen/src/compiler.rs`** — `assignment_to_a_slotless_compound_parameter_aborts` no longer uses `#[should_panic]` (banned by CONTRIBUTING): it now follows the crate's documented `catch_unwind(AssertUnwindSafe(..))` shape from `hassert/translate.rs`, with a `panic_text` payload helper and a message assertion, panic hook untouched.
- **`core/wasm-codegen/src/compiler.rs`** — the `expr_any` doc comment no longer claims "nothing else in codegen recurses over expression children"; it scopes the exhaustive-enumeration guarantee to the body scans and names the other descents (the `lower_expression` emission cluster, the hassert translator, `expr_root_is`, `is_syntactic_zero` and its wildcard arm). Every claim in the new text was fact-checked against the code.
- **`core/type-checker/src/type_checker.rs`** — the comment above the `if !s.is_extern()` guard now records why externs stay out of the recorded-target channel: codegen's import-call emitter and the escape scan guarding the by-reference parameter elision (`Compiler::param_escapes_to_extern`) both key on the bare-identifier callee shape. An earlier draft claimed a recorded target would divert extern calls into qualified lowering and fail loudly — that was verified false (the three recorded-target branches in `resolve_function_callee` are guarded by cross-file/`TypeMemberAccess` conditions a same-file bare extern call can never satisfy), so the comment states the contract without inventing a failure mechanism.
- **`CHANGELOG.md`** — entry for the wasmtime 43.0.0 → 47.0.3 bump (RUSTSEC-2026-0222) under Unreleased → Testing, house-style `([#335])` ref.

## Verification

`inference-wasm-codegen` 225/225 passed (rewritten test confirmed present in the pass list), `inference-type-checker` 116/116, clippy clean on both crates, `cargo check -p inference-tests --tests` clean, changed hunks rustfmt-clean, new intra-doc links resolve.

Replaces #337, which was opened from the pre-merge branch and therefore re-displayed the entire already-squash-merged #335 diff.

## AI-generated code

The changes in this PR were AI-generated (Claude Code agents), directed and reviewed by the author.
