### PR TITLE
wasm-to-v: parenthesize negative integer constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -605,6 +605,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Rocq Translation
 
+- Negative integer constants now reach the emitted `.v` parenthesized — `BI_const_num (Vi32 (-1))`, not `BI_const_num (Vi32 -1)`. Gallina's `-` is an infix operator, so the old spelling parsed as the subtraction `Vi32 - 1` and `coqc` rejected the whole module ("The term `Vi32` has type `Z -> value_num` while it is expected to have type `nat`"), making proof mode unusable for any program containing a negative constant anywhere — an offset, a threshold, an error code. Every signed width is affected, since `i8`/`i16`/`i32` all lower to `i32.const` and `i64` to `i64.const`; so is source that writes no minus sign at all, because a `u32`/`u64` literal above the signed maximum is stored as a negative constant of that width. The `hassert` obligation printer already parenthesized its constants, so obligation terms are unchanged, as is every non-negative constant — no existing `.v` golden moves ([#314])
 - WASM module-name subsection now reflects the CLI-supplied input file stem instead of the hardcoded `"output"`. The Rocq translator reads this back, so the emitted `Definition <mod>__<Spec>_specs` and `Theorem valid_<mod>` identifiers now use the source filename. Multi-module workflows that previously collided on a single `output` identifier now produce distinct ones
 - Empty per-spec lists emit `(@nil hassert)` — not `[]%N`, and no longer `list N` at all — so the generated `Definition` type-checks regardless of whether a scope is active at the consumer's `Require` site. Downstream proof scripts matching `[]%N` or `(@nil N)` literally must update ([issue#21], [issue#22])
 - Rewrite WASM-to-V translator for WasmCertCoq theory syntax ([#23])
@@ -705,6 +706,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Testing
 
+- New `coqc`-gated corpus fixture `tests/test_data/inf/spec_negative_consts.inf` carries a negative constant through every position one can reach a WASM constant instruction from: a function-local `const`, an expression-position literal at each of `i8`/`i16`/`i32`/`i64`, both signed minima, both unsigned all-ones patterns (negatives with no minus sign in the source), and two obligation terms. The corpus previously held no negative constant at all — top-level `const` declarations do not reach codegen (A032, #171) — which is why the gate never caught the ill-typed emission. Alongside it, `negative_constants_are_parenthesized` scans every generated module in the corpus for the unparenthesized spelling, so the rule binds each emitter that renders a Rocq term rather than only the arm the fixture happens to reach ([#314])
 - Bump the test suite's `wasmtime` execution-harness dependency from 43.0.0 to 47.0.3, picking up the fix for [RUSTSEC-2026-0222](https://rustsec.org/advisories/RUSTSEC-2026-0222.html); wasmtime only executes compiled modules in tests, so no compiler output changes ([#335])
 - Fix three golden-regeneration helpers that were stale against A042: `regenerate_const_in_forall_wasm`, `regenerate_struct_array_field_nondet_wasm`, and `regenerate_multidim_array_uzumaki_wasm` ran the analysis pass (`wasm_codegen`) while the golden tests they serve compile with `wasm_codegen_no_analysis`, so once A042 started rejecting non-det constructs outside `spec` the helpers crashed and those goldens could not be regenerated. Each helper now mirrors its test's pipeline. Eight sibling helpers with the same staleness (`if_nondet`, five `binops_*`, two `loops` non-det fixtures) are untouched — their goldens did not change here — and remain follow-up debt
 - Add `tests/src/robustness/deep_syntax.rs`, a generated-source module covering deep and
@@ -1293,6 +1295,7 @@ Initial tagged release.
 [#219]: https://github.com/Inferara/inference/issues/219
 [#220]: https://github.com/Inferara/inference/issues/220
 [#315]: https://github.com/Inferara/inference/issues/315
+[#314]: https://github.com/Inferara/inference/issues/314
 [#322]: https://github.com/Inferara/inference/issues/322
 [#329]: https://github.com/Inferara/inference/issues/329
 [#333]: https://github.com/Inferara/inference/issues/333

--- a/core/wasm-to-v/src/gallina.rs
+++ b/core/wasm-to-v/src/gallina.rs
@@ -1,0 +1,42 @@
+//! Gallina lexical helpers shared by the two emitters that render Rocq terms:
+//! the WASM instruction translator ([`crate::translator`]) and the `hassert`
+//! obligation printer ([`crate::hassert_print`]).
+//!
+//! Both spell integer constants through [`z_literal`], so the parenthesization
+//! rule below has exactly one implementation. It previously had two, and only
+//! one of them was right (#314).
+
+/// Renders a signed integer as a Gallina `Z` literal in *term* position.
+///
+/// Gallina's `-` is an infix operator, so an unparenthesized negative literal
+/// in argument position reads as a subtraction: `Vi32 -1` parses as the
+/// application-free expression `Vi32 - 1`, which fails to type-check. Negative
+/// values therefore carry their own parentheses; non-negative values render
+/// bare, where no ambiguity exists.
+pub(crate) fn z_literal(value: i64) -> String {
+    if value < 0 {
+        format!("({value})")
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::z_literal;
+
+    #[test]
+    fn non_negative_literals_render_bare() {
+        assert_eq!(z_literal(0), "0");
+        assert_eq!(z_literal(1), "1");
+        assert_eq!(z_literal(i64::from(i32::MAX)), "2147483647");
+        assert_eq!(z_literal(i64::MAX), "9223372036854775807");
+    }
+
+    #[test]
+    fn negative_literals_are_parenthesized() {
+        assert_eq!(z_literal(-1), "(-1)");
+        assert_eq!(z_literal(i64::from(i32::MIN)), "(-2147483648)");
+        assert_eq!(z_literal(i64::MIN), "(-9223372036854775808)");
+    }
+}

--- a/core/wasm-to-v/src/hassert_print.rs
+++ b/core/wasm-to-v/src/hassert_print.rs
@@ -10,6 +10,7 @@
 //! [`HAssert::Or`] → `Hor`. Every compound argument is parenthesized, so the
 //! output is unambiguous regardless of Gallina's application/precedence rules.
 
+use crate::gallina::z_literal;
 use inference_hassert::{HAssert, HBinop, HConst, HFnRef, HNumType, HRelop, HTerm};
 use rustc_hash::FxHashMap;
 
@@ -176,18 +177,9 @@ fn relop(op: HRelop) -> &'static str {
 }
 
 /// Renders a numeric constant as the emitted `Vi32`/`Vi64` helper application.
-/// A negative literal is parenthesized so it does not read as a subtraction.
 fn const_str(c: HConst) -> String {
     match c {
         HConst::I32(v) => format!("Vi32 {}", z_literal(i64::from(v))),
         HConst::I64(v) => format!("Vi64 {}", z_literal(v)),
-    }
-}
-
-fn z_literal(v: i64) -> String {
-    if v < 0 {
-        format!("({v})")
-    } else {
-        v.to_string()
     }
 }

--- a/core/wasm-to-v/src/lib.rs
+++ b/core/wasm-to-v/src/lib.rs
@@ -194,6 +194,7 @@
 //! - [WebAssembly Specification](https://webassembly.github.io/spec/) - WASM standard
 
 pub mod errors;
+mod gallina;
 mod hassert_print;
 pub mod rocq_names;
 pub mod translator;

--- a/core/wasm-to-v/src/translator.rs
+++ b/core/wasm-to-v/src/translator.rs
@@ -170,6 +170,7 @@ use inference_hassert::HSpecMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::errors::WasmToVError;
+use crate::gallina::z_literal;
 use crate::hassert_print;
 
 const LCB: &str = "{|\n";
@@ -1674,8 +1675,10 @@ fn translate_basic_operator(
             }
             "BI_memory_grow".to_string()
         }
-        Operator::I32Const { value } => format!("BI_const_num (Vi32 {value})"),
-        Operator::I64Const { value } => format!("BI_const_num (Vi64 {value})"),
+        Operator::I32Const { value } => {
+            format!("BI_const_num (Vi32 {})", z_literal(i64::from(*value)))
+        }
+        Operator::I64Const { value } => format!("BI_const_num (Vi64 {})", z_literal(*value)),
         Operator::I32Eqz => "BI_testop T_i32 TO_eqz".to_string(),
         Operator::I32Eq => "BI_relop T_i32 (Relop_i ROI_eq)".to_string(),
         Operator::I32Ne => "BI_relop T_i32 (Relop_i ROI_ne)".to_string(),

--- a/tests/src/rocq_typecheck.rs
+++ b/tests/src/rocq_typecheck.rs
@@ -40,12 +40,12 @@ mod gate {
     /// Corpus fixtures under `tests/test_data/inf/`, paired with the module name
     /// each is translated under. Together they exercise the proof-mode surface
     /// the issue calls out: inline and function-body-modifier `forall`/`exists`/
-    /// `assume`, cross-function calls (`BI_call`), comparisons, `assert`, and
-    /// structured control flow (`if`/`loop`). The `unique` block and the
-    /// `exists`-kind spec function are deliberately absent — neither has a
-    /// `hassert` encoding, so proof-mode codegen rejects them with fatal
-    /// `P002`/`P001` diagnostics (pinned by the unit tests in
-    /// `core/wasm-codegen/src/hassert/tests.rs` and end-to-end by
+    /// `assume`, cross-function calls (`BI_call`), comparisons, `assert`,
+    /// structured control flow (`if`/`loop`), and negative integer constants at
+    /// every width. The `unique` block and the `exists`-kind spec function are
+    /// deliberately absent — neither has a `hassert` encoding, so proof-mode
+    /// codegen rejects them with fatal `P002`/`P001` diagnostics (pinned by the
+    /// unit tests in `core/wasm-codegen/src/hassert/tests.rs` and end-to-end by
     /// `build_v_rejects_unique_block_with_p002` in `apps/infs`) rather than by a
     /// corpus entry that would compile against the stub.
     const CORPUS: &[(&str, &str)] = &[
@@ -62,6 +62,7 @@ mod gate {
         ("spec_short_circuit.inf", "spec_short_circuit"),
         ("spec_narrow_abi.inf", "spec_narrow_abi"),
         ("spec_literal_ctx.inf", "spec_literal_ctx"),
+        ("spec_negative_consts.inf", "spec_negative_consts"),
     ];
 
     /// Constructs the corpus must keep exercising, in the emitted `.v`. Two
@@ -291,6 +292,68 @@ mod gate {
         }
 
         let _ = std::fs::remove_dir_all(&work);
+    }
+
+    /// Gallina's `-` is an infix operator, so a negative integer constant has to
+    /// reach the `.v` parenthesized: `Vi32 -1` parses as the subtraction
+    /// `Vi32 - 1`, and `coqc` rejects the whole module with "The term `Vi32` has
+    /// type `Z -> value_num` while it is expected to have type `nat`" — one
+    /// negative constant anywhere makes proof mode unusable for the program
+    /// (#314).
+    ///
+    /// The corpus-wide scan is the load-bearing half: it holds every emitter
+    /// that renders a Rocq term to the rule, not only the arm this fixture
+    /// happens to reach. The per-spelling assertions then pin that the fixture
+    /// keeps *producing* a negative everywhere one is reachable — `i8`/`i16`/
+    /// `i32` share `i32.const` while `i64` has its own arm, the two `MIN` values
+    /// are the widest negatives each width can carry, the two unsigned cases are
+    /// negatives no minus sign appears in the source for, and the two `T_const`
+    /// spellings come from the separate `hassert` obligation printer.
+    #[test]
+    fn negative_constants_are_parenthesized() {
+        const FIXTURE: &str = "spec_negative_consts.inf";
+
+        let generated: Vec<(&str, String)> = CORPUS
+            .iter()
+            .map(|&(file, name)| (file, generate_v(file, name)))
+            .collect();
+        let unparenthesized: Vec<String> = generated
+            .iter()
+            .flat_map(|(file, v)| {
+                v.lines()
+                    .filter(|line| line.contains("Vi32 -") || line.contains("Vi64 -"))
+                    .map(move |line| format!("{file}: {}", line.trim()))
+            })
+            .collect();
+        assert!(
+            unparenthesized.is_empty(),
+            "a negative constant reached the `.v` unparenthesized; Gallina reads \
+             it as a subtraction and `coqc` rejects the module:\n{}",
+            unparenthesized.join("\n")
+        );
+
+        let (_, v) = generated
+            .iter()
+            .find(|(file, _)| *file == FIXTURE)
+            .unwrap_or_else(|| panic!("{FIXTURE} must be a CORPUS entry"));
+        for needle in [
+            "BI_const_num (Vi32 (-8))",                   // i8
+            "BI_const_num (Vi32 (-300))",                 // i16
+            "BI_const_num (Vi32 (-70000))",               // i32
+            "BI_const_num (Vi32 (-2147483648))",          // i32 minimum
+            "BI_const_num (Vi32 (-1))",                   // u32 all-ones
+            "BI_const_num (Vi64 (-4294967296))",          // i64
+            "BI_const_num (Vi64 (-9223372036854775808))", // i64 minimum
+            "BI_const_num (Vi64 (-1))",                   // u64 all-ones
+            "T_const (Vi32 (-70000))",                    // obligation term, i32
+            "T_const (Vi64 (-4294967296))",               // obligation term, i64
+        ] {
+            assert!(
+                v.contains(needle),
+                "{FIXTURE} no longer emits `{needle}`; the coqc gate would stop \
+                 covering that constant:\n{v}"
+            );
+        }
     }
 
     /// `&&`/`||` lower to a valued `if (result i32)` block, which proof-mode

--- a/tests/test_data/inf/spec_negative_consts.inf
+++ b/tests/test_data/inf/spec_negative_consts.inf
@@ -1,0 +1,70 @@
+// Negative integer constants, at every width and in every position that reaches
+// a WASM constant instruction.
+//
+// Gallina's `-` is an infix operator, so a negative constant must reach the `.v`
+// parenthesized or the emitted term reads as a subtraction and `coqc` rejects
+// the whole module (#314). Widths do not share a lowering: `i8`, `i16` and `i32`
+// all become `i32.const` while `i64` becomes `i64.const`, and each is emitted by
+// its own arm of the translator.
+//
+// The unsigned functions carry no minus sign at all. A `u32`/`u64` literal above
+// the signed maximum is the same bit pattern as a negative constant of that
+// width, and that is what the WASM instruction stores — so the ill-typed
+// spelling is reachable from source that never writes a minus.
+
+pub fn bias_i32(x: i32) -> i32 {
+    const K: i32 = -70000;
+    return x + K;
+}
+
+pub fn bias_i64(x: i64) -> i64 {
+    const K: i64 = -4294967296;
+    return x + K;
+}
+
+pub fn step_i8(x: i8) -> i8 {
+    return x + -8;
+}
+
+pub fn step_i16(x: i16) -> i16 {
+    return x + -300;
+}
+
+pub fn step_i32(x: i32) -> i32 {
+    return x + -70000;
+}
+
+pub fn step_i64(x: i64) -> i64 {
+    return x + -4294967296;
+}
+
+pub fn floor_i32() -> i32 {
+    return -2147483648;
+}
+
+pub fn floor_i64() -> i64 {
+    return -9223372036854775808;
+}
+
+pub fn all_ones_u32() -> u32 {
+    return 4294967295;
+}
+
+pub fn all_ones_u64() -> u64 {
+    return 18446744073709551615;
+}
+
+spec Negatives {
+    // Both arms put a negative constant inside the obligation itself, so the
+    // `hassert` printer is held to the same parenthesization as the module
+    // record's instruction terms.
+    fn bias_moves_down() forall {
+        let a: i32 = @;
+        assert(bias_i32(a) == a + -70000);
+    }
+
+    fn wide_bias_moves_down() forall {
+        let b: i64 = @;
+        assert(bias_i64(b) == b + -4294967296);
+    }
+}


### PR DESCRIPTION
Fixes #314.

`wasm-to-v` interpolated integer constants into Gallina term position bare, so any negative constant emitted `BI_const_num (Vi32 -1)`. Gallina's `-` is infix, so Rocq parses that as the subtraction `Vi32 - 1` and `coqc` rejects the whole module — proof mode was unusable for any program containing a negative constant. Every signed width was affected (i8/i16/i32 lower to `i32.const`, i64 to `i64.const`), and so was source with no minus sign at all: a u32/u64 literal above the signed maximum is stored as a negative constant of that width.

## Fix

The crate has exactly two emitters that render Rocq integer terms, and they disagreed: `hassert_print.rs` (proof obligations) already parenthesized negatives via a private helper, while the instruction translator did not — which is how the committed golden `spec_literal_ctx.v` could already carry a correct `(Vi64 (-1))` while ordinary integer code broke. The rule now has one implementation: `gallina.rs::z_literal` parenthesizes negative values and renders non-negative ones bare, and both `translator.rs` (`I32Const`/`I64Const`) and `hassert_print.rs` go through it. Global init expressions and data/element segment offsets route through the same `translate_basic_operator`, so they are covered by the same change.

Non-negative emission is byte-identical: no `.v` or `.wasm` golden moved, and both byte-identity golden tests pass unmodified.

## Tests

- New corpus fixture `spec_negative_consts.inf` wired into the `coqc` gate (`tests/src/rocq_typecheck.rs`): fn-local negative `const` at i32/i64, expression-position negatives at i8/i16/i32/i64, both signed minima, both unsigned all-ones patterns, and negatives inside `forall` spec asserts so the obligation printer is exercised too. The corpus previously contained no negative constant at all (top-level `const` does not reach codegen, A032/#171), which is why the gate never caught this. Verified red first: pre-fix, the fixture emits ten bare negatives and `coqc` rejects it with the issue's exact `"Vi32" has type "Z -> value_num" while it is expected to have type "nat"` error; post-fix `coqc` compiles it (gate ran for real against Rocq 9.2, all 14 corpus modules).
- `negative_constants_are_parenthesized` additionally scans every generated corpus `.v` for the bare-negative spelling, so the assertion binds every emitter, not just the arm the fixture reaches; unit tests pin the exact rendering of the boundary values in both directions (negatives parenthesized, non-negatives bare).

## Notes

- The issue's reproducer needed one adaptation: its `fn proof() { p(); }` is now rejected by `P005`, which post-dates the issue. The remaining shape reproduces the bug exactly and now emits `BI_const_num (Vi32 (-1))` and passes `coqc`.
- Audit note: `BI_br {relative_depth}` and `BI_call_indirect` emit their (always non-negative) indices without the `%N` suffix — a latent spelling inconsistency, not reachable as a negative, deliberately left untouched here.
