### PR TITLE
Stop emitting full debug info for dependencies in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,20 @@ rustc-hash = "2.1.3"
 # moves (#157).
 salsa = "0.27"
 
+# Debug builds carry full DWARF by default, for this workspace *and* for every
+# dependency in it — including Wasmtime and Cranelift, which the test suite
+# links. That debuginfo is the bulk of both the link time and the tens of
+# gigabytes a debug build leaves in `target/`, and almost none of it is ever
+# read: a failing test is located by the file and line in its backtrace, which
+# is what `line-tables-only` keeps.
+[profile.dev]
+debug = "line-tables-only"
+
+# Dependencies are not stepped through, so they carry no debuginfo at all. This
+# is the larger half of the saving, because the heaviest crates in the graph are
+# ones nobody debugs from here.
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 codegen-units = 1     # Better optimization (slower compile)


### PR DESCRIPTION
The dev profile defaults to `debug = 2`, so every debug build emits DWARF describing every type, local and lexical scope — for this workspace *and* for every dependency in it, Wasmtime and Cranelift included, which the test suite links.

Almost none of that is ever read here. A failing test is located by the file and line in its backtrace, which `line-tables-only` keeps, and nobody steps through Cranelift from this project.

```toml
[profile.dev]
debug = "line-tables-only"

[profile.dev.package."*"]
debug = false
```

## Measured

Both runs on an idle machine, each from a deleted `target/debug`, same tree:

| | Before | After |
|---|---|---|
| Cold `cargo build` (wall) | 31.9s | **25.0s** |
| Cold build (user CPU) | 187.0s | 185.8s |
| `target/debug` after build | 2.6G | **1.5G** |
| Cold full test cycle (wall) | 37.1s | **34.1s** |
| `target/debug` after build + test | 4.0G | **2.3G** |
| `infc` binary | 24M | 22M |

CPU time is essentially unchanged, so the saving is in linking and I/O rather than compilation. `inference-tests` passes 3319/0 under both profiles.

## Notes

- The `test` profile inherits from `dev`, so `cargo test` picks both settings up automatically — which is where it matters, since the test binary is the slow link.
- The first build after this lands pays one full rebuild, because changing a profile invalidates every artifact under it.
- Nothing here touches `opt-level`, so debug binaries run exactly as fast as before.
- For a real debugging session, override per build rather than reverting the file:
  ```
  cargo build --config 'profile.dev.debug=2' --config 'profile.dev.package."*".debug=2'
  ```

## What this does *not* fix

`target/` had reached 94G, but a clean build plus a full test run was only 4.0G even before this change — the rest was accumulation across branches, which cargo never garbage-collects. That is a separate problem, and this PR does not address it.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The new Cargo profile settings are supported by the repository’s toolchains, apply with the intended workspace-versus-dependency scope, and introduce no identified correctness or security failures.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Adds compatible Cargo development-profile settings that reduce debuginfo while preserving workspace source-line information. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build: stop emitting full debug info for..."](https://github.com/inferara/inference/commit/4d9c195a23dd93c2b0c065551171c85bc0942eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62017847)</sub>

<!-- /greptile_comment -->