### PR TITLE
infs: forward [wasm-dependencies] and -L to infc from project-mode builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,10 +47,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-index-
       
+      # `target/llvm-cov-target` is deliberately excluded: `cargo llvm-cov
+      # report` unions coverage regions from every binary it finds there, so a
+      # cached binary built from an earlier commit maps its stale line table
+      # onto the current sources and invents phantom (un)covered lines.
       - name: Cache cargo build
         uses: actions/cache@v4
         with:
-          path: target
+          path: |
+            target
+            !target/llvm-cov-target
           key: ${{ runner.os }}-cargo-build-coverage-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-coverage-
@@ -58,6 +64,26 @@ jobs:
       
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
+      # The infs integration suite self-skips its run-path tests when `wasmtime`
+      # is not in PATH, and its end-to-end compiler tests when
+      # `target/debug/infc` is absent — cargo-llvm-cov builds into its own
+      # target directory, so the compiler must be built here explicitly.
+      # Provisioning both lets the coverage run exercise the full suite instead
+      # of silently dropping those paths from the report.
+      - name: Install wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
+      - name: Build infc for tests that spawn the real compiler
+        env:
+          RUSTFLAGS: ""
+        run: cargo build -p inference-cli
+
+      # A cache restored via the fallback keys may predate the exclusion above
+      # and still carry stale coverage artifacts; start every run from a clean
+      # slate regardless of what the cache brought in.
+      - name: Clean stale coverage artifacts
+        run: cargo llvm-cov clean --workspace
 
       - name: Run tests with coverage for core crates
         run: |

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.3
 
+      # The infs run-path integration tests execute the artifacts they build
+      # and self-skip when `wasmtime` is not in PATH; without it the run
+      # family never executes anywhere in the build matrix.
+      - name: Install wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
       - name: Install MinGW (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- infs: project-mode `build` now forwards both the manifest's `[wasm-dependencies]` and the CLI's `-L`/`--wasm-lib-dir` to `infc`, and project-mode `run` forwards the manifest's (it has no `-L` flag of its own), so a project binding `use { … } from <module>` links — and in proof mode emits its `.v` — without the `INFERENCE_WASM_LIB_PATH` workaround ([#361])
 - wasm-to-v: `(*name*)` comments on `BI_local_get`/`BI_local_set`/`BI_local_tee` now resolve the local-name map by function index instead of type index, fixing misattributed names in linked or externally produced modules ([#336])
 - A dynamic array index appearing only inside a function-scoped `const` initializer no longer aborts the compiler (`bounds-check scratch local must be reserved` panic); it now compiles and is guarded like any other index ([#220])
 - Exported functions now normalize narrow scalar parameters (`bool`, `i8`, `u8`, `i16`, `u16`) at entry — low-bits/sign-extension per the C convention, `bool` by truthiness — so arbitrary host bit patterns cannot leak into the body
@@ -550,6 +551,7 @@ Initial tagged release.
 [#333]: https://github.com/Inferara/inference/issues/333
 [#335]: https://github.com/Inferara/inference/pull/335
 [#336]: https://github.com/Inferara/inference/issues/336
+[#361]: https://github.com/Inferara/inference/issues/361
 [#346]: https://github.com/Inferara/inference/issues/346
 [#345]: https://github.com/Inferara/inference/issues/345
 [#344]: https://github.com/Inferara/inference/issues/344

--- a/apps/infs/README.md
+++ b/apps/infs/README.md
@@ -109,6 +109,7 @@ infs build example.inf --analyze
 | `-v` | Generate Rocq (.v) translation file |
 | `--mode proof` | Proof mode: preserve non-det specs; implies `-v` inside `infc` |
 | `--mode compile` | Compile mode: strip specs for executable WASM |
+| `-L <dir>` / `--wasm-lib-dir <dir>` | Directory to search for external `.wasm` modules referenced by `use { … } from <module>;`; repeatable. In project mode a relative dir is anchored to the directory you invoked `infs` from, not the project root |
 | `--no-wasm-opt` | Skip `[build.wasm-opt]` post-build optimization (project mode only) |
 
 When no phase flag is given, `infs build` defaults to full compilation and writes the WASM binary to disk — equivalent to `--codegen -o`.
@@ -123,9 +124,10 @@ When `infs build` runs in project mode, it reads fields from `Inference.toml` to
 | `[build] mode = "compile"` (default) | Forwards nothing; `infc` defaults to compile mode |
 | `[verification] output-dir` | Honored only in effective-proof mode; relocates both `.wasm` and `.v` |
 | `[build] wasm-features` | Opt-in post-MVP WebAssembly proposals (currently `"bulk-memory"`); forwarded as `--wasm-features`, echoed as a `wasm-features:` line, and applied in both compile and proof mode. Empty (the default) means pure WebAssembly 1.0 |
+| `[wasm-dependencies]` | Each entry is forwarded as `--wasm-dep <name>=<path>`, with the declared path resolved against the project root; honored by both project `build` and project `run`, and never capability-gated |
 | `[build.wasm-opt]` | Opt-in post-build optimization of `out/main.wasm` via Binaryen `wasm-opt`, resolved from `WASM_OPT_PATH` → PATH → an infs-managed install; absent table is a no-op |
 
-Some of these are also honored in **single-file** mode, by walking up to the nearest `Inference.toml`. `[build] wasm-features` is honored by both `infs build <path>` and `infs run <path>` — deliberately, since those two and project `infs build` all write `out/main.wasm` for the same project and must not disagree about its instruction set. `[wasm-dependencies]` is honored by single-file `build` only; that single-file `run` does not resolve it is a pre-existing gap, tracked separately. `[build] wasm-features` requires an `infc` with ABI 1.2 or newer; an older compiler cannot honor the request, so it is refused with remediation instead of being handed the flag.
+Some of these are also honored in **single-file** mode, by walking up to the nearest `Inference.toml`. `[build] wasm-features` is honored by both `infs build <path>` and `infs run <path>` — deliberately, since those two and project `infs build` all write `out/main.wasm` for the same project and must not disagree about its instruction set. `[wasm-dependencies]` is honored by single-file `build` and by both project-mode paths (`infs build` and `infs run`); single-file `run` is the one path that does not resolve it, a pre-existing gap tracked as [#367](https://github.com/Inferara/inference/issues/367). `[build] wasm-features` requires an `infc` with ABI 1.2 or newer; an older compiler cannot honor the request, so it is refused with remediation instead of being handed the flag.
 
 Every table with a fixed set of fields rejects keys it does not recognize, so a misspelled manifest key is an error naming the offending key and the accepted ones, not a setting that silently does nothing.
 

--- a/apps/infs/docs/inference-toml.md
+++ b/apps/infs/docs/inference-toml.md
@@ -87,10 +87,12 @@ ABI gate as project mode. This is deliberate rather than incidental: `infs build
 `out/main.wasm` for the same project, so if they disagreed about the instruction
 set, the artifact you ship would depend on which command last touched it.
 
-That `infs run <path>` does not resolve `[wasm-dependencies]` is a pre-existing
-gap, not a consequence of the above; it is tracked separately. A file that imports
-an external module therefore needs `infs build` (or `-L`) rather than single-file
-`run`.
+`[wasm-dependencies]` is otherwise resolved everywhere: project `infs build` and
+project `infs run` both forward every declared entry to `infc`. That `infs run
+<path>` does not is a pre-existing gap, not a consequence of the above; it is
+tracked as [#367](https://github.com/Inferara/inference/issues/367). A file that
+imports an external module therefore needs project mode, `infs build <path>`, or
+`-L` rather than single-file `run`.
 
 Everything else in the manifest is project-mode configuration: `[build] mode`,
 `[verification] output-dir`, and `[build.wasm-opt]` are not consulted in

--- a/apps/infs/src/commands/build.rs
+++ b/apps/infs/src/commands/build.rs
@@ -59,6 +59,11 @@
 //! - **`--out-dir` is forwarded only to an `infc` that supports it**;
 //!   pairing a non-default `output-dir` with an older `infc` hard-errors with
 //!   remediation rather than failing opaquely in the subprocess.
+//! - **`[wasm-dependencies]`** is forwarded as one `--wasm-dep <name>=<path>`
+//!   per declaration (paths resolved against the project root), alongside every
+//!   `-L`/`--wasm-lib-dir` the user passed. `infc` resolves `use { … } from
+//!   <module>` from those two sources only, so without them a project binding
+//!   externals cannot link — in proof mode, cannot emit its `.v` at all.
 //!
 //! ## Manifest settings honored in single-file mode
 //!
@@ -72,8 +77,9 @@
 //! [`crate::commands::run`] for the third). A file outside any project takes the
 //! defaults and never errors.
 //!
-//! `[wasm-dependencies]` is resolved by single-file *build* only; that single-file
-//! `run` does not resolve it predates this and is tracked separately.
+//! `[wasm-dependencies]` is resolved on every path but one: single-file `build`
+//! (here) and both project paths forward it. That single-file `run` does not
+//! resolve it predates this and is tracked separately (#367).
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, ValueEnum};
@@ -133,7 +139,11 @@ pub struct BuildArgs {
     pub mode: Option<BuildMode>,
 
     /// Directory to search for external `.wasm` modules referenced by
-    /// `use { … } from <module>;`. Repeatable; forwarded verbatim to `infc`.
+    /// `use { … } from <module>;`. Repeatable; forwarded as `--wasm-lib-dir` in
+    /// both single-file and project mode. A relative dir always means what it
+    /// meant at the shell: single-file `infc` inherits the invocation directory,
+    /// and the project path anchors the dir to that directory before forwarding,
+    /// because it moves `infc` to the project root.
     #[clap(short = 'L', long = "wasm-lib-dir", value_name = "DIR")]
     pub wasm_lib_dirs: Vec<PathBuf>,
 
@@ -245,6 +255,11 @@ fn execute_single_file(path: &Path, args: &BuildArgs) -> Result<()> {
 /// Formats one resolved manifest dependency as the `<name>=<path>` argument
 /// forwarded to `infc --wasm-dep`.
 ///
+/// Shared by the single-file path here and the project path in
+/// [`crate::commands::project_build`]: the two must spell a dependency the same
+/// way, or one project would bind its externals differently depending on how the
+/// build was invoked.
+///
 /// `name` is already validated against the logical-name grammar in
 /// [`crate::project::manifest::validate_wasm_dependency_key`], so it never
 /// contains `=`. The receiver splits on the FIRST `=`, which is therefore always
@@ -262,7 +277,7 @@ fn execute_single_file(path: &Path, args: &BuildArgs) -> Result<()> {
 /// ## Errors
 ///
 /// Returns an error when `path` is not valid UTF-8.
-fn format_wasm_dep_arg(name: &str, path: &Path) -> Result<String> {
+pub(crate) fn format_wasm_dep_arg(name: &str, path: &Path) -> Result<String> {
     let Some(path) = path.to_str() else {
         bail!(
             "wasm dependency `{name}` resolves to a path that is not valid UTF-8 ({}); \
@@ -365,6 +380,7 @@ fn execute_project(ctx: &ProjectContext, args: &BuildArgs) -> Result<()> {
         args.generate_v_output,
         effective_mode,
         out_dir.as_deref(),
+        &args.wasm_lib_dirs,
         args.no_wasm_opt,
     )
 }

--- a/apps/infs/src/commands/build.rs
+++ b/apps/infs/src/commands/build.rs
@@ -447,6 +447,48 @@ fn resolve_out_dir(
 }
 
 #[cfg(test)]
+mod cli_surface_tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A minimal parser wrapping [`BuildArgs`], standing in for the real CLI so
+    /// the flag surface can be exercised without spawning the binary.
+    #[derive(Parser)]
+    struct BuildCli {
+        #[command(flatten)]
+        args: BuildArgs,
+    }
+
+    /// Both spellings of the lib-dir flag parse, repeat, mix, and preserve the
+    /// order given. The order is contractual, not cosmetic: `infc` searches the
+    /// directories in the order received and the first hit wins, so a parse
+    /// that reordered them would change which `.wasm` a module resolves to.
+    #[test]
+    fn lib_dir_flag_accepts_both_spellings_and_preserves_order() {
+        let cli = BuildCli::try_parse_from([
+            "build",
+            "-L",
+            "first",
+            "--wasm-lib-dir",
+            "second",
+            "-L",
+            "third",
+            "main.inf",
+        ])
+        .expect("both spellings of the lib-dir flag must parse");
+        assert_eq!(
+            cli.args.wasm_lib_dirs,
+            [
+                PathBuf::from("first"),
+                PathBuf::from("second"),
+                PathBuf::from("third")
+            ]
+        );
+        assert_eq!(cli.args.path.as_deref(), Some(Path::new("main.inf")));
+    }
+}
+
+#[cfg(test)]
 mod manifest_dep_tests {
     use super::*;
     use assert_fs::prelude::*;

--- a/apps/infs/src/commands/project_build.rs
+++ b/apps/infs/src/commands/project_build.rs
@@ -26,26 +26,29 @@
 //! The compatibility handshake ([`probe_compiler_compatibility`]) also lives
 //! here: it is part of "running a project build", and keeping it beside the
 //! single spawning site keeps the coupling tight. Every caller wants the probed
-//! capability, not just the pass/fail — the additive flags `infs` forwards
-//! (`--out-dir`, `--wasm-features`) are each gated on it.
+//! capability, not just the pass/fail — the additive flags `infs` gates
+//! (`--out-dir`, `--wasm-features`) are each checked against it.
 //!
 //! ## Which settings are parameters and which are read off the context
 //!
-//! [`run_project_build`] takes `mode` and `out_dir` as parameters but reads
-//! `[build] wasm-features` straight off `ctx`. The rule: a setting a CLI flag can
-//! override, or that a caller must be able to suppress, is threaded so the
-//! caller stays the single place that resolves it (`run` deliberately passes
-//! `mode = None` to force compile mode). A setting only the manifest can express,
-//! with no flag and nothing to suppress, is read from `ctx` — threading it would
-//! let two callers disagree about a property of the project itself. An
-//! instruction-set request is the latter: `build` and `run` emitting different
-//! instruction levels for one project is a bug, not a configuration.
+//! [`run_project_build`] takes `mode`, `out_dir`, and `wasm_lib_dirs` as
+//! parameters but reads `[build] wasm-features` and `[wasm-dependencies]`
+//! straight off `ctx`. The rule: a setting a CLI flag can override, or that a
+//! caller must be able to suppress, is threaded so the caller stays the single
+//! place that resolves it (`run` deliberately passes `mode = None` to force
+//! compile mode, and has no `-L` flag of its own to pass on). A setting only the
+//! manifest can express, with no flag and nothing to suppress, is read from
+//! `ctx` — threading it would let two callers disagree about a property of the
+//! project itself. An instruction-set request is the latter, as is the set of
+//! external modules the project links against: `build` and `run` emitting
+//! different instruction levels — or resolving one project's `use { … } from
+//! <module>` against different `.wasm` files — is a bug, not a configuration.
 
 use anyhow::{Context, Result, bail};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::commands::build::BuildMode;
+use crate::commands::build::{BuildMode, format_wasm_dep_arg};
 use crate::errors::InfsError;
 use crate::project::ProjectContext;
 use crate::project::manifest::MANIFEST_FILE_NAME;
@@ -82,6 +85,25 @@ use inference_compiler_interface::{
 /// `infs run` always passes `out_dir = None` (and `mode = None`), so project
 /// `run` always builds an executable in `out/`.
 ///
+/// External-module resolution reaches `infc` as two flag families, so a project
+/// whose sources bind `use { … } from <module>` can link: each `wasm_lib_dirs`
+/// entry becomes `--wasm-lib-dir <dir>`, and each `[wasm-dependencies]` entry
+/// becomes `--wasm-dep <name>=<path>` with the declared path resolved against
+/// the project root. Neither is capability-gated, matching the single-file path:
+/// both flags arrived with external-module support itself rather than at a
+/// distinguishable ABI minor, so the handshake has nothing to check — an `infc`
+/// old enough to lack them could not compile a `use { … } from <module>` binding
+/// at all.
+///
+/// A lib dir is anchored to the *invocation* directory before it is forwarded,
+/// precisely because this helper re-anchors the child process to the project
+/// root: `-L ../libs` typed in `<root>/src` names `<root>/src/../libs`, and
+/// forwarding it verbatim would have `infc` read it as `<root>/../libs` instead
+/// — failing to link, or silently linking a same-named module that happens to
+/// sit at the root-anchored path. Joining onto the invocation directory leaves
+/// an absolute dir unchanged. Single-file mode needs no such treatment: `infc`
+/// inherits the working directory there, so a relative dir keeps its meaning.
+///
 /// The manifest's `[build] wasm-features` is read straight off `ctx` rather than
 /// passed in, so `build` and `run` cannot disagree about the instruction level of
 /// the module they produce, and it applies in both compile and proof mode — a
@@ -103,6 +125,9 @@ use inference_compiler_interface::{
 /// - infc reports a *major* ABI version mismatch (hard error with remediation)
 /// - `out_dir` is requested but the resolved `infc` does not support `--out-dir`
 /// - the manifest requests `wasm-features` the resolved `infc` cannot honor
+/// - a `[wasm-dependencies]` key is not a well-formed logical module name
+/// - a resolved `[wasm-dependencies]` path is not valid UTF-8
+/// - lib dirs were passed and the current working directory cannot be determined
 /// - infc exits with non-zero code (as `InfsError::ProcessExitCode`)
 /// - post-build optimization is active and fails (missing/invalid artifact,
 ///   `wasm-opt` resolution, or the optimization itself)
@@ -111,6 +136,7 @@ pub(crate) fn run_project_build(
     generate_v_output: bool,
     mode: Option<BuildMode>,
     out_dir: Option<&Path>,
+    wasm_lib_dirs: &[PathBuf],
     no_wasm_opt: bool,
 ) -> Result<()> {
     if !ctx.entry_point.is_file() {
@@ -149,6 +175,19 @@ pub(crate) fn run_project_build(
             );
         }
         cmd.arg("--out-dir").arg(dir);
+    }
+
+    if !wasm_lib_dirs.is_empty() {
+        let cwd =
+            std::env::current_dir().context("Failed to determine the current working directory")?;
+        for dir in wasm_lib_dirs {
+            cmd.arg("--wasm-lib-dir").arg(cwd.join(dir));
+        }
+    }
+
+    for (name, path) in ctx.manifest.resolved_wasm_dependencies(&ctx.root)? {
+        cmd.arg("--wasm-dep")
+            .arg(format_wasm_dep_arg(&name, &path)?);
     }
 
     let features = ctx.manifest.build.resolved_wasm_features()?;
@@ -442,7 +481,7 @@ mod project_tests {
             entry_point: root.join("src").join("main.inf"),
         };
 
-        let err = run_project_build(&ctx, false, None, None, false).unwrap_err();
+        let err = run_project_build(&ctx, false, None, None, &[], false).unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("Missing entry point") && msg.contains("main.inf"),
@@ -466,7 +505,7 @@ mod project_tests {
             entry_point: entry,
         };
 
-        let err = run_project_build(&ctx, false, None, None, false).unwrap_err();
+        let err = run_project_build(&ctx, false, None, None, &[], false).unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("Missing entry point") && msg.contains("main.inf"),

--- a/apps/infs/src/commands/run.rs
+++ b/apps/infs/src/commands/run.rs
@@ -17,8 +17,9 @@
 //! `Inference.toml` and honors `[build] wasm-features`, so running one file of a
 //! project cannot execute a module at a different WebAssembly instruction level
 //! than `infs build` would produce for it. `[wasm-dependencies]` is not resolved
-//! on this path (single-file `build` does resolve it); that asymmetry predates
-//! this and is tracked separately.
+//! on this path — the only path where it is not (single-file `build` and both
+//! project paths do resolve it); that asymmetry predates this and is tracked
+//! separately (#367).
 //!
 //! ```bash
 //! infs run                                    # project mode: build + invoke main
@@ -42,6 +43,11 @@
 //!   behavior except when the enclosing manifest requests `wasm-features`, where
 //!   a capability probe is the only way to refuse a request the compiler cannot
 //!   honor.
+//! - **Resolves `[wasm-dependencies]`**, also via the shared helper: the project
+//!   it runs is the one `infs build` would produce, externals included. A
+//!   project binding `use { … } from <module>` is otherwise unrunnable, since
+//!   `infc` resolves externals from forwarded flags only. `run` has no
+//!   `-L`/`--wasm-lib-dir` flag, so the manifest is its only source.
 //! - **Always builds in compile mode**, regardless of the manifest's
 //!   `[build] mode`. `run` executes the WASM, and proof-mode WASM embeds the
 //!   custom non-deterministic opcodes (the `0xfc` family) that wasmtime cannot
@@ -160,8 +166,8 @@ pub fn execute(args: &RunArgs) -> Result<()> {
 /// `infs build <path>` honors it: one project must not emit modules at two
 /// different WebAssembly instruction levels depending on how the build was
 /// invoked, and this path overwrites the very artifact `infs build` produces.
-/// `[wasm-dependencies]` is *not* resolved here — that gap predates this and is
-/// tracked separately.
+/// `[wasm-dependencies]` is *not* resolved here — the last path where it is not,
+/// a gap that predates this and is tracked separately (#367).
 ///
 /// ## Errors
 ///
@@ -243,9 +249,12 @@ fn execute_project(args: &RunArgs) -> Result<()> {
     // custom non-deterministic opcodes (0xfc family) that wasmtime cannot
     // execute. Hence `mode = None` and `out_dir = None` here — manifest
     // mode/output-dir resolution lives only in `build`'s project path. The
-    // `[build.wasm-opt]` optimization still applies (unless `--no-wasm-opt`) so
-    // `run` executes exactly what `build` would ship.
-    run_project_build(&ctx, false, None, None, args.no_wasm_opt)?;
+    // empty `wasm_lib_dirs` is not a suppression: `run` simply has no
+    // `-L` flag, and the manifest's `[wasm-dependencies]` still reaches `infc`
+    // through the shared helper. The `[build.wasm-opt]` optimization still
+    // applies (unless `--no-wasm-opt`) so `run` executes exactly what `build`
+    // would ship.
+    run_project_build(&ctx, false, None, None, &[], args.no_wasm_opt)?;
 
     let wasm_path = project_wasm_path(&ctx);
     if !wasm_path.exists() {

--- a/apps/infs/tests/cli_integration.rs
+++ b/apps/infs/tests/cli_integration.rs
@@ -297,6 +297,38 @@ fn help_shows_available_commands() {
         .stdout(predicate::str::contains("--headless"));
 }
 
+/// `infs build --help` documents the external-lib-dir flag, including the
+/// relative-directory semantics: a relative `-L` always means what it meant at
+/// the shell, in project mode as much as in single-file mode. That sentence is
+/// the user-visible contract behind the invocation-directory anchoring in
+/// `run_project_build`, so it is pinned here — rendering the help is also the
+/// only invocation that materializes the flag's help text at all.
+///
+/// clap re-wraps help text to the terminal width, so the assertions run against
+/// a whitespace-normalized copy of the output rather than the raw bytes.
+#[test]
+fn build_help_documents_the_external_lib_dir_flag() {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.arg("build").arg("--help");
+
+    let assert = cmd.assert().success();
+    let normalized = stdout_of(&assert)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    for expected in [
+        "--wasm-lib-dir",
+        "-L",
+        "Directory to search for external `.wasm` modules",
+        "A relative dir always means what it meant at the shell",
+    ] {
+        assert!(
+            normalized.contains(expected),
+            "`infs build --help` must document {expected:?}; normalized output was:\n{normalized}"
+        );
+    }
+}
+
 // Headless Mode Tests
 
 /// Verifies that headless mode without a command shows informational output.

--- a/apps/infs/tests/cli_integration.rs
+++ b/apps/infs/tests/cli_integration.rs
@@ -2017,6 +2017,445 @@ fn project_build_rejects_an_unknown_manifest_key() {
     );
 }
 
+// Project-mode `[wasm-dependencies]` and `-L` Forwarding Tests
+//
+// `infc` resolves `use { … } from <module>` from `--wasm-dep`, `-L` and
+// `INFERENCE_WASM_LIB_PATH` alone, so a project build that forwards none of them
+// cannot link an external at all — and in proof mode cannot emit its `.v`. These
+// pin both ends: the wire spelling each project route puts on the command line,
+// and the end-to-end link through a real `infc` with no environment variable in
+// play.
+
+/// `src/main.inf` that binds an external: the declaration, the `use` that binds
+/// it to the logical module `arith`, and a `main` whose value only the linked
+/// function can produce. Unlinkable unless the dependency reaches `infc`.
+const PROJECT_MAIN_EXTERN_SRC: &str = "external fn sum(a: i32, b: i32) -> i32;\n\
+     use { sum } from arith;\n\n\
+     pub fn main() -> i32 {\n    return sum(40, 2);\n}\n";
+
+/// The library [`PROJECT_MAIN_EXTERN_SRC`] binds against, compiled on its own
+/// and vendored into the dependent project as `libs/arith.wasm`.
+const ARITH_LIB_SRC: &str = "pub fn sum(a: i32, b: i32) -> i32 {\n    return a + b;\n}\n";
+
+/// The manifest table declaring that dependency. The declared path is written in
+/// the manifest's own platform-independent spelling; `infs` resolves it against
+/// the project root before forwarding it.
+const ARITH_DEPENDENCY_TABLE: &str =
+    "[wasm-dependencies]\narith = { path = \"libs/arith.wasm\" }\n";
+
+/// Writes an executable `infc` stub under `dir` that reports a mismatched commit
+/// and the current ABI, and appends the argv of every non-probe invocation —
+/// everything but the `--commit-hash` and `--abi-version` handshake calls, one
+/// entry per line — to `log`. Returns the stub's path.
+///
+/// The mismatched commit is what makes the stub useful: every real-`infc` test
+/// here takes the `commit_matched` short-circuit, so none of them observes what
+/// actually lands on the command line. The stub cannot compile, so no artifact
+/// appears; with no `[build.wasm-opt]` table the post-build step is a no-op and a
+/// `build` through it still succeeds.
+///
+/// Unix-only: relies on an executable shell script.
+#[cfg(unix)]
+fn write_argv_logging_infc_stub(
+    dir: &assert_fs::TempDir,
+    log: &std::path::Path,
+) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let stub = dir.child("infc_stub");
+    stub.write_str(&format!(
+        "#!/bin/sh\n\
+         case \"$1\" in\n\
+           --commit-hash) printf 'nope\\n'; exit 0 ;;\n\
+           --abi-version) printf '{}.{}\\n'; exit 0 ;;\n\
+           *) printf '%s\\n' \"$@\" >> '{}'; exit 0 ;;\n\
+         esac\n",
+        inference_compiler_interface::COMPILER_ABI_MAJOR,
+        inference_compiler_interface::COMPILER_ABI_MINOR,
+        log.display()
+    ))
+    .unwrap();
+    let mut perms = std::fs::metadata(stub.path()).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(stub.path(), perms).unwrap();
+    stub.path().to_path_buf()
+}
+
+/// The argv entry immediately following each occurrence of `flag`, in order of
+/// appearance.
+///
+/// Adjacency is the property under test, and this expresses it exactly: a fused
+/// `--flag=value` token never matches `flag` and yields no entry at all, while a
+/// value split across entries leaves only its first word here — an expectation on
+/// the result fails for either spelling. A flag in final position (its value
+/// dropped) yields `None` rather than vanishing.
+#[cfg(unix)]
+fn argv_values_after<'a>(argv: &[&'a str], flag: &str) -> Vec<Option<&'a str>> {
+    argv.iter()
+        .enumerate()
+        .filter(|(_, entry)| **entry == flag)
+        .map(|(index, _)| argv.get(index + 1).copied())
+        .collect()
+}
+
+/// The raw newline-separated argv a stub logged.
+///
+/// Returned as one owned `String` rather than the split entries because the
+/// entries borrow from it: a caller keeps this alive and splits it in place, so
+/// the `&str` slices it feeds to [`argv_values_after`] outlive the call.
+#[cfg(unix)]
+fn logged_argv(log: &std::path::Path) -> String {
+    std::fs::read_to_string(log).expect("the stub must log its argv")
+}
+
+/// Compiles [`ARITH_LIB_SRC`] with the real `infc` in a temp directory of its own
+/// and returns the emitted module bytes.
+///
+/// The dependency is a genuine compiler artifact rather than a checked-in blob:
+/// what these tests link must be what `infc` emits today, or a change to the
+/// module shape would leave them linking a stale fixture.
+fn build_arith_library(infc_path: &std::path::Path) -> Vec<u8> {
+    let lib = assert_fs::TempDir::new().unwrap();
+    lib.child("arith.inf").write_str(ARITH_LIB_SRC).unwrap();
+
+    let mut cmd = Command::new(infc_path);
+    cmd.current_dir(lib.path()).arg("arith.inf");
+    cmd.assert().success();
+
+    std::fs::read(lib.child("out").child("arith.wasm").path())
+        .expect("infc must produce out/arith.wasm for the library")
+}
+
+/// Scaffolds a project that binds the `arith` external: the manifest declares the
+/// dependency, `src/main.inf` binds `sum`, and `libs/arith.wasm` holds `library`.
+fn scaffold_project_with_arith_dependency(dir: &assert_fs::TempDir, library: &[u8]) {
+    scaffold_project_with_manifest(dir, "demo", PROJECT_MAIN_EXTERN_SRC, ARITH_DEPENDENCY_TABLE);
+    dir.child("libs")
+        .child("arith.wasm")
+        .write_binary(library)
+        .unwrap();
+}
+
+/// The wire spelling of external-module forwarding on the project `build` route.
+///
+/// Three properties at once, none of them observable through a real `infc`: both
+/// spellings of the lib-dir flag reach `infc` as `--wasm-lib-dir` plus an
+/// adjacent value, in the order given; the manifest dependency is forwarded
+/// exactly once; and its value is the declared path resolved against the project
+/// *root*, absolute — the resolution the manifest promises, independent of any
+/// working directory.
+#[cfg(unix)]
+#[test]
+fn project_build_forwards_lib_dirs_and_manifest_dep_to_infc() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        ARITH_DEPENDENCY_TABLE,
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    // Two real directories, passed through the two spellings of the same flag.
+    let first = temp.child("vendor-a");
+    first.create_dir_all().unwrap();
+    let second = temp.child("vendor-b");
+    second.create_dir_all().unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("build")
+        .arg("-L")
+        .arg(first.path())
+        .arg("--wasm-lib-dir")
+        .arg(second.path());
+    cmd.assert().success();
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![
+            Some(first.path().to_str().unwrap()),
+            Some(second.path().to_str().unwrap()),
+        ],
+        "both lib-dir spellings must reach infc as `--wasm-lib-dir`, in the \
+         order given, got argv: {argv:?}"
+    );
+
+    let expected_dep = format!(
+        "arith={}",
+        temp.path()
+            .canonicalize()
+            .unwrap()
+            .join("libs")
+            .join("arith.wasm")
+            .display()
+    );
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep"),
+        vec![Some(expected_dep.as_str())],
+        "the manifest dependency must be forwarded exactly once, as \
+         `<name>=<path resolved against the project root>`, got argv: {argv:?}"
+    );
+}
+
+/// A *relative* lib dir keeps the meaning it had at the shell.
+///
+/// The project route spawns `infc` with its working directory set to the project
+/// root, so a lib dir forwarded verbatim would be re-read against the root rather
+/// than against the directory the user typed it in. Here `-L ../libs` is passed
+/// from `<root>/src`, where it names `<root>/libs`; re-anchored to the root it
+/// would name `<root>/../libs` — outside the project, and a same-named `.wasm`
+/// sitting there would link silently in place of the intended one. The absolute
+/// dir alongside it pins the other half: joining must leave it untouched.
+///
+/// The expectation is built from the *canonicalized* subdirectory because
+/// `std::env::current_dir()` in the child reports the symlink-resolved path,
+/// which on macOS differs from the temp path this test holds.
+#[cfg(unix)]
+#[test]
+fn project_build_anchors_a_relative_lib_dir_to_the_invocation_directory() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        ARITH_DEPENDENCY_TABLE,
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    // `<root>/libs` is what `../libs` names from `<root>/src`; the root-anchored
+    // reading, `<root>/../libs`, is the temp directory's parent.
+    temp.child("libs").create_dir_all().unwrap();
+    let absolute = temp.child("vendor");
+    absolute.create_dir_all().unwrap();
+
+    let invocation_dir = temp.child("src");
+    let relative = std::path::Path::new("..").join("libs");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(invocation_dir.path())
+        .arg("build")
+        .arg("-L")
+        .arg(&relative)
+        .arg("-L")
+        .arg(absolute.path());
+    cmd.assert().success();
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let anchored = invocation_dir
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join(&relative)
+        .display()
+        .to_string();
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![
+            Some(anchored.as_str()),
+            Some(absolute.path().to_str().unwrap()),
+        ],
+        "a relative lib dir must reach infc anchored at the invocation \
+         directory (`{anchored}`), and an absolute one unchanged, got argv: \
+         {argv:?}"
+    );
+}
+
+/// Every declared dependency is forwarded, not just the first, and in the
+/// manifest resolution's name order — so two manifests differing only in the
+/// order they list the same dependencies produce the same `infc` invocation.
+/// Declared here in reverse of the expected order, which a straight iteration
+/// over the declarations would preserve.
+#[cfg(unix)]
+#[test]
+fn project_build_forwards_every_manifest_dependency_in_name_order() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        "[wasm-dependencies]\n\
+         zeta = { path = \"libs/zeta.wasm\" }\n\
+         alpha = { path = \"libs/alpha.wasm\" }\n",
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("build");
+    cmd.assert().success();
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let root = temp.path().canonicalize().unwrap();
+    let alpha = format!("alpha={}", root.join("libs").join("alpha.wasm").display());
+    let zeta = format!("zeta={}", root.join("libs").join("zeta.wasm").display());
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep"),
+        vec![Some(alpha.as_str()), Some(zeta.as_str())],
+        "every declaration must be forwarded, in name order, got argv: {argv:?}"
+    );
+}
+
+/// Neutrality: a project that declares no dependency and passes no lib dir gets
+/// neither flag on the command line. The forwarding is inert for the projects
+/// that do not bind externals, which is nearly all of them.
+#[cfg(unix)]
+#[test]
+fn project_build_without_dependencies_forwards_no_external_flags() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project(&temp, "demo", PROJECT_MAIN_SRC);
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("build");
+    cmd.assert().success();
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+    assert!(
+        argv_values_after(&argv, "--wasm-dep").is_empty()
+            && argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
+        "a project with no externals must get neither flag, got argv: {argv:?}"
+    );
+}
+
+/// The same wire spelling on the project `run` route, which has no lib-dir flag
+/// of its own: the manifest is its only source of externals, so a route that
+/// dropped it would leave every project binding `use { … } from <module>`
+/// unrunnable.
+///
+/// wasmtime is checked before the build, hence the gate. The stub compiles
+/// nothing, so `out/main.wasm` never appears and the command fails *after* the
+/// build step — that exact failure is what proves the build ran at all.
+#[cfg(unix)]
+#[test]
+fn project_run_forwards_manifest_dep_to_infc() {
+    if !is_wasmtime_available() {
+        eprintln!("Skipping test: wasmtime not available");
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        ARITH_DEPENDENCY_TABLE,
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let expected_dep = format!(
+        "arith={}",
+        temp.path()
+            .canonicalize()
+            .unwrap()
+            .join("libs")
+            .join("arith.wasm")
+            .display()
+    );
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep"),
+        vec![Some(expected_dep.as_str())],
+        "project `run` must forward the manifest dependency, got argv: {argv:?}"
+    );
+    assert!(
+        argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
+        "`run` has no lib-dir flag to forward, got argv: {argv:?}"
+    );
+}
+
+/// The end-to-end acceptance: a project whose sources bind an external links in
+/// proof mode and emits both artifacts, with no environment workaround.
+///
+/// `INFERENCE_WASM_LIB_PATH` is explicitly removed — it is `infc`'s last-resort
+/// search tier and the very workaround this replaces, so an inherited value would
+/// let a passing run prove nothing about the manifest. The `.v` is the load-bearing
+/// half: external resolution runs before code generation, so a proof build that
+/// cannot resolve produces no translation at all.
+#[test]
+fn project_proof_build_links_a_manifest_dependency_without_env() {
+    let Some(infc_path) = require_infc() else {
+        return;
+    };
+
+    let library = build_arith_library(&infc_path);
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_arith_dependency(&temp, &library);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &infc_path)
+        .env_remove("INFERENCE_WASM_LIB_PATH")
+        .current_dir(temp.path())
+        .arg("build")
+        .arg("--mode")
+        .arg("proof");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Linked 1 external module"));
+
+    let wasm = std::fs::read(temp.child("proofs").child("main.wasm").path())
+        .expect("a linked proof build must write proofs/main.wasm");
+    assert!(!wasm.is_empty(), "the linked .wasm must not be empty");
+
+    let translation = std::fs::read_to_string(temp.child("proofs").child("main.v").path())
+        .expect("a linked proof build must write proofs/main.v");
+    assert!(!translation.is_empty(), "the linked .v must not be empty");
+}
+
+/// The linked external actually executes: project `run` on the same project
+/// prints `sum(40, 2)`. Resolution reaching `infc` is necessary but not
+/// sufficient — this pins that what `run` executes is a module with the
+/// dependency's code merged in, not one left with an unresolved import.
+#[test]
+fn project_run_executes_a_linked_manifest_dependency() {
+    let Some(infc_path) = require_infc_and_wasmtime() else {
+        return;
+    };
+
+    let library = build_arith_library(&infc_path);
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_arith_dependency(&temp, &library);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &infc_path)
+        .env_remove("INFERENCE_WASM_LIB_PATH")
+        .current_dir(temp.path())
+        .arg("run");
+    let stdout = stdout_of(&cmd.assert().success());
+    assert!(
+        stdout.contains("42"),
+        "wasmtime must print the linked call's result (40 + 2), got:\n{stdout}"
+    );
+}
+
 // Phase 2: Toolchain Management Command Tests
 
 // Install Command Tests

--- a/book/src/projects-and-the-infs-toolchain.md
+++ b/book/src/projects-and-the-infs-toolchain.md
@@ -181,7 +181,7 @@ Flags:
 |------|-------------|
 | `-v` | Generate Rocq `.v` translation in addition to `.wasm` |
 | `--mode {compile,proof}` | Override compilation mode |
-| `-L <DIR>` / `--wasm-lib-dir <DIR>` | Add a directory to search for external `.wasm` modules; repeatable |
+| `-L <DIR>` / `--wasm-lib-dir <DIR>` | Add a directory to search for external `.wasm` modules; repeatable. A relative directory is read against the directory you invoked `infs` from, in both modes |
 
 **Mode resolution** (precedence, highest first):
 
@@ -314,11 +314,14 @@ infs build
     +-- spawn infc
             CWD = <project root>
             arg: src/main.inf
-            arg: --mode proof           (if effective proof mode)
             arg: -v                     (if .v requested)
+            arg: --mode proof           (if effective proof mode)
             arg: --out-dir <dir>        (if effective proof mode + ABI ≥ 1.1)
-            arg: --wasm-dep name=path   (one per [wasm-dependencies] entry)
-            arg: -L <dir>               (repeated for each --wasm-lib-dir)
+            arg: --wasm-lib-dir <dir>   (one per -L/--wasm-lib-dir; a relative
+                                         dir is anchored to the invocation
+                                         directory, since infc runs at the root)
+            arg: --wasm-dep name=path   (one per [wasm-dependencies] entry; the
+                                         declared path resolved against the root)
 ```
 
 **`infc` flags** confirmed against `core/cli/src/parser.rs`:


### PR DESCRIPTION
## Problem

Closes #361.

Project-mode `infs build`/`infs run` spawned `infc` with no `--wasm-dep` and no `--wasm-lib-dir`, while `infc` resolves externals only from those flags plus `INFERENCE_WASM_LIB_PATH`. Any project whose sources bind externals (`use { f } from module`) therefore failed resolution in every project-mode build — including every linked proof build — unless the env var was hand-crafted. `build` also silently dropped its own explicit `-L`/`--wasm-lib-dir` CLI flags. Single-file `build` already forwarded both.

## Fix

Follows the threading rule `run_project_build`'s module docs already state (CLI-overridable settings are threaded; manifest-only settings are read off `ctx`):

- `run_project_build` gains a `wasm_lib_dirs: &[PathBuf]` parameter; project `build` threads its `-L`/`--wasm-lib-dir` flags, project `run` passes none (it has no `-L` flag).
- Each lib dir is anchored to the **invocation directory** before forwarding, because the helper re-anchors the child process to the project root — `-L ../libs` typed in `<root>/src` must name `<root>/src/../libs`, not `<root>/../libs`. Absolute dirs pass through unchanged; single-file mode is untouched (`infc` inherits the CWD there).
- `[wasm-dependencies]` is read off `ctx.manifest` (same rationale as `wasm-features`: `build` and `run` must not resolve one project's externals against different `.wasm` files) and forwarded as `--wasm-dep <name>=<path>` with paths resolved against the project root, via the same `format_wasm_dep_arg` single-file build uses.
- Forwarding is unconditional (no ABI gate), matching single-file build: both flags arrived with external-module support itself, so there is no distinguishable ABI minor to check.
- Project `run` inherits the manifest-dep forwarding through the shared helper — intended, since a project binding externals could not `infs run` at all.

## Tests

7 new integration tests in `apps/infs/tests/cli_integration.rs`:

- argv-logging stub tests pinning the exact forwarded flags for project `build` (manifest dep as absolute `name=path`, multiple deps in name order, both `-L` spellings in order) and project `run`;
- a neutrality test asserting a dependency-free project produces no external flags (argv unchanged vs before);
- a relative-`-L` test invoking from a subdirectory, asserting invocation-CWD anchoring (fails if the `cwd.join` is removed — verified by temporary neutralization);
- real-`infc` end-to-end acceptance: proof-mode build of a project with a bound extern emits `proofs/main.wasm` + `proofs/main.v` with `INFERENCE_WASM_LIB_PATH` explicitly removed, and `infs run` executes the linked extern.

`cargo test -p infs`: 550 unit + 158 integration, all green; `cargo clippy -p infs --all-targets -- -D warnings` clean; touched files rustfmt-clean.

## Docs

Corrected the now-stale "`[wasm-dependencies]` is honored by single-file `build` only" claims in `apps/infs/README.md` (plus new table rows for the dep forwarding and the `-L` flag), `apps/infs/docs/inference-toml.md`, the book's spawn-argv diagram (now matches the wire: `--wasm-lib-dir` long form before `--wasm-dep`, correct `-v`/`--mode` order), and the rustdoc in all three command modules. The docs' "tracked separately" caveat about single-file `run` now points at the newly filed #367. One condensed CHANGELOG entry.

## Behavior note

A project declaring `[wasm-dependencies]` against a pre-#216 `infc` now fails with clap's unknown-argument error instead of failing later at extern resolution — identical to single-file `build`'s existing exposure.

## Coverage-job fix (second commit)

The initial `codecov/patch` failure was diagnosed to stale-artifact pollution, not missing coverage: the coverage job caches `target/` across runs, and `cargo llvm-cov report` unions regions from every binary it finds in `target/llvm-cov-target` — including binaries built from earlier commits, whose old line tables map onto current sources and invent phantom uncovered lines (the flagged "misses" were doc comments). With a clean slate, every added executable line in this PR measures covered locally (16/16 with the full suite).

Fixes in `.github/workflows/coverage.yml`:
- exclude `target/llvm-cov-target` from the cache and run `cargo llvm-cov clean --workspace` before measuring, so reports are built only from current binaries;
- install `wasmtime` and prebuild `target/debug/infc` — without them every run-path and real-compiler integration test self-skips in the coverage job, so the lines only they exercise (e.g. project `run`'s build call) were genuinely unmeasured.

Plus two CLI-surface tests: `infs build --help` documenting the relative `-L` anchoring contract, and both `-L`/`--wasm-lib-dir` spellings parsing repeatably in first-hit-wins order.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/infs/src/commands/project_build.rs | Extends the shared project compiler invocation to forward invocation-anchored library directories and manifest-resolved WebAssembly dependencies. |
| apps/infs/src/commands/build.rs | Threads repeatable project-mode library-directory arguments into the shared build helper while preserving existing single-file behavior. |
| apps/infs/src/commands/run.rs | Uses the shared project build path so project runs inherit manifest dependency forwarding without adding a run-specific library-directory option. |
| apps/infs/tests/cli_integration.rs | Adds argument-level and end-to-end tests covering dependency forwarding, relative path anchoring, proof output, and linked execution. |
| .github/workflows/coverage.yml | Removes stale LLVM coverage artifacts and provisions the compiler and runtime needed to exercise integration paths during coverage collection. |
| .github/workflows/reusable-build.yml | Installs wasmtime so run-path integration tests execute in the reusable build matrix. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant infs
  participant Manifest as Inference.toml
  participant infc
  participant Runtime as wasmtime

  User->>infs: build/run from invocation directory
  infs->>Manifest: discover project and dependencies
  Manifest-->>infs: wasm-dependencies
  infs->>infs: anchor relative -L paths to invocation directory
  infs->>infc: source + --wasm-lib-dir + --wasm-dep
  infc-->>infs: linked WASM and optional Rocq output
  opt run command
    infs->>Runtime: execute linked WASM
    Runtime-->>User: program result
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: install wasmtime in the build matrix..."](https://github.com/inferara/inference/commit/ed366592f3b702339c6201322c0bbe33578f083e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51413357)</sub>

**Context used:**

- Knowledge Base — [infs: Unified Toolchain CLI](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/infs-cli.md)
- Knowledge Base — [Compiler Orchestration: infc End-to-End](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/compiler-orchestration.md)

<!-- /greptile_comment -->