### PR TITLE
Update build_compiler_book_pr.yml

### DIFF
--- a/.github/workflows/build_compiler_book_pr.yml
+++ b/.github/workflows/build_compiler_book_pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build_compiler_book_pr.yml
+++ b/.github/workflows/build_compiler_book_pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: self-hosted-ubuntu
 
     steps:
       - name: Checkout code

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ubuntu
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C instrument-coverage"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   miri:
     name: Miri UB Detection
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ubuntu
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1

--- a/.github/workflows/publish-compiler-book.yml
+++ b/.github/workflows/publish-compiler-book.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ubuntu
     permissions:
       contents: read
 

--- a/.github/workflows/publish-inf-wasmparser.yml
+++ b/.github/workflows/publish-inf-wasmparser.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish:
     name: Publish inf-wasmparser to crates.io
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: self-hosted-ubuntu
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.3

--- a/.github/workflows/publish-inf-wast.yml
+++ b/.github/workflows/publish-inf-wast.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish:
     name: Publish inf-wast to crates.io
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: self-hosted-ubuntu
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.3

--- a/.github/workflows/publish-wat-fmt.yml
+++ b/.github/workflows/publish-wat-fmt.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish:
     name: Publish wat-fmt to crates.io
-    runs-on: [self-hosted, X64, Linux]
+    runs-on: self-hosted-ubuntu
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.3

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [self-hosted-ubuntu, windows-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/rocq-typecheck.yml
+++ b/.github/workflows/rocq-typecheck.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   rocq-typecheck:
     name: coqc round-trip gate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-ubuntu
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.3


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge while pull requests can execute contributor-controlled Docker builds on the self-hosted runner.

The compiler-book workflow still triggers for pull-request changes under `book/**`, checks out those changes, and builds the contributor-controlled Dockerfile using `self-hosted-ubuntu`, leaving the previously reported trust-boundary failure unresolved.

**Files Needing Attention:** .github/workflows/build_compiler_book_pr.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/build_compiler_book_pr.yml | Moves the pull-request compiler-book Docker build to `self-hosted-ubuntu`; the previously reported trust-boundary issue remains. |
| .github/workflows/coverage.yml | Moves the coverage job to the standardized self-hosted Ubuntu runner. |
| .github/workflows/miri.yml | Moves Miri checks to the standardized self-hosted Ubuntu runner. |
| .github/workflows/publish-compiler-book.yml | Moves compiler-book publishing to the standardized self-hosted Ubuntu runner. |
| .github/workflows/publish-inf-wasmparser.yml | Replaces the generic self-hosted label set with the standardized Ubuntu runner label. |
| .github/workflows/publish-inf-wast.yml | Replaces the generic self-hosted label set with the standardized Ubuntu runner label. |
| .github/workflows/publish-wat-fmt.yml | Replaces the generic self-hosted label set with the standardized Ubuntu runner label. |
| .github/workflows/reusable-build.yml | Moves the Linux matrix entry to the standardized self-hosted Ubuntu runner while retaining Windows and macOS coverage. |
| .github/workflows/rocq-typecheck.yml | Moves the Rocq type-checking job to the standardized self-hosted Ubuntu runner. |

</details>

<sub>Reviews (2): Last reviewed commit: ["use self-hosted-ubuntu"](https://github.com/inferara/inference/commit/ae36156b95f76fcd82012f06676ec0e76f1970e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57359439)</sub>

<!-- /greptile_comment -->