### PR TITLE
Resolve wasm-dependencies for a single file project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,10 +338,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- infs: single-file `run` now forwards the enclosing manifest's `[wasm-dependencies]` and gains a `-L`/`--wasm-lib-dir` flag (project `run` forwards `-L` too), so a file or project binding `use { … } from <module>` runs instead of failing external resolution ([#367])
 - infs: `infc` now resolves from the directory holding the running `infs`, whatever that directory is named, instead of requiring a literal `target/<debug|release>/` path and one of three enumerated build targets; a redirected `CARGO_TARGET_DIR`, a `--target-dir`, a custom cargo profile, or an unlisted target used to make the tier decline silently and run whatever `infc` was on `PATH` — the wrong compiler, looking like success. An installed `infs` now prefers an adjacent `infc` over a `PATH` hit, `INFS_VERBOSE` reports the fallthrough, and `infs doctor` labels the tier `sibling of infs` and no longer calls a plain managed install ambiguous ([#371])
 - infs: `infs doctor`, PATH-conflict detection, and the managed `bin/` symlinks no longer consult the three-target allow-list merely to learn whether binaries end in `.exe`. On any other build target `doctor` reported `Cannot detect platform`, conflict detection and symlink validation returned empty results that read as "nothing wrong", and `infs default <version>` failed outright. `Platform` keeps its allow-list wherever the platform identity genuinely matters — downloads, manifest artifact selection, self-update ([#371])
 - infs tests: the integration suite resolves `infc` from the running test binary's own directory instead of a hardcoded `target/debug`, so the end-to-end tests that spawn the real compiler no longer silently self-skip on the Windows and release CI legs; a missing `infc` or `wasmtime` now fails the run under `CI` instead of skipping ([#369])
-- infs: project-mode `build` now forwards both the manifest's `[wasm-dependencies]` and the CLI's `-L`/`--wasm-lib-dir` to `infc`, and project-mode `run` forwards the manifest's (it has no `-L` flag of its own), so a project binding `use { … } from <module>` links — and in proof mode emits its `.v` — without the `INFERENCE_WASM_LIB_PATH` workaround ([#361])
+- infs: project-mode `build` now forwards both the manifest's `[wasm-dependencies]` and the CLI's `-L`/`--wasm-lib-dir` to `infc`, and project-mode `run` forwards the manifest's, so a project binding `use { … } from <module>` links — and in proof mode emits its `.v` — without the `INFERENCE_WASM_LIB_PATH` workaround ([#361])
 - wasm-to-v: `(*name*)` comments on `BI_local_get`/`BI_local_set`/`BI_local_tee` now resolve the local-name map by function index instead of type index, fixing misattributed names in linked or externally produced modules ([#336])
 - A dynamic array index appearing only inside a function-scoped `const` initializer no longer aborts the compiler (`bounds-check scratch local must be reserved` panic); it now compiles and is guarded like any other index ([#220])
 - Exported functions now normalize narrow scalar parameters (`bool`, `i8`, `u8`, `i16`, `u16`) at entry — low-bits/sign-extension per the C convention, `bool` by truthiness — so arbitrary host bit patterns cannot leak into the body
@@ -557,6 +558,7 @@ Initial tagged release.
 [#335]: https://github.com/Inferara/inference/pull/335
 [#336]: https://github.com/Inferara/inference/issues/336
 [#361]: https://github.com/Inferara/inference/issues/361
+[#367]: https://github.com/Inferara/inference/issues/367
 [#369]: https://github.com/Inferara/inference/issues/369
 [#371]: https://github.com/Inferara/inference/issues/371
 [#346]: https://github.com/Inferara/inference/issues/346

--- a/apps/infs/README.md
+++ b/apps/infs/README.md
@@ -124,10 +124,10 @@ When `infs build` runs in project mode, it reads fields from `Inference.toml` to
 | `[build] mode = "compile"` (default) | Forwards nothing; `infc` defaults to compile mode |
 | `[verification] output-dir` | Honored only in effective-proof mode; relocates both `.wasm` and `.v` |
 | `[build] wasm-features` | Opt-in post-MVP WebAssembly proposals (currently `"bulk-memory"`); forwarded as `--wasm-features`, echoed as a `wasm-features:` line, and applied in both compile and proof mode. Empty (the default) means pure WebAssembly 1.0 |
-| `[wasm-dependencies]` | Each entry is forwarded as `--wasm-dep <name>=<path>`, with the declared path resolved against the project root; honored by both project `build` and project `run`, and never capability-gated |
+| `[wasm-dependencies]` | Each entry is forwarded as `--wasm-dep <name>=<path>`, with the declared path resolved against the project root; honored on every build and run path, and never capability-gated |
 | `[build.wasm-opt]` | Opt-in post-build optimization of `out/main.wasm` via Binaryen `wasm-opt`, resolved from `WASM_OPT_PATH` → PATH → an infs-managed install; absent table is a no-op |
 
-Some of these are also honored in **single-file** mode, by walking up to the nearest `Inference.toml`. `[build] wasm-features` is honored by both `infs build <path>` and `infs run <path>` — deliberately, since those two and project `infs build` all write `out/main.wasm` for the same project and must not disagree about its instruction set. `[wasm-dependencies]` is honored by single-file `build` and by both project-mode paths (`infs build` and `infs run`); single-file `run` is the one path that does not resolve it, a pre-existing gap tracked as [#367](https://github.com/Inferara/inference/issues/367). `[build] wasm-features` requires an `infc` with ABI 1.2 or newer; an older compiler cannot honor the request, so it is refused with remediation instead of being handed the flag.
+Some of these are also honored in **single-file** mode, by walking up to the nearest `Inference.toml`. `[build] wasm-features` is honored by both `infs build <path>` and `infs run <path>` — deliberately, since those two and project `infs build` all write `out/main.wasm` for the same project and must not disagree about its instruction set. `[wasm-dependencies]` is honored on all four compilation paths — single-file `build`, single-file `run`, project `build`, and project `run` — and is never capability-gated. `[build] wasm-features` requires an `infc` with ABI 1.2 or newer; an older compiler cannot honor the request, so it is refused with remediation instead of being handed the flag.
 
 Every table with a fixed set of fields rejects keys it does not recognize, so a misspelled manifest key is an error naming the offending key and the accepted ones, not a setting that silently does nothing.
 
@@ -149,6 +149,9 @@ infs run example.inf
 # Single-file mode: invoke a custom entry point
 infs run example.inf --entry-point helper
 
+# Single-file mode: search libs/ for external .wasm modules
+infs run example.inf -L libs
+
 # Pass arguments to the program (single-file only)
 infs run example.inf -- arg1 arg2
 
@@ -156,7 +159,17 @@ infs run example.inf -- arg1 arg2
 infs run --no-wasm-opt
 ```
 
-Requires `wasmtime` to be installed. In project mode, `infs run` applies the same `[build.wasm-opt]` post-build optimization as `infs build` before executing the result.
+### Run Flags
+
+| Flag | Description |
+|------|-------------|
+| `--entry-point <name>` | Function to invoke in single-file mode (default `main`); project mode always invokes `main`, and requesting anything else is rejected with guidance to use single-file mode |
+| `-L <dir>` / `--wasm-lib-dir <dir>` | Directory to search for external `.wasm` modules referenced by `use { … } from <module>;`; repeatable. In project mode a relative dir is anchored to the directory you invoked `infs` from; in single-file mode no anchoring step runs, because `infc` already inherits that directory as its working directory |
+| `--no-wasm-opt` | Skip `[build.wasm-opt]` post-build optimization (project mode only) |
+
+In single-file mode, options must appear before the first bare trailing token: everything from that token onward — including anything that looks like a flag — is passed to the invoked function instead of being parsed by `infs run`. `infs run f.inf -L libs 1` parses `-L libs` and passes `1` to the function; `infs run f.inf 1 -L libs` passes `1 -L libs` verbatim and parses no `-L` at all. Use `--` to pass arguments that themselves start with `-` unambiguously.
+
+Requires `wasmtime` to be installed. In both modes, `infs run` resolves the enclosing or discovered manifest's `[wasm-dependencies]` and forwards any `-L` directories, so a file or project binding `use { … } from <module>` runs without a separate link step. In project mode, `infs run` also applies the same `[build.wasm-opt]` post-build optimization as `infs build` before executing the result.
 
 ### Project Commands
 

--- a/apps/infs/docs/inference-toml.md
+++ b/apps/infs/docs/inference-toml.md
@@ -73,13 +73,13 @@ for.
 
 `infs build path/to/file.inf` and `infs run path/to/file.inf` compile one named
 file rather than the project's entry point, but they are not manifest-blind: each
-walks up from the source file to the nearest `Inference.toml`. Which settings are
-honored differs by command:
+walks up from the source file to the nearest `Inference.toml`. Both commands
+honor the same settings:
 
 | Setting | `infs build <path>` | `infs run <path>` |
 |---|---|---|
 | `[build] wasm-features` | honored | honored |
-| `[wasm-dependencies]` | honored | **not** resolved |
+| `[wasm-dependencies]` | honored | honored |
 
 `[build] wasm-features` is honored by both, with the same validation and the same
 ABI gate as project mode. This is deliberate rather than incidental: `infs build`,
@@ -87,12 +87,13 @@ ABI gate as project mode. This is deliberate rather than incidental: `infs build
 `out/main.wasm` for the same project, so if they disagreed about the instruction
 set, the artifact you ship would depend on which command last touched it.
 
-`[wasm-dependencies]` is otherwise resolved everywhere: project `infs build` and
-project `infs run` both forward every declared entry to `infc`. That `infs run
-<path>` does not is a pre-existing gap, not a consequence of the above; it is
-tracked as [#367](https://github.com/Inferara/inference/issues/367). A file that
-imports an external module therefore needs project mode, `infs build <path>`, or
-`-L` rather than single-file `run`.
+`[wasm-dependencies]` is resolved identically everywhere: project `infs build`,
+project `infs run`, single-file `infs build <path>`, and single-file `infs run
+<path>` all forward every declared entry to `infc` as `--wasm-dep <name>=<path>`,
+and none of the four gate it on `infc`'s ABI. Both single-file commands also
+accept `-L`/`--wasm-lib-dir` to add extra search directories beyond the
+manifest, so a file that imports an external module runs directly without a
+separate link step.
 
 Everything else in the manifest is project-mode configuration: `[build] mode`,
 `[verification] output-dir`, and `[build.wasm-opt]` are not consulted in

--- a/apps/infs/src/commands/build.rs
+++ b/apps/infs/src/commands/build.rs
@@ -69,17 +69,20 @@
 //!
 //! Two `[build]`-adjacent settings are read from the *enclosing* project even
 //! when a source path is given, by walking up to the nearest `Inference.toml`:
-//! `[wasm-dependencies]`, and `[build] wasm-features`. The latter is not an
-//! optional nicety — `infs build`, `infs build src/main.inf`, and `infs run
-//! src/main.inf` all write `out/main.wasm` for the same project, so they must not
-//! disagree about its WebAssembly instruction level; the feature request, its
-//! validation, and its ABI gate are identical on all three paths (see
-//! [`crate::commands::run`] for the third). A file outside any project takes the
-//! defaults and never errors.
+//! `[wasm-dependencies]`, and `[build] wasm-features`. Neither is an optional
+//! nicety — `infs build`, `infs build src/main.inf`, and `infs run
+//! src/main.inf` all write `out/main.wasm` for the same project, so they must
+//! not disagree about its WebAssembly instruction level, nor about which `.wasm`
+//! files its `use { … } from <module>` bindings resolve to. The feature request
+//! (with its validation and ABI gate) and the dependency resolution are
+//! identical on all three paths — which is why both are derived by the shared
+//! helpers here rather than re-derived per command (see
+//! [`crate::commands::run`] for the third path). A file outside any project
+//! takes the defaults and never errors.
 //!
-//! `[wasm-dependencies]` is resolved on every path but one: single-file `build`
-//! (here) and both project paths forward it. That single-file `run` does not
-//! resolve it predates this and is tracked separately (#367).
+//! `[wasm-dependencies]` is therefore resolved on every compilation path: both
+//! single-file paths through [`manifest_wasm_dependencies`], and both project
+//! paths off the discovered [`ProjectContext`].
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, ValueEnum};
@@ -328,11 +331,17 @@ pub(crate) fn enclosing_manifest(source_path: &Path) -> Result<Option<(PathBuf, 
 /// `.wasm` path (relative entries resolved against the manifest directory).
 /// `None` — a source outside any project — yields an empty list.
 ///
+/// The paths are absolute by construction, which is what lets a caller forward
+/// them without knowing the working directory `infc` will inherit. Centralizing
+/// that is why both single-file paths call this rather than reaching into
+/// `wasm_dependencies` themselves: one project must bind the same module name to
+/// the same file whether it was built or run.
+///
 /// ## Errors
 ///
 /// Returns an error if any `[wasm-dependencies]` key is not a well-formed logical
 /// module name.
-fn manifest_wasm_dependencies(
+pub(crate) fn manifest_wasm_dependencies(
     enclosing: Option<&(PathBuf, InferenceToml)>,
 ) -> Result<Vec<(String, PathBuf)>> {
     let Some((manifest_dir, manifest)) = enclosing else {

--- a/apps/infs/src/commands/project_build.rs
+++ b/apps/infs/src/commands/project_build.rs
@@ -35,14 +35,15 @@
 //! parameters but reads `[build] wasm-features` and `[wasm-dependencies]`
 //! straight off `ctx`. The rule: a setting a CLI flag can override, or that a
 //! caller must be able to suppress, is threaded so the caller stays the single
-//! place that resolves it (`run` deliberately passes `mode = None` to force
-//! compile mode, and has no `-L` flag of its own to pass on). A setting only the
-//! manifest can express, with no flag and nothing to suppress, is read from
-//! `ctx` — threading it would let two callers disagree about a property of the
-//! project itself. An instruction-set request is the latter, as is the set of
-//! external modules the project links against: `build` and `run` emitting
-//! different instruction levels — or resolving one project's `use { … } from
-//! <module>` against different `.wasm` files — is a bug, not a configuration.
+//! place that resolves it — `build` and `run` each own their `-L` entries and
+//! pass them through, and `run` deliberately passes `mode = None` to force
+//! compile mode. A setting only the manifest can express, with no flag and
+//! nothing to suppress, is read from `ctx` — threading it would let two callers
+//! disagree about a property of the project itself. An instruction-set request
+//! is the latter, as is the set of external modules the project links against:
+//! `build` and `run` emitting different instruction levels — or resolving one
+//! project's `use { … } from <module>` against different `.wasm` files — is a
+//! bug, not a configuration.
 
 use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
@@ -101,8 +102,9 @@ use inference_compiler_interface::{
 /// forwarding it verbatim would have `infc` read it as `<root>/../libs` instead
 /// — failing to link, or silently linking a same-named module that happens to
 /// sit at the root-anchored path. Joining onto the invocation directory leaves
-/// an absolute dir unchanged. Single-file mode needs no such treatment: `infc`
-/// inherits the working directory there, so a relative dir keeps its meaning.
+/// an absolute dir unchanged. Neither single-file path needs that treatment:
+/// single-file `build` and `run` both let `infc` inherit the working directory,
+/// so a relative dir already keeps its meaning and is forwarded verbatim.
 ///
 /// The manifest's `[build] wasm-features` is read straight off `ctx` rather than
 /// passed in, so `build` and `run` cannot disagree about the instruction level of

--- a/apps/infs/src/commands/run.rs
+++ b/apps/infs/src/commands/run.rs
@@ -14,18 +14,36 @@
 //! (so `<root>/out/main.wasm` is produced), and invokes `main` by convention.
 //!
 //! Single-file mode is not manifest-blind: it walks up to the nearest
-//! `Inference.toml` and honors `[build] wasm-features`, so running one file of a
-//! project cannot execute a module at a different WebAssembly instruction level
-//! than `infs build` would produce for it. `[wasm-dependencies]` is not resolved
-//! on this path — the only path where it is not (single-file `build` and both
-//! project paths do resolve it); that asymmetry predates this and is tracked
-//! separately (#367).
+//! `Inference.toml` and honors both `[build] wasm-features` and
+//! `[wasm-dependencies]`, so running one file of a project cannot execute a
+//! module at a different WebAssembly instruction level than `infs build` would
+//! produce for it, and cannot fail to resolve an external that the same build
+//! links. This path overwrites the very artifact `infs build` produces, so any
+//! divergence would be observable as one command destroying the other's output.
+//!
+//! ## External-module search directories
+//!
+//! `-L`/`--wasm-lib-dir` is accepted in both modes, spelled exactly as on `infs
+//! build`, but the two modes anchor a relative directory differently — and both
+//! land on "it means what it meant at the shell":
+//!
+//! - **Single-file mode forwards each directory verbatim.** `infc` inherits the
+//!   invocation working directory here, so a relative dir already resolves
+//!   against the directory the user typed it in.
+//! - **Project mode anchors first**, because the shared helper re-anchors `infc`
+//!   to the project root; see [`crate::commands::project_build`].
 //!
 //! ```bash
 //! infs run                                    # project mode: build + invoke main
 //! infs run program.inf                        # single-file: invoke main()
 //! infs run program.inf --entry-point helper   # single-file: invoke helper()
+//! infs run program.inf -L libs                # single-file: search libs/ for externals
+//! infs run -L libs                            # project mode: same, for the whole project
 //! ```
+//!
+//! Options must be placed **before** the first bare trailing token: [`RunArgs`]
+//! collects trailing var-args for the invoked function, so `infs run f.inf 1 -L
+//! libs` passes `-L` and `libs` to the program rather than parsing them.
 //!
 //! ## Project-mode conventions
 //!
@@ -42,12 +60,14 @@
 //!   project-build helper. Single-file `run` keeps its prior no-handshake
 //!   behavior except when the enclosing manifest requests `wasm-features`, where
 //!   a capability probe is the only way to refuse a request the compiler cannot
-//!   honor.
-//! - **Resolves `[wasm-dependencies]`**, also via the shared helper: the project
-//!   it runs is the one `infs build` would produce, externals included. A
-//!   project binding `use { … } from <module>` is otherwise unrunnable, since
-//!   `infc` resolves externals from forwarded flags only. `run` has no
-//!   `-L`/`--wasm-lib-dir` flag, so the manifest is its only source.
+//!   honor. Neither `--wasm-dep` nor `--wasm-lib-dir` is capability-gated on
+//!   either path: both arrived with external-module support itself rather than
+//!   at a distinguishable ABI minor, so the handshake has nothing to check.
+//! - **Resolves `[wasm-dependencies]`**, also via the shared helper, and
+//!   forwards every `-L` it was passed: the project it runs is the one `infs
+//!   build` would produce, externals included. A project binding `use { … } from
+//!   <module>` is otherwise unrunnable, since `infc` resolves externals from
+//!   forwarded flags only.
 //! - **Always builds in compile mode**, regardless of the manifest's
 //!   `[build] mode`. `run` executes the WASM, and proof-mode WASM embeds the
 //!   custom non-deterministic opcodes (the `0xfc` family) that wasmtime cannot
@@ -73,7 +93,9 @@ use clap::Args;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::commands::build::{enclosing_manifest, manifest_wasm_features};
+use crate::commands::build::{
+    enclosing_manifest, format_wasm_dep_arg, manifest_wasm_dependencies, manifest_wasm_features,
+};
 use crate::commands::project_build::{
     forward_wasm_features, probe_compiler_compatibility, run_project_build,
 };
@@ -89,7 +111,13 @@ const DEFAULT_ENTRY_POINT: &str = "main";
 /// Arguments for the run command.
 ///
 /// The run command compiles source to WASM and executes it with wasmtime.
-/// Any arguments after the source path are passed to the invoked function.
+///
+/// [`RunArgs::args`] is a trailing var-arg, which sets the ordering contract for
+/// the whole struct: options are consumed wherever they appear *before* the first
+/// bare token that is not the source path, and everything from that token onward
+/// is handed to the invoked function untouched. `infs run f.inf -L libs 1` passes
+/// `libs` to the compiler and `1` to the program; `infs run f.inf 1 -L libs`
+/// passes all three of `1`, `-L`, `libs` to the program.
 #[derive(Args)]
 pub struct RunArgs {
     /// Path to the source file to run.
@@ -110,6 +138,23 @@ pub struct RunArgs {
     #[clap(long, default_value = DEFAULT_ENTRY_POINT)]
     pub entry_point: String,
 
+    /// Directory to search for external `.wasm` modules referenced by
+    /// `use { … } from <module>;`. Repeatable; forwarded as `--wasm-lib-dir` in
+    /// both single-file and project mode, spelled exactly as on `infs build`. A
+    /// relative dir always means what it meant at the shell: single-file `infc`
+    /// inherits the invocation directory, and the project path anchors the dir to
+    /// that directory before forwarding, because it moves `infc` to the project
+    /// root.
+    ///
+    /// Must appear before the first bare trailing token, which starts the
+    /// arguments handed to the invoked function: `infs run f.inf -L libs 1`
+    /// searches `libs`, `infs run f.inf 1 -L libs` does not.
+    // Kept ahead of `no_wasm_opt` to mirror `BuildArgs`: clap lists options in
+    // declaration order, so the two flags shared with `infs build` must be declared
+    // in the same relative order for both `--help` screens to present them alike.
+    #[clap(short = 'L', long = "wasm-lib-dir", value_name = "DIR")]
+    pub wasm_lib_dirs: Vec<PathBuf>,
+
     /// Skip the `[build.wasm-opt]` post-build optimization for this build.
     ///
     /// Project mode only: `run` executes the artifact it builds, so this makes
@@ -124,6 +169,12 @@ pub struct RunArgs {
     /// For `main`, these are ignored (argc=0, argv=0 is always used). These only
     /// apply in single-file mode: the first bare token binds to `path`, so
     /// project mode (no path) never receives trailing args.
+    ///
+    /// Collection starts at the first bare token after the source path and takes
+    /// everything from there, options included — so `infs run f.inf 1 -L libs`
+    /// yields `["1", "-L", "libs"]` rather than parsing `-L`. Place every option
+    /// before that token, or separate the program's arguments with `--`
+    /// (`infs run f.inf -- -L x` yields `["-L", "x"]`).
     #[clap(trailing_var_arg = true)]
     pub args: Vec<String>,
 }
@@ -156,24 +207,31 @@ pub fn execute(args: &RunArgs) -> Result<()> {
 ///
 /// 1. Validates source file exists
 /// 2. Checks for wasmtime availability
-/// 3. Resolves the enclosing project's `[build] wasm-features`, if any
+/// 3. Resolves the enclosing project's `[build] wasm-features` and
+///    `[wasm-dependencies]`, if any
 /// 4. Locates the infc compiler
-/// 5. Compiles source to WASM via infc subprocess
+/// 5. Compiles source to WASM via infc subprocess, forwarding those settings
+///    alongside every `-L` the user passed
 /// 6. Executes WASM with wasmtime, invoking `--entry-point`
 /// 7. Propagates exit code from wasmtime
 ///
-/// The enclosing manifest's `wasm-features` is honored here for the same reason
-/// `infs build <path>` honors it: one project must not emit modules at two
-/// different WebAssembly instruction levels depending on how the build was
-/// invoked, and this path overwrites the very artifact `infs build` produces.
-/// `[wasm-dependencies]` is *not* resolved here — the last path where it is not,
-/// a gap that predates this and is tracked separately (#367).
+/// The enclosing manifest is honored here for the same reason `infs build
+/// <path>` honors it: one project must not emit modules at two different
+/// WebAssembly instruction levels, or bind one module name to two different
+/// `.wasm` files, depending on how the build was invoked — and this path
+/// overwrites the very artifact `infs build` produces.
+///
+/// Every manifest-derived setting comes off the single [`enclosing_manifest`]
+/// call above, and that resolution happens *before* the compiler lookup so a
+/// malformed manifest is reported without first probing the toolchain.
 ///
 /// ## Errors
 ///
 /// Returns an error if:
 /// - The source file does not exist
 /// - wasmtime is not found in PATH
+/// - a `[wasm-dependencies]` key is not a well-formed logical module name, or a
+///   resolved dependency path is not valid UTF-8
 /// - infc compiler cannot be found
 /// - the enclosing manifest requests `wasm-features` the resolved `infc` cannot
 ///   honor (which is also the only case that runs the ABI handshake here)
@@ -188,6 +246,7 @@ fn execute_single_file(path: &Path, args: &RunArgs) -> Result<()> {
 
     let enclosing = enclosing_manifest(path)?;
     let features = manifest_wasm_features(enclosing.as_ref().map(|(_, manifest)| manifest))?;
+    let deps = manifest_wasm_dependencies(enclosing.as_ref())?;
     let manifest_path = enclosing
         .as_ref()
         .map(|(dir, _)| dir.join(MANIFEST_FILE_NAME));
@@ -198,6 +257,8 @@ fn execute_single_file(path: &Path, args: &RunArgs) -> Result<()> {
         &infc_path,
         infc_source,
         path,
+        &args.wasm_lib_dirs,
+        &deps,
         &features,
         manifest_path.as_deref(),
     )?;
@@ -208,11 +269,13 @@ fn execute_single_file(path: &Path, args: &RunArgs) -> Result<()> {
 /// Builds and runs a discovered project (project mode).
 ///
 /// Resolves the project from the current directory, performs the shared project
-/// build (which runs the `infc` compatibility handshake), then invokes `main` on
-/// `<root>/out/main.wasm` via wasmtime. Project mode always invokes `main`; a
-/// non-`main` `--entry-point` is rejected. Trailing var-args cannot reach this
-/// path (the first token binds to `path`); the warning is a defensive guard
-/// documenting the ignore-args policy.
+/// build (which runs the `infc` compatibility handshake and forwards the
+/// `-L` directories given here), then invokes `main` on `<root>/out/main.wasm`
+/// via wasmtime. Project mode always invokes `main`; a non-`main` `--entry-point`
+/// is rejected. Trailing var-args cannot reach this path (the first token binds
+/// to `path`); the warning is a defensive guard documenting the ignore-args
+/// policy. `-L` is the one flag that *can* reach here, since it takes its own
+/// value rather than a bare token.
 ///
 /// wasmtime availability is checked *first* — before any compilation — so an
 /// environment lacking the runtime fails fast, matching single-file mode.
@@ -223,7 +286,8 @@ fn execute_single_file(path: &Path, args: &RunArgs) -> Result<()> {
 /// - `--entry-point` is set to a non-`main` value (project mode invokes `main`)
 /// - wasmtime is not found in PATH
 /// - No `Inference.toml` is found in the current directory or any ancestor
-/// - The project build fails (missing entry point, ABI handshake, infc error)
+/// - The project build fails (missing entry point, ABI handshake,
+///   external-module forwarding, infc error)
 /// - The build succeeds but `<root>/out/main.wasm` is absent
 /// - WASM execution fails
 fn execute_project(args: &RunArgs) -> Result<()> {
@@ -254,13 +318,19 @@ fn execute_project(args: &RunArgs) -> Result<()> {
     // regardless of `[build] mode` in the manifest: proof-mode WASM embeds the
     // custom non-deterministic opcodes (0xfc family) that wasmtime cannot
     // execute. Hence `mode = None` and `out_dir = None` here — manifest
-    // mode/output-dir resolution lives only in `build`'s project path. The
-    // empty `wasm_lib_dirs` is not a suppression: `run` simply has no
-    // `-L` flag, and the manifest's `[wasm-dependencies]` still reaches `infc`
-    // through the shared helper. The `[build.wasm-opt]` optimization still
-    // applies (unless `--no-wasm-opt`) so `run` executes exactly what `build`
-    // would ship.
-    run_project_build(&ctx, false, None, None, &[], args.no_wasm_opt)?;
+    // mode/output-dir resolution lives only in `build`'s project path. The lib
+    // dirs pass straight through; the helper anchors them to the invocation
+    // directory because it moves `infc` to the project root. The
+    // `[build.wasm-opt]` optimization still applies (unless `--no-wasm-opt`) so
+    // `run` executes exactly what `build` would ship.
+    run_project_build(
+        &ctx,
+        false,
+        None,
+        None,
+        &args.wasm_lib_dirs,
+        args.no_wasm_opt,
+    )?;
 
     let wasm_path = project_wasm_path(&ctx);
     if !wasm_path.exists() {
@@ -299,24 +369,48 @@ fn check_wasmtime_availability() -> Result<()> {
 
 /// Compiles source file to WASM binary using infc subprocess.
 ///
-/// Calls infc with `--parse --codegen -o` flags to generate the WASM file
-/// in the `out/` directory, forwarding `features` as `--wasm-features` so the
-/// artifact this command then executes carries the instruction set the enclosing
-/// project asked for.
+/// Calls infc with `--parse --codegen -o` to generate the WASM file in the
+/// `out/` directory, forwarding everything the artifact this command then
+/// executes must be built with. The wire order is
+///
+/// ```text
+/// <source> --parse --codegen -o [--wasm-lib-dir <dir>]* [--wasm-dep <name>=<path>]* [--wasm-features <list>]
+/// ```
+///
+/// which is the relative order single-file `infs build` uses, so the two
+/// commands present one project to `infc` identically.
+///
+/// `wasm_lib_dirs` is forwarded **verbatim**, deliberately: this path never sets
+/// the child's working directory, so `infc` inherits the invocation directory and
+/// a relative dir still names what the user typed. Anchoring them would be wrong
+/// here, and is required only where the child is re-anchored to the project root —
+/// see [`run_project_build`].
+///
+/// `deps` arrives already resolved to absolute paths, so it needs no anchoring
+/// under any working directory.
 ///
 /// The compatibility handshake runs only when there is a feature request to gate.
 /// Single-file `run` otherwise keeps its historical handshake-free behavior: the
 /// probe exists to refuse an unhonorable request, and paying for it on every run
 /// would add ABI warnings to invocations that ask nothing of the compiler.
+/// Neither `--wasm-lib-dir` nor `--wasm-dep` is gated: both arrived with
+/// external-module support itself rather than at a distinguishable ABI minor, so
+/// there is no capability to probe. An `infc` too old to accept them is therefore
+/// reported by `infc`'s own argument parser rather than with remediation from
+/// here.
 ///
 /// # Errors
 ///
-/// Returns an error if the resolved `infc` cannot honor a requested feature, if
-/// `infc` exits non-zero, or if the expected artifact is absent afterwards.
+/// Returns an error if a resolved dependency path is not valid UTF-8 (it cannot
+/// round-trip through the single-`String` `--wasm-dep` argument), if the resolved
+/// `infc` cannot honor a requested feature, if `infc` exits non-zero, or if the
+/// expected artifact is absent afterwards.
 fn compile_to_wasm(
     infc_path: &Path,
     infc_source: ResolutionSource,
     source_path: &Path,
+    wasm_lib_dirs: &[PathBuf],
+    deps: &[(String, PathBuf)],
     features: &[WasmFeatureName],
     manifest_path: Option<&Path>,
 ) -> Result<PathBuf> {
@@ -325,6 +419,14 @@ fn compile_to_wasm(
         .arg("--parse")
         .arg("--codegen")
         .arg("-o");
+
+    for dir in wasm_lib_dirs {
+        cmd.arg("--wasm-lib-dir").arg(dir);
+    }
+
+    for (name, path) in deps {
+        cmd.arg("--wasm-dep").arg(format_wasm_dep_arg(name, path)?);
+    }
 
     if !features.is_empty() {
         let compat = probe_compiler_compatibility(infc_path, infc_source)?;
@@ -411,6 +513,127 @@ fn run_wasmtime(wasm_path: &Path, entry_point: &str, args: &[String]) -> Result<
 }
 
 #[cfg(test)]
+mod cli_surface_tests {
+    use super::*;
+    use clap::Parser;
+
+    /// A minimal parser wrapping [`RunArgs`], standing in for the real CLI so
+    /// the flag surface can be exercised without spawning the binary.
+    #[derive(Parser)]
+    struct RunCli {
+        #[command(flatten)]
+        args: RunArgs,
+    }
+
+    /// Parses `argv` (with the command name prepended) or panics with the clap
+    /// error, so a failed parse is diagnosed rather than reported as a bad field.
+    fn parse(argv: &[&str]) -> RunArgs {
+        let mut full = vec!["run"];
+        full.extend_from_slice(argv);
+        RunCli::try_parse_from(full)
+            .unwrap_or_else(|err| panic!("`infs {}` must parse: {err}", argv.join(" ")))
+            .args
+    }
+
+    /// The lib-dir flag is an *option*, not a second positional. Were the
+    /// `short`/`long` attributes lost, `wasm_lib_dirs` would become positional #2
+    /// and silently swallow the trailing-var-arg slot, so the source path and the
+    /// (empty) program arguments are asserted alongside the directory.
+    #[test]
+    fn lib_dir_flag_is_an_option_not_a_second_positional() {
+        let args = parse(&["f.inf", "-L", "libs"]);
+        assert_eq!(args.path.as_deref(), Some(Path::new("f.inf")));
+        assert_eq!(args.wasm_lib_dirs, [PathBuf::from("libs")]);
+        assert!(args.args.is_empty());
+    }
+
+    /// The flag is positionally free relative to the source path, as any option
+    /// is: it binds the same whether it precedes or follows the path.
+    #[test]
+    fn lib_dir_flag_may_precede_the_source_path() {
+        let args = parse(&["-L", "libs", "f.inf"]);
+        assert_eq!(args.path.as_deref(), Some(Path::new("f.inf")));
+        assert_eq!(args.wasm_lib_dirs, [PathBuf::from("libs")]);
+        assert!(args.args.is_empty());
+    }
+
+    /// Both spellings parse, repeat, mix, and preserve the order given. The
+    /// order is contractual, not cosmetic: `infc` searches the directories in the
+    /// order received and the first hit wins, so a parse that reordered them
+    /// would change which `.wasm` a module resolves to.
+    #[test]
+    fn lib_dir_flag_accepts_both_spellings_and_preserves_order() {
+        let args = parse(&[
+            "-L",
+            "first",
+            "--wasm-lib-dir",
+            "second",
+            "-L",
+            "third",
+            "f.inf",
+        ]);
+        assert_eq!(
+            args.wasm_lib_dirs,
+            [
+                PathBuf::from("first"),
+                PathBuf::from("second"),
+                PathBuf::from("third")
+            ]
+        );
+        assert_eq!(args.path.as_deref(), Some(Path::new("f.inf")));
+    }
+
+    /// Project mode is the only mode `-L` can reach without a source path: any
+    /// bare token would bind to `path` and select single-file mode instead, so a
+    /// project-mode lib dir must arrive through the option's own value.
+    #[test]
+    fn lib_dir_flag_reaches_project_mode_without_a_source_path() {
+        let args = parse(&["-L", "libs"]);
+        assert!(args.path.is_none(), "no bare token means project mode");
+        assert_eq!(args.wasm_lib_dirs, [PathBuf::from("libs")]);
+        assert!(args.args.is_empty());
+    }
+
+    /// Options placed between the source path and the first bare token are still
+    /// parsed as options; collection of the program's arguments starts at that
+    /// bare token.
+    #[test]
+    fn options_before_the_first_bare_token_are_parsed() {
+        let args = parse(&["f.inf", "--entry-point", "helper", "-L", "libs", "1"]);
+        assert_eq!(args.path.as_deref(), Some(Path::new("f.inf")));
+        assert_eq!(args.entry_point, "helper");
+        assert_eq!(args.wasm_lib_dirs, [PathBuf::from("libs")]);
+        assert_eq!(args.args, ["1"]);
+    }
+
+    /// The ordering contract, stated as the failure it produces: once a bare
+    /// trailing token has been seen, everything after it — flags included — goes
+    /// to the invoked function verbatim. This is not a parse bug to be fixed but
+    /// the property that lets a program take arguments that look like `infs`
+    /// flags; it is pinned so a future flag rearrangement cannot silently change
+    /// which side of the boundary an argument lands on.
+    #[test]
+    fn a_lib_dir_after_the_first_bare_token_becomes_a_program_argument() {
+        let args = parse(&["f.inf", "1", "-L", "libs"]);
+        assert!(
+            args.wasm_lib_dirs.is_empty(),
+            "`-L` after a bare token is the program's, not the compiler's"
+        );
+        assert_eq!(args.args, ["1", "-L", "libs"]);
+    }
+
+    /// `--` is the explicit form of the same boundary, for a program whose first
+    /// argument itself looks like a flag.
+    #[test]
+    fn a_double_dash_hands_flag_shaped_arguments_to_the_program() {
+        let args = parse(&["f.inf", "--", "-L", "x"]);
+        assert_eq!(args.path.as_deref(), Some(Path::new("f.inf")));
+        assert!(args.wasm_lib_dirs.is_empty());
+        assert_eq!(args.args, ["-L", "x"]);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -443,6 +666,7 @@ mod tests {
             path: None,
             entry_point: "helper".to_string(),
             no_wasm_opt: false,
+            wasm_lib_dirs: Vec::new(),
             args: Vec::new(),
         };
 
@@ -467,6 +691,7 @@ mod tests {
             path: None,
             entry_point: DEFAULT_ENTRY_POINT.to_string(),
             no_wasm_opt: false,
+            wasm_lib_dirs: Vec::new(),
             args: Vec::new(),
         };
 

--- a/apps/infs/tests/cli_integration.rs
+++ b/apps/infs/tests/cli_integration.rs
@@ -2235,14 +2235,18 @@ fn project_build_rejects_an_unknown_manifest_key() {
     );
 }
 
-// Project-mode `[wasm-dependencies]` and `-L` Forwarding Tests
+// `[wasm-dependencies]` and `-L` Forwarding Tests
 //
 // `infc` resolves `use { … } from <module>` from `--wasm-dep`, `-L` and
-// `INFERENCE_WASM_LIB_PATH` alone, so a project build that forwards none of them
-// cannot link an external at all — and in proof mode cannot emit its `.v`. These
-// pin both ends: the wire spelling each project route puts on the command line,
-// and the end-to-end link through a real `infc` with no environment variable in
-// play.
+// `INFERENCE_WASM_LIB_PATH` alone, so a route that forwards none of them cannot
+// link an external at all — and in proof mode cannot emit its `.v`. All four
+// compilation routes are covered here (project `build`, project `run`,
+// single-file `build`, single-file `run`), because a project is only as runnable
+// as its least-equipped route: `infs build src/main.inf` linking where `infs run
+// src/main.inf` does not is the shape of the bug these pin against, and the two
+// commands overwrite the same artifact. Each route is pinned at both ends: the
+// wire spelling it puts on the command line, and the end-to-end link through a
+// real `infc` with no environment variable in play.
 
 /// `src/main.inf` that binds an external: the declaration, the `use` that binds
 /// it to the logical module `arith`, and a `main` whose value only the linked
@@ -2261,10 +2265,10 @@ const ARITH_LIB_SRC: &str = "pub fn sum(a: i32, b: i32) -> i32 {\n    return a +
 const ARITH_DEPENDENCY_TABLE: &str =
     "[wasm-dependencies]\narith = { path = \"libs/arith.wasm\" }\n";
 
-/// Writes an executable `infc` stub under `dir` that reports a mismatched commit
-/// and the current ABI, and appends the argv of every non-probe invocation —
-/// everything but the `--commit-hash` and `--abi-version` handshake calls, one
-/// entry per line — to `log`. Returns the stub's path.
+/// Writes an executable `infc` stub named `infc_stub` under `dir` that reports a
+/// mismatched commit and the current ABI, and appends the argv of every
+/// non-probe invocation — everything but the `--commit-hash` and `--abi-version`
+/// handshake calls, one entry per line — to `log`. Returns the stub's path.
 ///
 /// The mismatched commit is what makes the stub useful: every real-`infc` test
 /// here takes the `commit_matched` short-circuit, so none of them observes what
@@ -2272,25 +2276,57 @@ const ARITH_DEPENDENCY_TABLE: &str =
 /// appears; with no `[build.wasm-opt]` table the post-build step is a no-op and a
 /// `build` through it still succeeds.
 ///
+/// The handshake calls leave no trace in `log`; a test that needs to *count*
+/// them reaches for [`write_infc_stub`] with a probe log instead.
+///
 /// Unix-only: relies on an executable shell script.
 #[cfg(unix)]
 fn write_argv_logging_infc_stub(
     dir: &assert_fs::TempDir,
     log: &std::path::Path,
 ) -> std::path::PathBuf {
+    write_infc_stub(dir, "infc_stub", log, None)
+}
+
+/// The general form of [`write_argv_logging_infc_stub`]: an `infc` stub written
+/// under `dir` as `name`, logging non-probe argv to `argv_log` and — when
+/// `probe_log` is given — one line per handshake probe to that second file.
+///
+/// `name` exists because a stub bakes in one log path: two commands whose argv
+/// must be compared need two stubs side by side in one project directory, and
+/// the fixed name would have the second overwrite the first.
+///
+/// `probe_log` is what makes the handshake observable at all. The probe arms
+/// answer and exit without touching `argv_log`, and a mismatched-commit stub
+/// prints nothing a caller could see, so an invocation that probes is otherwise
+/// indistinguishable from one that does not — and the rule that single-file
+/// `run` probes *only* to gate a feature request would be unpinnable.
+///
+/// Unix-only: relies on an executable shell script.
+#[cfg(unix)]
+fn write_infc_stub(
+    dir: &assert_fs::TempDir,
+    name: &str,
+    argv_log: &std::path::Path,
+    probe_log: Option<&std::path::Path>,
+) -> std::path::PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
-    let stub = dir.child("infc_stub");
+    let record_probe = probe_log.map_or_else(String::new, |log| {
+        format!("printf '%s\\n' \"$1\" >> '{}'; ", log.display())
+    });
+
+    let stub = dir.child(name);
     stub.write_str(&format!(
         "#!/bin/sh\n\
          case \"$1\" in\n\
-           --commit-hash) printf 'nope\\n'; exit 0 ;;\n\
-           --abi-version) printf '{}.{}\\n'; exit 0 ;;\n\
+           --commit-hash) {record_probe}printf 'nope\\n'; exit 0 ;;\n\
+           --abi-version) {record_probe}printf '{}.{}\\n'; exit 0 ;;\n\
            *) printf '%s\\n' \"$@\" >> '{}'; exit 0 ;;\n\
          esac\n",
         inference_compiler_interface::COMPILER_ABI_MAJOR,
         inference_compiler_interface::COMPILER_ABI_MINOR,
-        log.display()
+        argv_log.display()
     ))
     .unwrap();
     let mut perms = std::fs::metadata(stub.path()).unwrap().permissions();
@@ -2324,6 +2360,21 @@ fn argv_values_after<'a>(argv: &[&'a str], flag: &str) -> Vec<Option<&'a str>> {
 #[cfg(unix)]
 fn logged_argv(log: &std::path::Path) -> String {
     std::fs::read_to_string(log).expect("the stub must log its argv")
+}
+
+/// The handshake probes a stub recorded, one flag per entry.
+///
+/// An absent file is the zero-probe outcome, not a missing log: the stub creates
+/// it on its first append, so a command that never probed leaves no file at all.
+/// Deliberately not [`logged_argv`]'s `expect`, which would report that outcome
+/// as a broken fixture rather than as the result under test.
+#[cfg(unix)]
+fn logged_probes(log: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_owned)
+        .collect()
 }
 
 /// Compiles [`ARITH_LIB_SRC`] with the real `infc` in a temp directory of its own
@@ -2553,10 +2604,15 @@ fn project_build_without_dependencies_forwards_no_external_flags() {
     );
 }
 
-/// The same wire spelling on the project `run` route, which has no lib-dir flag
-/// of its own: the manifest is its only source of externals, so a route that
-/// dropped it would leave every project binding `use { … } from <module>`
-/// unrunnable.
+/// The same wire spelling on the project `run` route, driven by the manifest
+/// alone: a route that dropped the declaration would leave every project binding
+/// `use { … } from <module>` unrunnable, whatever the invocation passed.
+///
+/// This invocation passes no `-L`, so none is forwarded — the assertion below
+/// pins that the manifest path emits the dependency flag *without* dragging an
+/// empty lib-dir flag onto the command line. The `-L` route itself is pinned
+/// separately by
+/// [`project_run_forwards_a_lib_dir_anchored_to_the_invocation_directory`].
 ///
 /// wasmtime is checked before the build, hence the gate. The stub compiles
 /// nothing, so `out/main.wasm` never appears and the command fails *after* the
@@ -2605,7 +2661,78 @@ fn project_run_forwards_manifest_dep_to_infc() {
     );
     assert!(
         argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
-        "`run` has no lib-dir flag to forward, got argv: {argv:?}"
+        "no `-L` was passed on this invocation, so none may be forwarded, got \
+         argv: {argv:?}"
+    );
+}
+
+/// The project `run` route forwards its own `-L`, anchored to the invocation
+/// directory exactly as project `build` does.
+///
+/// Project `run` re-anchors `infc` to the project root, so a lib dir forwarded
+/// verbatim would be re-read from there rather than from the directory the user
+/// typed it in. `-L ../libs` is passed from `<root>/src`, where it names
+/// `<root>/libs`; left verbatim it would name `<root>/../libs` — outside the
+/// project, where a same-named `.wasm` would link silently in place of the
+/// intended one. The absolute dir alongside it pins the other half: joining must
+/// leave it untouched.
+///
+/// Two failures are caught: a `run` that never grew the flag (clap rejects `-L`
+/// and nothing is logged), and a `run` that grew it but still hands the shared
+/// project helper an empty slice (the flag never reaches the wire). The
+/// expectation is built from the *canonicalized* subdirectory because
+/// `std::env::current_dir()` in the child reports the symlink-resolved path,
+/// which on macOS differs from the temp path this test holds.
+#[cfg(unix)]
+#[test]
+fn project_run_forwards_a_lib_dir_anchored_to_the_invocation_directory() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project(&temp, "demo", PROJECT_MAIN_SRC);
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    temp.child("libs").create_dir_all().unwrap();
+    let absolute = temp.child("vendor");
+    absolute.create_dir_all().unwrap();
+
+    let invocation_dir = temp.child("src");
+    let relative = std::path::Path::new("..").join("libs");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(invocation_dir.path())
+        .arg("run")
+        .arg("-L")
+        .arg(&relative)
+        .arg("-L")
+        .arg(absolute.path());
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let anchored = invocation_dir
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join(&relative)
+        .display()
+        .to_string();
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![
+            Some(anchored.as_str()),
+            Some(absolute.path().to_str().unwrap()),
+        ],
+        "project `run` must forward a relative lib dir anchored at the \
+         invocation directory (`{anchored}`), and an absolute one unchanged, \
+         got argv: {argv:?}"
     );
 }
 
@@ -2671,6 +2798,751 @@ fn project_run_executes_a_linked_manifest_dependency() {
         stdout.contains("42"),
         "wasmtime must print the linked call's result (40 + 2), got:\n{stdout}"
     );
+}
+
+/// Scaffolds a throwaway project with a logging `infc` stub, runs `infs run`
+/// with `args` from the project root, and returns the argv the stub recorded.
+///
+/// Each call gets its own temp directory and stub: the stub bakes in one log
+/// path and appends to it, so two invocations sharing a stub would produce a log
+/// no caller could attribute. The command is asserted to fail — the stub
+/// compiles nothing, so the missing-artifact guard always fires — which is what
+/// proves the spawn happened before the log is read.
+#[cfg(unix)]
+fn single_file_run_logged_argv(args: &[&str]) -> String {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project(&temp, "demo", PROJECT_MAIN_SRC);
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .args(args);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    logged_argv(argv_log.path())
+}
+
+/// Single-file `run` forwards the enclosing manifest's dependency, as the
+/// project routes do.
+///
+/// This is the route the bug lived on: `infs build src/main.inf` resolved the
+/// manifest's `[wasm-dependencies]` and `infs run src/main.inf` did not, so a
+/// project binding `use { … } from <module>` could be built but not run — and
+/// because the two commands write the same `out/main.wasm`, running one file of
+/// such a project first destroyed the linked artifact and then failed to
+/// re-link it.
+///
+/// The value must be absolute and appear exactly once: the manifest resolves its
+/// declarations against the project root, and single-file mode spawns `infc`
+/// without setting a working directory, so a path left relative to the root
+/// would be re-read against whatever directory the user happened to invoke from.
+///
+/// wasmtime is checked before compilation, hence the gate. The expectation is
+/// built from the *canonicalized* root because the child reports its working
+/// directory symlink-resolved, which on macOS differs from the temp path held
+/// here.
+#[cfg(unix)]
+#[test]
+fn single_file_run_forwards_manifest_dep_to_infc() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        ARITH_DEPENDENCY_TABLE,
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .arg(std::path::Path::new("src").join("main.inf"));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let expected_dep = format!(
+        "arith={}",
+        temp.path()
+            .canonicalize()
+            .unwrap()
+            .join("libs")
+            .join("arith.wasm")
+            .display()
+    );
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep"),
+        vec![Some(expected_dep.as_str())],
+        "single-file `run` must forward the enclosing manifest's dependency \
+         exactly once, as `<name>=<path resolved against the project root>`, \
+         got argv: {argv:?}"
+    );
+    assert!(
+        argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
+        "no `-L` was passed on this invocation, so none may be forwarded, got \
+         argv: {argv:?}"
+    );
+}
+
+/// Every declared dependency reaches `infc`, not just the first, and in the
+/// manifest resolution's name order — so two manifests differing only in the
+/// order they list the same dependencies produce the same invocation, and so
+/// single-file `run` agrees with the project routes on that order. Declared here
+/// in reverse of the expected order, which a straight iteration over the
+/// declarations would preserve.
+#[cfg(unix)]
+#[test]
+fn single_file_run_forwards_every_manifest_dependency_in_name_order() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        "[wasm-dependencies]\n\
+         zeta = { path = \"libs/zeta.wasm\" }\n\
+         alpha = { path = \"libs/alpha.wasm\" }\n",
+    );
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .arg(std::path::Path::new("src").join("main.inf"));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    let root = temp.path().canonicalize().unwrap();
+    let alpha = format!("alpha={}", root.join("libs").join("alpha.wasm").display());
+    let zeta = format!("zeta={}", root.join("libs").join("zeta.wasm").display());
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep"),
+        vec![Some(alpha.as_str()), Some(zeta.as_str())],
+        "every declaration must be forwarded, in name order, got argv: {argv:?}"
+    );
+}
+
+/// A relative `-L` reaches `infc` **verbatim** on the single-file route — the
+/// deliberate mirror image of the project route's anchoring.
+///
+/// Single-file mode never sets the child's working directory, so `infc` inherits
+/// the invocation directory and a relative dir already resolves against the one
+/// the user typed it in. Anchoring it here would be a double correction: `-L
+/// ../libs` passed from `<root>/src` would be rewritten to an absolute path that
+/// happens to name the same directory today, and to the *wrong* directory the
+/// moment anchoring and inheritance disagree.
+///
+/// This is the guard against "fixing" the asymmetry by copying the project
+/// route's `cwd.join`: adding one turns the first logged value into an absolute
+/// path and fails this assertion. The absolute dir alongside it pins that
+/// verbatim forwarding is not doing anything to well-formed input either.
+#[cfg(unix)]
+#[test]
+fn single_file_run_forwards_a_relative_lib_dir_verbatim() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project(&temp, "demo", PROJECT_MAIN_SRC);
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    temp.child("libs").create_dir_all().unwrap();
+    let absolute = temp.child("vendor");
+    absolute.create_dir_all().unwrap();
+
+    let invocation_dir = temp.child("src");
+    let relative = std::path::Path::new("..").join("libs");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(invocation_dir.path())
+        .arg("run")
+        .arg("main.inf")
+        .arg("-L")
+        .arg(&relative)
+        .arg("-L")
+        .arg(absolute.path());
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![
+            Some(relative.to_str().unwrap()),
+            Some(absolute.path().to_str().unwrap()),
+        ],
+        "single-file `run` must forward every lib dir exactly as typed — `infc` \
+         inherits the invocation directory here, so anchoring would be a second \
+         correction, got argv: {argv:?}"
+    );
+}
+
+/// Runs one single-file command (`build` or `run`) over `source` with `-L
+/// lib_dir` from `project`'s root, through a stub of its own, and returns the
+/// argv it put on the wire.
+///
+/// The stub is named and logged per command so two commands can be compared
+/// against one project: a stub bakes in one log path and the log carries one
+/// entry per line with no invocation boundary, so a shared one could not be
+/// attributed to either command.
+///
+/// The expected outcome differs by command and is asserted here, because
+/// reaching it is what proves the spawn happened before the log is read: the
+/// stub compiles nothing, so `run` always fails at its missing-artifact guard,
+/// while `build` — which asks for no artifact of its own, and finds no
+/// `[build.wasm-opt]` table to post-process — succeeds.
+#[cfg(unix)]
+fn single_file_command_argv(
+    project: &assert_fs::TempDir,
+    command: &str,
+    source: &std::path::Path,
+    lib_dir: &std::path::Path,
+) -> String {
+    let log = project.child(format!("{command}-argv.log"));
+    let stub = write_infc_stub(project, &format!("infc_stub_{command}"), log.path(), None);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(project.path())
+        .arg(command)
+        .arg(source)
+        .arg("-L")
+        .arg(lib_dir);
+
+    let assert = cmd.assert();
+    if command == "run" {
+        assert
+            .failure()
+            .stderr(predicate::str::contains("WASM file not found"));
+    } else {
+        assert.success();
+    }
+
+    logged_argv(log.path())
+}
+
+/// The wire order single-file `run` presents matches single-file `build`,
+/// compared against `build`'s *observed* command line rather than a transcribed
+/// copy of it:
+/// `<source> [phase flags] [--wasm-lib-dir …]* [--wasm-dep …]* [--wasm-features …]`.
+///
+/// Order is not semantically load-bearing to `infc`'s parser, but "the two
+/// single-file commands present one project to `infc` identically" is the whole
+/// claim this change makes, and only a positional assertion can hold it: a
+/// forwarding block appended after the feature block would satisfy every
+/// presence check above while quietly diverging from `build`.
+///
+/// Both commands are driven here because the divergence has two ends. The two
+/// forwarding blocks are near-identical in `build` and in the shared project
+/// helper, so a refactor that swaps them in one place — dependencies before lib
+/// dirs — is entirely plausible; against a transcribed expectation only the
+/// command that was actually spawned would notice, leaving the two single-file
+/// routes silently disagreeing about the project they write the same
+/// `out/main.wasm` for.
+///
+/// The manifest declares both a feature request and a dependency and the
+/// invocation adds a lib dir, so all three blocks are on the line at once — the
+/// only arrangement in which their relative order is observable.
+///
+/// The phase flags are the one legitimate difference and are factored out
+/// explicitly: `run` compiles through `--parse --codegen -o` because it then
+/// executes the artifact, while `build` carries only the `-v`/`--mode` the
+/// invocation asked for — none here. Everything after that prefix must match
+/// entry for entry.
+#[cfg(unix)]
+#[test]
+fn single_file_run_wire_order_matches_single_file_build() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(
+        &temp,
+        "demo",
+        PROJECT_MAIN_EXTERN_SRC,
+        &format!("[build]\nwasm-features = [\"bulk-memory\"]\n\n{ARITH_DEPENDENCY_TABLE}"),
+    );
+
+    let vendor = temp.child("vendor");
+    vendor.create_dir_all().unwrap();
+    let source = std::path::Path::new("src").join("main.inf");
+
+    let build_logged = single_file_command_argv(&temp, "build", &source, vendor.path());
+    let build_argv: Vec<&str> = build_logged.lines().collect();
+    let run_logged = single_file_command_argv(&temp, "run", &source, vendor.path());
+    let run_argv: Vec<&str> = run_logged.lines().collect();
+
+    assert_eq!(
+        run_argv.first().copied(),
+        source.to_str(),
+        "the source path must lead the `run` invocation, got argv: {run_argv:?}"
+    );
+    assert_eq!(
+        run_argv.get(1..4),
+        Some(["--parse", "--codegen", "-o"].as_slice()),
+        "the compilation flags must follow the source path unchanged, got \
+         argv: {run_argv:?}"
+    );
+    assert_eq!(
+        build_argv.first().copied(),
+        source.to_str(),
+        "the source path must lead the `build` invocation too, got argv: \
+         {build_argv:?}"
+    );
+    assert!(
+        !build_argv
+            .iter()
+            .any(|entry| ["--parse", "--codegen", "-o", "-v", "--mode"].contains(entry)),
+        "this invocation passed neither `-v` nor `--mode`, so `build` must \
+         carry no phase flag at all — the whole difference between the two \
+         command lines is `run`'s `--parse --codegen -o`, got argv: \
+         {build_argv:?}"
+    );
+
+    let build_external = &build_argv[1..];
+    let run_external = &run_argv[4..];
+
+    // Asserted before the comparison, so two empty blocks could never agree
+    // vacuously: all three families really are on `build`'s line, each with an
+    // adjacent value.
+    let expected_dep = format!(
+        "arith={}",
+        temp.path()
+            .canonicalize()
+            .unwrap()
+            .join("libs")
+            .join("arith.wasm")
+            .display()
+    );
+    assert_eq!(
+        argv_values_after(build_external, "--wasm-lib-dir"),
+        vec![Some(vendor.path().to_str().unwrap())],
+        "`build` must carry the lib dir, got argv: {build_argv:?}"
+    );
+    assert_eq!(
+        argv_values_after(build_external, "--wasm-dep"),
+        vec![Some(expected_dep.as_str())],
+        "`build` must carry the manifest dependency, got argv: {build_argv:?}"
+    );
+    assert_eq!(
+        argv_values_after(build_external, "--wasm-features"),
+        vec![Some("bulk-memory")],
+        "`build` must carry the manifest feature request, got argv: {build_argv:?}"
+    );
+
+    assert_eq!(
+        run_external, build_external,
+        "past the phase flags the two single-file commands must present one \
+         project identically — same flags, same order, same values.\n  \
+         build: {build_argv:?}\n  run:   {run_argv:?}"
+    );
+
+    let position = |flag: &str| {
+        run_argv
+            .iter()
+            .position(|entry| *entry == flag)
+            .unwrap_or_else(|| panic!("`{flag}` must be on the wire, got argv: {run_argv:?}"))
+    };
+    let (lib_dir, dep, features) = (
+        position("--wasm-lib-dir"),
+        position("--wasm-dep"),
+        position("--wasm-features"),
+    );
+    assert!(
+        lib_dir < dep && dep < features,
+        "the blocks must appear in the documented order (lib dirs, then \
+         dependencies, then features), got argv: {run_argv:?}"
+    );
+}
+
+/// Scaffolds a throwaway project whose manifest carries `manifest_extra`, runs
+/// `infs run <src/main.inf>` through a stub that records the compile
+/// invocation's argv *and* every handshake probe, and returns both logs.
+///
+/// Each call gets its own temp directory and stub, for the reason
+/// [`single_file_run_logged_argv`] documents. The command is asserted to fail —
+/// the stub compiles nothing, so the missing-artifact guard always fires — which
+/// is what proves the spawn happened before the logs are read.
+#[cfg(unix)]
+fn single_file_run_argv_and_probes(manifest_extra: &str) -> (String, Vec<String>) {
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_manifest(&temp, "demo", PROJECT_MAIN_EXTERN_SRC, manifest_extra);
+    let argv_log = temp.child("argv.log");
+    let probe_log = temp.child("probe.log");
+    let stub = write_infc_stub(&temp, "infc_stub", argv_log.path(), Some(probe_log.path()));
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .arg(std::path::Path::new("src").join("main.inf"));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    (
+        logged_argv(argv_log.path()),
+        logged_probes(probe_log.path()),
+    )
+}
+
+/// Single-file `run` runs the `infc` compatibility handshake **only** to gate a
+/// feature request: a project that requests none is compiled with no probe at
+/// all.
+///
+/// The handshake is not free of consequence. It prints ABI-drift warnings, and
+/// on a major mismatch it hard-errors — so probing unconditionally would break
+/// `infs run f.inf` against an `infc` that compiles it perfectly well, and would
+/// attach compatibility noise to invocations that ask the compiler for nothing
+/// beyond what it has always accepted. The gate is a single `if` around the
+/// probe, exactly the kind of guard a later change hoists out to reuse the
+/// result for some new capability-gated flag; nothing else in the suite would
+/// notice, because the probe answers and exits without touching the argv log.
+///
+/// This project *does* declare a dependency, so the forwarding still happens —
+/// which pins the other half of the rule: `--wasm-dep` (like `--wasm-lib-dir`)
+/// arrived with external-module support itself rather than at a distinguishable
+/// ABI minor, so it is not capability-gated and must not drag a probe in with
+/// it. The dependency's presence on the wire is asserted first, so a run that
+/// spawned nothing at all could not pass as a run that merely did not probe.
+#[cfg(unix)]
+#[test]
+fn single_file_run_without_a_feature_request_performs_no_handshake() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let (logged, probes) = single_file_run_argv_and_probes(ARITH_DEPENDENCY_TABLE);
+    let argv: Vec<&str> = logged.lines().collect();
+
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-dep").len(),
+        1,
+        "the manifest dependency must still reach infc — an ungated flag needs \
+         no probe, got argv: {argv:?}"
+    );
+    assert!(
+        argv_values_after(&argv, "--wasm-features").is_empty(),
+        "a manifest with no `[build] wasm-features` must request none, got \
+         argv: {argv:?}"
+    );
+    assert!(
+        probes.is_empty(),
+        "single-file `run` must not run the compatibility handshake when there \
+         is no feature request to gate, got probes: {probes:?}"
+    );
+}
+
+/// The other side of that gate: the same project *with* `[build] wasm-features`
+/// is probed before the request is forwarded.
+///
+/// The request is the one thing single-file `run` cannot forward blind — an
+/// `infc` predating `--wasm-features` must be refused with remediation rather
+/// than handed a flag it will reject opaquely — so the probe is a precondition
+/// of the flag, and this pins that it actually runs rather than the flag being
+/// emitted unchecked.
+///
+/// Both probe flags are expected because the stub reports a *mismatched* commit:
+/// the matching-commit short-circuit would answer compatibility after
+/// `--commit-hash` alone, so the second call is the stub's doing, and asserting
+/// the pair keeps the sequence itself visible.
+#[cfg(unix)]
+#[test]
+fn single_file_run_with_a_feature_request_performs_the_handshake() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let (logged, probes) = single_file_run_argv_and_probes(&format!(
+        "[build]\nwasm-features = [\"bulk-memory\"]\n\n{ARITH_DEPENDENCY_TABLE}"
+    ));
+    let argv: Vec<&str> = logged.lines().collect();
+
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-features"),
+        vec![Some("bulk-memory")],
+        "the manifest request must reach infc, got argv: {argv:?}"
+    );
+    assert_eq!(
+        probes,
+        ["--commit-hash", "--abi-version"],
+        "a feature request must be gated on the handshake, which a \
+         mismatched-commit stub answers in two calls, got probes: {probes:?}"
+    );
+}
+
+/// Neutrality inside a project: a manifest with no `[wasm-dependencies]` table
+/// and an invocation with no `-L` put neither flag on the command line.
+///
+/// The forwarding is inert for the projects that bind no externals, which is
+/// nearly all of them — an implementation that emitted a bare or empty flag for
+/// the absent table would break every one of them at once.
+#[cfg(unix)]
+#[test]
+fn single_file_run_without_dependencies_forwards_no_external_flags() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project(&temp, "demo", PROJECT_MAIN_SRC);
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .arg(std::path::Path::new("src").join("main.inf"));
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+    assert!(
+        argv_values_after(&argv, "--wasm-dep").is_empty()
+            && argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
+        "a project with no externals must get neither flag, got argv: {argv:?}"
+    );
+}
+
+/// Neutrality outside a project: a loose source file with no `Inference.toml` in
+/// any ancestor compiles through the same argv it always did.
+///
+/// Single-file `run` is the one command that works with no project at all, so
+/// the manifest lookup must stay a no-op there rather than becoming a
+/// precondition. The failure asserted is the missing-artifact guard — reaching
+/// it proves the compiler was spawned, so an implementation that treated the
+/// absent manifest as an error would surface as a different message here, not as
+/// a silently empty argv.
+#[cfg(unix)]
+#[test]
+fn single_file_run_outside_a_project_forwards_no_external_flags() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.child("standalone.inf")
+        .write_str(PROJECT_MAIN_SRC)
+        .unwrap();
+    let argv_log = temp.child("argv.log");
+    let stub = write_argv_logging_infc_stub(&temp, argv_log.path());
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &stub)
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("standalone.inf");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("WASM file not found"));
+
+    let logged = logged_argv(argv_log.path());
+    let argv: Vec<&str> = logged.lines().collect();
+    assert_eq!(
+        argv,
+        ["standalone.inf", "--parse", "--codegen", "-o"],
+        "a manifest-free single-file run must present the argv it always did"
+    );
+}
+
+/// The ordering contract, observed on the wire through the real binary's clap
+/// configuration rather than a stand-in parser.
+///
+/// `run` collects trailing var-args for the invoked function, so an option is
+/// only an option until the first bare token that is not the source path. That
+/// is the property letting a program take arguments that look like `infs` flags,
+/// and it is pinned as a contrast: the same `-L libs` reaches the compiler
+/// before that boundary and the program after it. A future flag rearrangement
+/// cannot silently move an argument across it.
+#[cfg(unix)]
+#[test]
+fn a_trailing_argument_swallows_a_later_lib_dir_flag_on_the_wire() {
+    if !require_wasmtime() {
+        return;
+    }
+
+    let source = std::path::Path::new("src").join("main.inf");
+    let source = source.to_str().unwrap();
+
+    let after_path = single_file_run_logged_argv(&[source, "-L", "libs"]);
+    let argv: Vec<&str> = after_path.lines().collect();
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![Some("libs")],
+        "a lib dir after the source path but before any bare token is the \
+         compiler's, got argv: {argv:?}"
+    );
+
+    let before_path = single_file_run_logged_argv(&["-L", "libs", source]);
+    let argv: Vec<&str> = before_path.lines().collect();
+    assert_eq!(
+        argv_values_after(&argv, "--wasm-lib-dir"),
+        vec![Some("libs")],
+        "a lib dir before the source path binds the same way, got argv: {argv:?}"
+    );
+
+    let after_bare_token = single_file_run_logged_argv(&[source, "ignored", "-L", "libs"]);
+    let argv: Vec<&str> = after_bare_token.lines().collect();
+    assert!(
+        argv_values_after(&argv, "--wasm-lib-dir").is_empty(),
+        "a lib dir after a bare trailing token belongs to the invoked function \
+         and must never reach the compiler, got argv: {argv:?}"
+    );
+}
+
+/// The issue's acceptance criterion: a project that binds an external is
+/// *runnable* through single-file `run`, with no environment workaround.
+///
+/// Forwarding reaching `infc` is necessary but not sufficient — this pins that
+/// what wasmtime executes is a module with the dependency's code merged in
+/// rather than one left with an unresolved import, by asserting the value only
+/// the linked function can produce.
+///
+/// `INFERENCE_WASM_LIB_PATH` is explicitly removed from the child environment:
+/// it is `infc`'s last-resort search tier and the exact workaround this
+/// replaces, so an inherited value would let a passing run prove nothing about
+/// the manifest.
+#[test]
+fn single_file_run_executes_a_linked_manifest_dependency() {
+    let Some(infc_path) = require_infc_and_wasmtime() else {
+        return;
+    };
+
+    let library = build_arith_library(&infc_path);
+    let temp = assert_fs::TempDir::new().unwrap();
+    scaffold_project_with_arith_dependency(&temp, &library);
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &infc_path)
+        .env_remove("INFERENCE_WASM_LIB_PATH")
+        .current_dir(temp.path())
+        .arg("run")
+        .arg(std::path::Path::new("src").join("main.inf"));
+    let stdout = stdout_of(&cmd.assert().success());
+    assert!(
+        stdout.contains("Linked 1 external module"),
+        "the manifest dependency must be linked, not merely forwarded, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("42"),
+        "wasmtime must print the linked call's result (40 + 2), got:\n{stdout}"
+    );
+}
+
+/// The `-L` half of acceptance, end to end and manifest-free: a loose source
+/// file binding an external links against a directory named on the command line.
+///
+/// The lib dir is *relative*, which is the point: verbatim forwarding is only
+/// correct if `infc` reads it against the same directory the user typed it in.
+/// A run that anchored or rewrote it would resolve the module somewhere else and
+/// fail here, so this is the behavioral counterpart to the argv-level verbatim
+/// assertion — it proves the forwarding is right, not merely literal.
+///
+/// `INFERENCE_WASM_LIB_PATH` is removed for the same reason as above: with it in
+/// play, resolution could succeed through `infc`'s last-resort tier no matter
+/// what `-L` carried.
+#[test]
+fn single_file_run_links_through_an_explicit_lib_dir() {
+    let Some(infc_path) = require_infc_and_wasmtime() else {
+        return;
+    };
+
+    let library = build_arith_library(&infc_path);
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.child("main.inf")
+        .write_str(PROJECT_MAIN_EXTERN_SRC)
+        .unwrap();
+    temp.child("libs")
+        .child("arith.wasm")
+        .write_binary(&library)
+        .unwrap();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.env("INFC_PATH", &infc_path)
+        .env_remove("INFERENCE_WASM_LIB_PATH")
+        .current_dir(temp.path())
+        .arg("run")
+        .arg("main.inf")
+        .arg("-L")
+        .arg("libs");
+    let stdout = stdout_of(&cmd.assert().success());
+    assert!(
+        stdout.contains("Linked 1 external module"),
+        "the lib dir must resolve the external, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("42"),
+        "wasmtime must print the linked call's result (40 + 2), got:\n{stdout}"
+    );
+}
+
+/// `infs run --help` documents the external-lib-dir flag, its relative-directory
+/// semantics, and the ordering contract that is unique to this command.
+///
+/// Rendering the help is the only invocation that materializes the flag's help
+/// text, so it is the only place the documented contract can be pinned. The
+/// ordering sentence matters more here than on `build`: `run` collects trailing
+/// var-args, so a user who writes `infs run f.inf 1 -L libs` gets no diagnostic
+/// at all — the flag simply becomes a program argument — and the help text is
+/// the only warning they will ever see.
+///
+/// clap re-wraps help text to the terminal width, so the assertions run against
+/// a whitespace-normalized copy of the output rather than the raw bytes.
+#[test]
+fn run_help_documents_the_external_lib_dir_flag() {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("infs"));
+    cmd.arg("run").arg("--help");
+
+    let assert = cmd.assert().success();
+    let normalized = stdout_of(&assert)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    for expected in [
+        "--wasm-lib-dir",
+        "-L",
+        "Directory to search for external `.wasm` modules",
+        "A relative dir always means what it meant at the shell",
+        "Must appear before the first bare trailing token",
+    ] {
+        assert!(
+            normalized.contains(expected),
+            "`infs run --help` must document {expected:?}; normalized output was:\n{normalized}"
+        );
+    }
 }
 
 // Phase 2: Toolchain Management Command Tests

--- a/book/src/projects-and-the-infs-toolchain.md
+++ b/book/src/projects-and-the-infs-toolchain.md
@@ -98,7 +98,9 @@ than silently shipping a differently-configured artifact. Only
 `[dependencies]` and `[wasm-dependencies]` accept arbitrary keys, because their
 keys name the dependencies. `wasm-features` entries are WebAssembly *proposal* names
 (`"bulk-memory"`), not instruction names, and the setting is honored in project
-builds, single-file builds, and single-file `infs run`; see
+builds, single-file builds, and single-file `infs run`. `[wasm-dependencies]`
+entries have the same reach: project `build`, project `run`, single-file
+`build`, and single-file `run` all forward every declared entry to `infc`. See
 `apps/infs/docs/inference-toml.md` for the full reference.
 
 ### Reserved Project Names
@@ -228,7 +230,22 @@ directory), with no manifest `output-dir` forwarded.
 infs run                                 # project mode: build + invoke main
 infs run program.inf                     # single-file: compile and invoke main
 infs run program.inf --entry-point helper  # single-file: invoke helper()
+infs run program.inf -L libs             # single-file: search libs/ for external .wasm
 ```
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `--entry-point <name>` | Function to invoke in single-file mode (default `main`); rejected for anything but `main` in project mode |
+| `-L <DIR>` / `--wasm-lib-dir <DIR>` | Add a directory to search for external `.wasm` modules; repeatable. Anchored to the invocation directory in project mode; in single-file mode no anchoring step runs, since `infc` already inherits that directory |
+| `--no-wasm-opt` | Skip `[build.wasm-opt]` post-build optimization (project mode only) |
+
+In single-file mode, `-L` and the other options must appear before the first
+bare trailing token: `infs run program.inf -L libs 1` parses `-L libs` and
+passes `1` to the invoked function, while `infs run program.inf 1 -L libs`
+passes `1 -L libs` verbatim as two trailing arguments, parsing no `-L` at all.
+Use `--` to pass arguments that themselves look like flags.
 
 In **project mode** (no path given):
 
@@ -239,13 +256,21 @@ In **project mode** (no path given):
   is rejected with guidance to use single-file mode instead.
 - Checks wasmtime availability before starting the build, failing fast if the
   runtime is absent.
+- Resolves the manifest's `[wasm-dependencies]` and forwards any `-L`
+  directories the same way project `build` does, anchored to the invocation
+  directory, so a project binding `use { … } from <module>` runs without a
+  separate link step.
 - `out/main.wasm` is the expected artifact; if the build succeeds but the file
   is absent, `run` errors before invoking wasmtime.
 
 In **single-file mode** (path given), `--entry-point` (default `main`) selects
 which exported function to invoke. `main` is called with `argc=0, argv=0`
 automatically; other functions receive the trailing arguments from the command
-line.
+line — anything after the first bare token that options did not consume, or
+after `--`. Single-file `run` also resolves the enclosing manifest's
+`[wasm-dependencies]` and forwards any `-L` directories verbatim: `infc`
+inherits the invoking shell's working directory here, so a relative `-L`
+already means what it meant at the shell, with no anchoring step needed.
 
 Both modes require `wasmtime` in `PATH`. Installation instructions are printed
 when it is not found.
@@ -301,7 +326,7 @@ section.
 itself — all of that is `infc`'s responsibility. The relationship:
 
 ```text
-infs build
+infs build / infs run (project mode)
     |
     +-- discover_and_load(Inference.toml)
     |
@@ -315,15 +340,96 @@ infs build
     +-- spawn infc
             CWD = <project root>
             arg: src/main.inf
-            arg: -v                     (if .v requested)
-            arg: --mode proof           (if effective proof mode)
-            arg: --out-dir <dir>        (if effective proof mode + ABI ≥ 1.1)
+            arg: -v                     (if .v requested; `run` never requests it)
+            arg: --mode proof           (if effective proof mode; `run` never requests it)
+            arg: --out-dir <dir>        (if effective proof mode + ABI ≥ 1.1; `run` never requests it)
             arg: --wasm-lib-dir <dir>   (one per -L/--wasm-lib-dir; a relative
                                          dir is anchored to the invocation
-                                         directory, since infc runs at the root)
+                                         directory, since infc runs at the root —
+                                         `build` and `run` both pass their own
+                                         `-L` flags through here)
             arg: --wasm-dep name=path   (one per [wasm-dependencies] entry; the
                                          declared path resolved against the root)
+            arg: --wasm-features <list> (if [build] wasm-features requests any;
+                                         requires infc ABI ≥ 1.2. Applies in both
+                                         modes — a `.v` describing a different
+                                         instruction set than the shipped `.wasm`
+                                         would be worthless)
 ```
+
+Project `run` forces compile mode (`mode = None`) and never requests `--out-dir`,
+so the `-v`/`--mode proof`/`--out-dir` lines above never fire for it — but it
+shares this exact spawn otherwise, including the `-L` and `[wasm-dependencies]`
+forwarding.
+
+Single-file `build <path>` and `run <path>` spawn `infc` directly instead of
+through the shared project-build helper, and — unlike the two project-mode
+paths above — they do **not** send `infc` the same argument list: `build`
+forwards only what the user explicitly passed, leaning on `infc`'s own
+phase-flag default for the rest, while `run` always requests the full
+pipeline explicitly, because it needs the finished WASM artifact in hand to
+execute it. What they do agree on: neither sets `current_dir`, so `infc`
+inherits the invocation directory; every `-L` is forwarded verbatim, with no
+anchoring step; and whichever of `--wasm-lib-dir`, `--wasm-dep`, and
+`--wasm-features` a given invocation sends, they appear in that same relative
+order.
+
+```text
+infs build <path> (single-file mode)
+    |
+    +-- enclosing_manifest(path)   # walk up from the source file; optional
+    |
+    +-- compatibility handshake     # unconditional — always runs, before any
+    |       infc --commit-hash      # flag below is decided (unlike `run`,
+    |       infc --abi-version      # which only handshakes when wasm-features
+    |                               # are requested)
+    |
+    +-- spawn infc
+            CWD = inherited from the invoking shell
+            arg: <path>
+            arg: -v                     (if `-v` was passed; `run` never sends it)
+            arg: --mode <mode>          (if `--mode` was passed; `run` never
+                                         sends it)
+            arg: --wasm-lib-dir <dir>   (one per -L/--wasm-lib-dir, forwarded
+                                         verbatim; no anchoring step runs)
+            arg: --wasm-dep name=path   (one per [wasm-dependencies] entry from
+                                         the enclosing manifest, if any)
+            arg: --wasm-features <list> (if the enclosing manifest requests any;
+                                         requires infc ABI ≥ 1.2)
+```
+
+`build` never adds `--parse`, `--codegen`, or `-o`: with no phase flag at all,
+`infc`'s own default — full compilation, WASM written to disk — already does
+what `build` wants.
+
+```text
+infs run <path> (single-file mode)
+    |
+    +-- enclosing_manifest(path)   # walk up from the source file; optional
+    |
+    +-- compatibility handshake     # conditional — runs only when the
+    |       infc --commit-hash      # enclosing manifest requests wasm-features,
+    |       infc --abi-version      # the only thing here needing a capability
+    |                               # check; skipped entirely otherwise, unlike
+    |                               # `build`
+    |
+    +-- spawn infc
+            CWD = inherited from the invoking shell
+            arg: <path>
+            arg: --parse                (always; `build` never sends it)
+            arg: --codegen              (always; `build` never sends it)
+            arg: -o                     (always; `build` never sends it)
+            arg: --wasm-lib-dir <dir>   (one per -L/--wasm-lib-dir, forwarded
+                                         verbatim; no anchoring step runs)
+            arg: --wasm-dep name=path   (one per [wasm-dependencies] entry from
+                                         the enclosing manifest, if any)
+            arg: --wasm-features <list> (if the enclosing manifest requests any;
+                                         requires infc ABI ≥ 1.2)
+```
+
+`run` always requests `--parse --codegen -o` explicitly rather than relying on
+`infc`'s default, and neither `-v` nor `--mode` is ever part of its argv: the
+`RunArgs` struct (`apps/infs/src/commands/run.rs`) carries no such flags.
 
 **`infc` flags** confirmed against `core/cli/src/parser.rs`:
 
@@ -341,7 +447,7 @@ infs build
 | `--commit-hash` | Print the build commit hash and exit; used by the `infs` handshake |
 | `--abi-version` | Print `<major>.<minor>` ABI version and exit; used by the `infs` handshake |
 
-> **Note:** The current ABI version is `1.1`.
+> **Note:** The current ABI version is `1.2`.
 
 The default behavior when no phase flag is supplied is full compilation with
 WASM output written to disk — equivalent to `--codegen -o`.
@@ -359,12 +465,14 @@ is parsed as `<major>.<minor>`:
 - **Unknown/old** (`infc` exits non-zero or prints `unknown`): silent; treated
   as graceful skip, equivalent to ABI unknown.
 
-The current ABI is `1.1` (`COMPILER_ABI_MAJOR = 1`, `COMPILER_ABI_MINOR = 1`
-in `core/compiler-interface/src/lib.rs`). The `--out-dir` flag was introduced
-at minor 1. `infs` gates its use: `--out-dir` is forwarded only to an `infc`
-that reports ABI minor ≥ 1 (or matches by commit hash). Pairing a manifest
-with a non-default `[verification] output-dir` against an older `infc` is a
-hard error:
+The current ABI is `1.2` (`COMPILER_ABI_MAJOR = 1`, `COMPILER_ABI_MINOR = 2`
+in `core/compiler-interface/src/lib.rs`). Each additive flag is gated at the
+minor it was introduced at, independently: `--out-dir` landed at minor 1, and
+`--wasm-features` at minor 2. `infs` forwards each only to an `infc` that
+reports an ABI minor at or above the flag's own (or matches by commit hash) —
+an `infc` that reports minor 1, for instance, supports `--out-dir` but not
+`--wasm-features`. Pairing a manifest with a non-default `[verification]
+output-dir` against an older `infc` is a hard error:
 
 ```text
 error: the resolved infc does not support `--out-dir` (requires infc ABI ≥ 1.1);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the new dependency and library-directory forwarding paths preserve the established build semantics and are extensively covered.

The changed run paths reuse existing manifest validation, preserve invocation-relative `-L` meanings in both child-working-directory modes, and forward arguments in the same order as build, with no concrete blocking or non-blocking defect remaining.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/infs/src/commands/run.rs | Adds the run-mode library-directory CLI surface, manifest dependency resolution, and correct mode-specific forwarding without an accepted defect. |
| apps/infs/src/commands/build.rs | Exposes the existing dependency-resolution helper for reuse by single-file run while retaining validation and path anchoring behavior. |
| apps/infs/src/commands/project_build.rs | Documents and receives project-run library directories through the existing invocation-directory anchoring path. |
| apps/infs/tests/cli_integration.rs | Adds broad wire-format, argument-ordering, compatibility, and end-to-end coverage for all build and run routes. |
| apps/infs/docs/inference-toml.md | Updates manifest behavior documentation to reflect dependency forwarding on every compilation path. |
| apps/infs/README.md | Documents the new run flags, their ordering boundary, and mode-specific relative-path semantics. |
| book/src/projects-and-the-infs-toolchain.md | Updates user-facing toolchain guidance for single-file and project external-module resolution. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  CLI["infs run"] --> Mode{"Source path supplied?"}
  Mode -->|Yes| Single["Single-file mode"]
  Mode -->|No| Project["Project mode"]
  Single --> Manifest["Find enclosing Inference.toml"]
  Manifest --> Deps["Resolve wasm-dependencies to absolute paths"]
  Single --> Verbatim["Forward -L paths verbatim"]
  Deps --> InfcSingle["Spawn infc in invocation directory"]
  Verbatim --> InfcSingle
  Project --> Discover["Discover project and manifest"]
  Discover --> Anchor["Anchor relative -L paths to invocation directory"]
  Anchor --> InfcProject["Spawn infc in project root"]
  Discover --> InfcProject
  InfcSingle --> Wasm["Produce out/*.wasm"]
  InfcProject --> Wasm
  Wasm --> Runtime["Invoke with wasmtime"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Resolve wasm-dependencies for a single f..."](https://github.com/inferara/inference/commit/d9c6541fbdd2bb0a4b467a12964dd20c3e68a19a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51692096)</sub>

**Context used:**

- Knowledge Base — [infs: Unified Toolchain CLI](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/inference/-/docs/infs-cli.md)

<!-- /greptile_comment -->