### PR TITLE
Document the %N scope recipe for mathcomp consumers of emitted .v (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add compilation targets matrix documentation (`book/compilation_targets.md`): Compile/Proof x Debug/Release x with/without non-det operations ([issue#97])
 - Add `unreachable` emission rationale document (`book/unreachable-emission-in-codegen.md`) ([#144])
 - Add arithmetic overflow in WASM codegen deep-dive (`book/arithmetic-overflow-in-wasm-codegen.md`) ([#146])
+- Add a "mathcomp consumers" note to `core/wasm-to-v/ROCQ_CONTRACT.md`: emitted `.v` spells `N` literals with the `%N` scope key, which mathcomp's `ssrnat` rebinds to `nat_scope`, so a consumer that imports mathcomp ahead of the emitted definitions must re-delimit with `Local Delimit Scope N_scope with N.` after its mathcomp imports (`Local` because a file-global `Delimit` leaks through `Require`); `%num` cannot be emitted instead without breaking the mathcomp-free standalone contract and the repo's `coqc` gate ([#413])
 
 ### Type Checker
 
@@ -590,3 +591,4 @@ Initial tagged release.
 [#402]: https://github.com/Inferara/inference/issues/402
 [#354]: https://github.com/Inferara/inference/issues/354
 [#412]: https://github.com/Inferara/inference/issues/412
+[#413]: https://github.com/Inferara/inference/issues/413

--- a/core/wasm-to-v/ROCQ_CONTRACT.md
+++ b/core/wasm-to-v/ROCQ_CONTRACT.md
@@ -194,6 +194,56 @@ index-oriented `ValidSpec` should look for `ValidSpecFI` instead.
 `list reachability_spec` directly — definitionally identical,
 syntactically plain standard-library `list`.
 
+### mathcomp consumers
+
+The emitted `.v` is vanilla-Rocq-first: it imports no mathcomp, and the
+standalone `coqc` gate elaborates it against plain standard-library
+context. A consumer that *does* import mathcomp — wasm-verifier's proof
+developments do — needs one accommodation, discovered while discharging
+the emitted reachability obligations downstream
+(Inference-Global-Software/wasm-verifier#42): re-delimit `%N` after the
+mathcomp imports. Every `N` literal in an emitted file is spelled with
+the standard-library scope key — `0%N`, `1%N` (indices, `reach_func`,
+`reach_visible_locs`, `Ma` arguments). mathcomp's `ssrnat` rebinds that
+key to `nat_scope` (keeping `%num` as its replacement key for `BinNat`'s
+`N_scope`), so once `ssrnat` is imported — directly or through
+`all_ssreflect`, `seq`, `div`, … — a `1%N` written to mean `1 : N`
+re-reads as `1 : nat` and fails with type errors at the record fields.
+The working recipe is one line, placed after the mathcomp imports and
+before the emitted definitions:
+
+```coq
+Local Delimit Scope N_scope with N.
+```
+
+Delimiting is last-writer-wins, which is why placement after the
+mathcomp imports matters, and why the line triggers Rocq's default-on
+`hiding-delimiting-key` warning (prefix `#[warning="-hiding-delimiting-key"]`
+to silence it). The trade is symmetrical: after the re-delimit,
+mathcomp's own `%N`-keyed `nat` notations no longer parse in that file
+— `%nat` and `%num` still do. `Local` also matters: a file-global
+`Delimit` leaks to every file that `Require`s the consumer and
+re-breaks `%N` there in the other direction. The emitter deliberately
+does not switch to `%num`: that key is *defined by `ssrnat`*, so it does
+not exist in the mathcomp-free context this contract targets, and
+emitting it would break both the standalone contract and this repo's
+own `coqc` gate. `%N` is the right key for what the emitter targets;
+the re-delimit line is the consumer's half of the bargain.
+
+The discharge originally needed a second accommodation, now gone.
+Emitted files once bound the `Ma` helper's offset argument as `of`,
+which ssreflect turns into a keyword (its anonymous-binder syntax,
+`of T` for `(_ : T)`), so the helper's `memarg_offset := of` field
+stopped parsing once ssreflect was loaded, and a consumer had to keep
+that one preamble line ahead of every ssreflect-importing line. The
+binder is `ofs` now (#412): current emissions parse with mathcomp
+loaded first, the re-delimit line above being the only accommodation
+left, and only a `.v` generated before the rename still needs the old
+ordering. The rename covers the fixed preamble, not names the source
+supplies — emitted definition names are user identifiers printed
+verbatim, so a source function named `of` would reintroduce the
+collision for its own `Definition` line.
+
 ## Emitted-file anatomy
 
 The following is the complete, unedited `.v` output for


### PR DESCRIPTION
Fixes #413. Stacked on #414 (base is `412-ma-ofs-binder`); this PR contains only the documentation commit.

Adds a "mathcomp consumers" subsection to `ROCQ_CONTRACT.md`'s required-context section covering what the downstream discharge (Inference-Global-Software/wasm-verifier#42) discovered:

- the `Local Delimit Scope N_scope with N.` recipe, placed after the mathcomp imports, with the mechanism: mathcomp's `ssrnat` rebinds the `%N` key to `nat_scope` (keeping `%num` as its replacement key for `BinNat`'s `N_scope`), so an ssrnat-importing consumer re-reads `1%N : N` as `nat` and fails at the record fields. Also why `Local` matters (a file-global `Delimit` leaks through `Require`), the default-on `hiding-delimiting-key` warning, and the symmetric cost (mathcomp's `%N`-keyed `nat` notations stop parsing in that file)
- why the emitter stays on `%N` rather than emitting `%num`: that key is defined by `ssrnat`, so it does not exist in the mathcomp-free context the standalone contract and the repo's own coqc gate target
- the import-order accommodation recorded as historical: gone as of the `Ma ofs` rename (#412), needed only for a `.v` generated before it; with the residual noted that emitted `Definition` names are user identifiers printed verbatim, so a source function named `of` would reintroduce the collision for its own line

Claims verified against primary sources (mathcomp 2.6.0 `boot/ssrnat.v` L136-138 for the two `Delimit` lines; rocq `ssrparser.mlg`'s `ssrbinder` grammar for the `of` keyword) and replayed locally against Rocq 9.2 by simulating ssrnat's `Delimit` sequence.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/wasm-to-v/ROCQ_CONTRACT.md | Documents `%N` scope rebinding for mathcomp consumers and the historical ssreflect import-order accommodation. |
| CHANGELOG.md | Adds a changelog entry describing the new mathcomp-consumer guidance. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Document the %N scope recipe for mathcom..."](https://github.com/inferara/inference/commit/50a9a3470ef5f3b9494c13baa70e067e22d0d628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53605013)</sub>

<!-- /greptile_comment -->